### PR TITLE
Add streaming payment channels extension (stream intent)

### DIFF
--- a/draft-tempo-stream-extension.md
+++ b/draft-tempo-stream-extension.md
@@ -287,7 +287,36 @@ Behavior:
 The server SHOULD monitor for this event and settle before the grace period
 ends if it has outstanding vouchers.
 
-#### 4.2.4. withdraw
+#### 4.2.4. topUp
+
+User adds more funds and/or extends expiry.
+
+```solidity
+function topUp(
+    bytes32 channelId,
+    uint128 additionalDeposit,
+    uint64 newExpiry
+) external;
+```
+
+Behavior:
+1. Verify `msg.sender == channel.payer`
+2. Verify channel is not finalized
+3. If `additionalDeposit > 0`:
+   - Transfer `additionalDeposit` tokens from payer to contract
+   - Add to `channel.deposit`
+4. If `newExpiry > channel.expiry`:
+   - Update `channel.expiry = newExpiry`
+5. Emit `TopUp` event
+
+**Rationale for expiry extension:**
+
+The server can settle at any time before expiry—they bear no risk from a longer
+expiry. Expiry only protects the user's right to withdraw unspent funds if the
+server disappears. Extending expiry is purely the user's choice to wait longer
+for their potential refund.
+
+#### 4.2.5. withdraw
 
 User withdraws remaining funds after expiry or close grace period.
 
@@ -341,6 +370,13 @@ event CloseRequested(
     uint256 closeGraceEnd
 );
 
+event TopUp(
+    bytes32 indexed channelId,
+    uint256 additionalDeposit,
+    uint256 newDeposit,
+    uint256 newExpiry
+);
+
 event Withdrawn(
     bytes32 indexed channelId,
     uint256 refunded
@@ -358,6 +394,7 @@ service delivery.
 **Characteristics:**
 
 - Payer deposits funds into escrow contract at channel open
+- Payer can top up deposit and/or extend expiry at any time
 - Payer signs cumulative EIP-712 vouchers authorizing withdrawals
 - Server can settle (withdraw) at any time using valid vouchers
 - Partial settlement is supported; channel remains usable


### PR DESCRIPTION
## Summary

This PR adds a new extension to the Tempo Payment Method that enables **unidirectional streaming payment channels** for incremental, voucher-based payments.

## Motivation

For metered services like AI inference APIs, the payment amount is only known as the response streams. Existing intents (`charge`, `authorize`, `subscription`) require upfront or bounded amounts. The `stream` intent solves this by allowing users to pay exactly for tokens received.

## Key Features

- **New `stream` intent**: Opens a unidirectional payment channel
- **EIP-712 cumulative vouchers**: Clients sign incremental payment authorizations
- **Out-of-band voucher submission**: Vouchers sent to `voucherEndpoint` during SSE streaming
- **Periodic settlement**: On-chain transfers batch multiple vouchers for efficiency
- **Access Key integration**: Delegated payment authority with spending limits

## Flow

```
1. Client requests streaming resource → 402 with stream challenge
2. Client provisions Access Key, signs initial voucher
3. Client retries with open credential → streaming begins
4. As tokens stream, client sends updated vouchers (out-of-band)
5. Server settles periodically or at close
6. Client pays exactly for tokens received
```

## New File

- `draft-tempo-stream-extension.md`: Complete spec for the stream intent

## Spec Sections

1. Intent definition and use cases
2. Request schema (`maxAmount`, `channelId`, `voucherEndpoint`, etc.)
3. Credential schema (open/voucher/close actions)
4. EIP-712 voucher format with cumulative semantics
5. Verification procedure
6. Settlement procedure
7. Channel lifecycle
8. Security considerations (replay, DoS, expiry, etc.)
9. Examples with full flow diagrams

## Next Steps

After this spec is merged, implementation in `ai-payments` repo.