### PR TITLE
CORE-003: Add RFC 9457 (Problem Details) normative reference

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -653,6 +653,9 @@ identifiers upon publication.
 - **[RFC9111]** Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke,
   Ed., "HTTP Caching", STD 98, RFC 9111, June 2022.
 
+- **[RFC9457]** Nottingham, M., Wilde, E., and S. Dalal, "Problem Details
+  for HTTP APIs", RFC 9457, July 2023.
+
 ### 13.2. Informative References
 
 - **[W3C-DID]** W3C, "Decentralized Identifiers (DIDs) v1.0",


### PR DESCRIPTION
Add missing normative reference to RFC 9457 (Problem Details for HTTP APIs).