### PR TITLE
Core: Challenge binding to URI, method, and realm

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -232,10 +232,16 @@ auth-param      = token BWS "=" BWS ( token / quoted-string )
   entropy for each challenge. Clients MUST include this value in the
   credential to correlate the response with the challenge. Servers
   MUST reject credentials with unknown, expired, or already-used `id`
-  values.
+  values. Servers MUST associate each challenge `id` with the specific
+  target URI and HTTP method for which it was issued. Servers MUST
+  reject credentials where the target URI or HTTP method differs from
+  the original challenge.
 
 **`realm`**: Protection space identifier per {{RFC7235}}. Servers MUST
   include this parameter to define the scope of the payment requirement.
+  Servers MUST verify that the credential's challenge `id` was issued
+  for the same realm as the current request. Credentials MUST NOT be
+  accepted across different realms.
 
 **`method`**: Payment method identifier ({{payment-methods}}). MUST be a lowercase
   ASCII string.


### PR DESCRIPTION
Implements CORE-010 and CORE-020 from review notes.

## Changes

- **CORE-010**: The `id` parameter now MUST be bound to the target URI and HTTP method. Servers MUST reject credentials where these differ from the original challenge.

- **CORE-020**: Credentials MUST match the same realm. Cross-realm credential reuse is explicitly prohibited.

## Dependencies

Depends on PR 1 (fix/core-status-codes)