### PR TITLE
Tempo Method: CAIP-2 chain identifiers, fee payer error handling, rate limiting

### DIFF
--- a/specs/methods/draft-tempo-payment-method-00.md
+++ b/specs/methods/draft-tempo-payment-method-00.md
@@ -1038,6 +1038,7 @@ The `request` decodes to:
 {
   "amount": "1000000",
   "asset": "0x20c0000000000000000000000000000000000001",
+  "chain": "eip155:42431",
   "destination": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
   "expires": "2025-01-06T12:00:00Z"
 }
@@ -1143,6 +1144,7 @@ The `request` decodes to:
 ~~~json
 {
   "asset": "0x20c0000000000000000000000000000000000001",
+  "chain": "eip155:42431",
   "expires": "2025-02-05T12:00:00Z",
   "limit": "50000000"
 }
@@ -1251,6 +1253,7 @@ The `request` decodes to:
 {
   "amount": "10000000",
   "asset": "0x20c0000000000000000000000000000000000001",
+  "chain": "eip155:42431",
   "expires": "2026-01-06T00:00:00Z",
   "period": "2592000"
 }


### PR DESCRIPTION
## Summary

### Changes

**TEMPO-003: CAIP-2 Chain Identifiers**
- Added `chain` field to all request schemas (Charge, Authorize, Subscription) using CAIP-2 format (e.g., `eip155:42431`) -- this allows us to determine differences between tempo mainnet and testnet 
- Added CAIP-2 informative reference
- Updated all examples to include `chain` field

**TEMPO-004: Fee Payer Error Handling**
- Added error handling when `feePayer: true` but server cannot pay fees
- Server returns 402 with `fee-payment-unavailable` problem type and fresh challenge with `feePayer: false`
- Added fee token exhaustion monitoring guidance

**TEMPO-007: Rate Limiting & Transaction Validation**
- Added "Validation Before Signing" requirement: servers MUST validate transaction structure before signing fee commitment
- Added rate limiting guidance: 10 requests/minute per client address for new clients
- Added griefing attack prevention guidance

## Stacked PRs

This PR depends on:
- PR7: fix/intent-amount-schema
- PR5: fix/core-body-binding
- PR2: fix/core-challenge-binding
- PR1: fix/core-status-codes