### PR TITLE
Remove redundant definitions within specs

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -149,8 +149,8 @@ conditions:
 | Payment verified, but policy denies access | 403 | No challenge (payment was valid) |
 
 Servers MUST return 402 with a `WWW-Authenticate: Payment` header when
-payment is required or when a payment credential fails validation.
-Servers SHOULD NOT return 402 without this header.
+payment is required or when a payment credential fails validation
+(see {{usage-of-402}} for details).
 
 Error details are provided in the response body using Problem Details
 {{RFC9457}} rather than in the `WWW-Authenticate` header parameters.
@@ -169,11 +169,7 @@ authentication schemes. The distinction is intentional:
 This design ensures clients can distinguish payment requirements from
 other authentication schemes that use 401.
 
-## Usage of 402 Payment Required
-
-The 402 (Payment Required) status code was reserved by {{RFC9110}} for future
-use. This specification defines semantics for 402 within the context of the
-Payment authentication scheme.
+## Usage of 402 Payment Required {#usage-of-402}
 
 ### When to Return 402
 

--- a/specs/intents/draft-payment-intent-subscription-00.md
+++ b/specs/intents/draft-payment-intent-subscription-00.md
@@ -124,16 +124,7 @@ amount per billing period.
 
 ## Billing Periods
 
-Standard billing periods:
-
-| Period | Duration | Seconds |
-|--------|----------|---------|
-| `day` | 1 day | 86400 |
-| `week` | 7 days | 604800 |
-| `month` | ~30 days | 2592000 |
-| `year` | ~365 days | 31536000 |
-
-Payment method specifications MAY define custom period formats.
+See {{period-formats}} for supported period values and their durations.
 
 # Request Schema
 
@@ -183,7 +174,7 @@ Clients can detect the format:
 - Three lowercase letters: ISO 4217 currency code
 - Otherwise: Well-known symbol or method-specific identifier
 
-## Period Formats
+## Period Formats {#period-formats}
 
 The `period` field supports named periods or explicit durations:
 

--- a/specs/methods/draft-stripe-payment-method-00.md
+++ b/specs/methods/draft-stripe-payment-method-00.md
@@ -193,28 +193,19 @@ to charge a specified amount on a recurring basis.
 # Request Schema
 
 The `request` parameter in the `WWW-Authenticate` challenge contains a
-base64url-encoded JSON object. The schema follows the shared intent schema
-defined in the intent specifications, with Stripe-specific extensions in
-the `methodDetails` field.
+base64url-encoded JSON object. The schema uses shared fields defined by
+the intent specifications (charge, authorize, subscription), with
+Stripe-specific extensions in the `methodDetails` field.
 
 Clients parse the request and construct the appropriate Stripe Payment
-Token or Setup Intent to fulfill it.
+Token or Setup Intent to fulfill it. For shared field definitions, see
+the corresponding intent specification.
 
 ## Charge Request
 
-For `intent="charge"`, the request uses the shared charge schema with
-Stripe-specific method details:
-
-### Shared Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Amount in smallest currency unit (e.g., cents) |
-| `currency` | string | REQUIRED | Three-letter ISO currency code (e.g., `"usd"`) |
-| `description` | string | OPTIONAL | Human-readable payment description |
-| `externalId` | string | OPTIONAL | Merchant's identifier (e.g., order ID, cart ID) |
-
-### Method Details
+For `intent="charge"`, the request uses the shared charge schema
+(see draft-payment-intent-charge) with the following Stripe-specific
+method details:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -250,19 +241,8 @@ const spt = await stripe.createPaymentToken({
 ## Authorize Request
 
 For `intent="authorize"`, the request uses the shared authorize schema
-with Stripe-specific method details:
-
-### Shared Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Maximum authorization amount in smallest currency unit |
-| `currency` | string | REQUIRED | Three-letter ISO currency code |
-| `expires` | string | OPTIONAL | Authorization expiry in ISO 8601 format |
-| `description` | string | OPTIONAL | Human-readable payment description |
-| `externalId` | string | OPTIONAL | Merchant's identifier |
-
-### Method Details
+(see draft-payment-intent-authorize) with the following Stripe-specific
+method details:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -299,20 +279,8 @@ const spt = await stripe.createPaymentToken({
 ## Subscription Request
 
 For `intent="subscription"`, the request uses the shared subscription
-schema with Stripe-specific method details:
-
-### Shared Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Amount per billing period in smallest currency unit |
-| `currency` | string | REQUIRED | Three-letter ISO currency code |
-| `period` | string | REQUIRED | Billing period: `"day"`, `"week"`, `"month"`, or `"year"` |
-| `cycles` | number | OPTIONAL | Number of billing cycles before subscription ends |
-| `description` | string | OPTIONAL | Human-readable subscription description |
-| `externalId` | string | OPTIONAL | Merchant's identifier |
-
-### Method Details
+schema (see draft-payment-intent-subscription) with the following
+Stripe-specific method details:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/specs/methods/draft-tempo-payment-method-00.md
+++ b/specs/methods/draft-tempo-payment-method-00.md
@@ -216,28 +216,19 @@ approvals do not support periodic limit semantics.
 # Request Schema
 
 The `request` parameter in the `WWW-Authenticate` challenge contains a
-base64url-encoded JSON object. The schema follows the shared intent schema
-defined in the intent specifications, with Tempo-specific extensions in
-the `methodDetails` field.
+base64url-encoded JSON object. The schema uses shared fields defined by
+the intent specifications (charge, authorize, subscription), with
+Tempo-specific extensions in the `methodDetails` field.
 
 Clients parse the request and construct the appropriate Tempo Transaction
-or Key Authorization to fulfill it.
+or Key Authorization to fulfill it. For shared field definitions, see
+the corresponding intent specification.
 
 ## Charge Request
 
-For `intent="charge"`, the request uses the shared charge schema with
-Tempo-specific method details:
-
-### Shared Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Amount in base units (stringified number) |
-| `currency` | string | REQUIRED | TIP-20 token address (e.g., `"0x20c0..."`) |
-| `recipient` | string | REQUIRED | Recipient address |
-| `expires` | string | REQUIRED | Expiry timestamp in ISO 8601 format |
-
-### Method Details
+For `intent="charge"`, the request uses the shared charge schema
+(see draft-payment-intent-charge) with the following Tempo-specific
+method details:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -273,18 +264,8 @@ MUST set `fee_token` and pay fees themselves.
 ## Authorize Request
 
 For `intent="authorize"`, the request uses the shared authorize schema
-with Tempo-specific method details:
-
-### Shared Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Maximum spend amount in base units |
-| `currency` | string | REQUIRED | TIP-20 token address |
-| `expires` | string | REQUIRED | Expiry timestamp in ISO 8601 format |
-| `recipient` | string | OPTIONAL | Authorized spender address (required for transaction fulfillment) |
-
-### Method Details
+(see draft-payment-intent-authorize) with the following Tempo-specific
+method details:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -325,18 +306,8 @@ client MUST sign a transaction with `fee_token` set to pay fees themselves.
 ## Subscription Request
 
 For `intent="subscription"`, the request uses the shared subscription
-schema with Tempo-specific method details:
-
-### Shared Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Amount per period in base units |
-| `currency` | string | REQUIRED | TIP-20 token address |
-| `period` | string | REQUIRED | Billing period (`"day"`, `"week"`, `"month"`, `"year"`, or seconds) |
-| `expires` | string | REQUIRED | Subscription end timestamp in ISO 8601 format |
-
-### Method Details
+schema (see draft-payment-intent-subscription) with the following
+Tempo-specific method details:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|


### PR DESCRIPTION
## Summary

- Core spec: Consolidate duplicate 402 requirements, add cross-reference
- Subscription intent: Merge duplicate billing period tables into single Period Formats section
- Stripe method: Remove repeated shared fields tables, reference intent specs instead
- Tempo method: Remove repeated shared fields tables, reference intent specs instead