### PR TITLE
fix: capitalize intent titles and normalize author frontmatter

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -12,19 +12,19 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Jeff Weinstein
     ins: J. Weinstein
     email: jweinstein@stripe.com
-    organization: Stripe
+    org: Stripe
 
 normative:
   RFC2119:

--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -11,15 +11,15 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
 
 normative:
   RFC2119:

--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -1,5 +1,5 @@
 ---
-title: authorize Intent for HTTP Payment Authentication
+title: Authorize Intent for HTTP Payment Authentication
 abbrev: Payment Intent Authorize
 docname: draft-payment-intent-authorize-00
 category: info
@@ -11,15 +11,15 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
 
 normative:
   RFC2119:

--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -1,5 +1,5 @@
 ---
-title: charge Intent for HTTP Payment Authentication
+title: Charge Intent for HTTP Payment Authentication
 abbrev: Payment Intent Charge
 docname: draft-payment-intent-charge-00
 category: info
@@ -11,15 +11,15 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
 
 normative:
   RFC2119:

--- a/specs/intents/draft-payment-intent-subscription-00.md
+++ b/specs/intents/draft-payment-intent-subscription-00.md
@@ -1,5 +1,5 @@
 ---
-title: subscription Intent for HTTP Payment Authentication
+title: Subscription Intent for HTTP Payment Authentication
 abbrev: Payment Intent Subscription
 docname: draft-payment-intent-subscription-00
 category: info
@@ -11,15 +11,15 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
 
 normative:
   RFC2119:

--- a/specs/methods/draft-stripe-payment-method-00.md
+++ b/specs/methods/draft-stripe-payment-method-00.md
@@ -11,11 +11,11 @@ author:
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Steve Kaliski
     ins: S. Kaliski
     email: stevekaliski@stripe.com
-    organization: Stripe
+    org: Stripe
 
 normative:
   RFC2119:

--- a/specs/methods/draft-tempo-payment-method-00.md
+++ b/specs/methods/draft-tempo-payment-method-00.md
@@ -12,15 +12,15 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
 
 normative:
   RFC2119:


### PR DESCRIPTION
## Changes

**Title capitalization:**
- `charge Intent` → `Charge Intent`
- `authorize Intent` → `Authorize Intent`
- `subscription Intent` → `Subscription Intent`

**Author frontmatter normalization:**
- Changed field order to: `name`, `ins`, `email`, `organization` (matching core/discovery/tempo-method specs)
- Changed `org:` → `organization:` for consistency

## Files changed
- specs/intents/draft-payment-intent-charge-00.md
- specs/intents/draft-payment-intent-authorize-00.md
- specs/intents/draft-payment-intent-subscription-00.md
- specs/methods/draft-stripe-payment-method-00.md