### PR TITLE
fix: normalize frontmatter across all specs

### DIFF
--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -2,6 +2,7 @@
 title: Discovery Mechanisms for HTTP Payment Authentication
 abbrev: Payment Discovery
 docname: draft-payment-discovery-00
+version: 00
 category: info
 ipr: trust200902
 submissiontype: IETF

--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -2,6 +2,7 @@
 title: Authorize Intent for HTTP Payment Authentication
 abbrev: Payment Intent Authorize
 docname: draft-payment-intent-authorize-00
+version: 00
 category: info
 ipr: trust200902
 submissiontype: IETF
@@ -25,10 +26,11 @@ normative:
   RFC2119:
   RFC8174:
   I-D.httpauth-payment:
-    title: The "Payment" HTTP Authentication Scheme
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
     author:
-      - ins: J. Moxey
-    date: 2025
+      - name: Jake Moxey
+    date: 2026-01
 ---
 
 --- abstract

--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -2,6 +2,7 @@
 title: Charge Intent for HTTP Payment Authentication
 abbrev: Payment Intent Charge
 docname: draft-payment-intent-charge-00
+version: 00
 category: info
 ipr: trust200902
 submissiontype: IETF
@@ -25,10 +26,11 @@ normative:
   RFC2119:
   RFC8174:
   I-D.httpauth-payment:
-    title: The "Payment" HTTP Authentication Scheme
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
     author:
-      - ins: J. Moxey
-    date: 2025
+      - name: Jake Moxey
+    date: 2026-01
 ---
 
 --- abstract

--- a/specs/intents/draft-payment-intent-subscription-00.md
+++ b/specs/intents/draft-payment-intent-subscription-00.md
@@ -2,6 +2,7 @@
 title: Subscription Intent for HTTP Payment Authentication
 abbrev: Payment Intent Subscription
 docname: draft-payment-intent-subscription-00
+version: 00
 category: info
 ipr: trust200902
 submissiontype: IETF
@@ -25,10 +26,11 @@ normative:
   RFC2119:
   RFC8174:
   I-D.httpauth-payment:
-    title: The "Payment" HTTP Authentication Scheme
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
     author:
-      - ins: J. Moxey
-    date: 2025
+      - name: Jake Moxey
+    date: 2026-01
 ---
 
 --- abstract

--- a/specs/methods/draft-stripe-payment-method-00.md
+++ b/specs/methods/draft-stripe-payment-method-00.md
@@ -2,6 +2,7 @@
 title: Stripe Payment Method for HTTP Payment Authentication
 abbrev: Stripe Payment Method
 docname: draft-stripe-payment-method-00
+version: 00
 category: info
 ipr: trust200902
 submissiontype: IETF
@@ -22,10 +23,11 @@ normative:
   RFC8174:
   RFC7235:
   I-D.httpauth-payment:
-    title: The "Payment" HTTP Authentication Scheme
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
     author:
-      - ins: J. Moxey
-    date: 2025
+      - name: Jake Moxey
+    date: 2026-01
 
 informative:
   STRIPE-API:


### PR DESCRIPTION
## Changes

**Added `version: 00` to:**
- specs/extensions/draft-payment-discovery-00.md
- specs/intents/draft-payment-intent-authorize-00.md
- specs/intents/draft-payment-intent-charge-00.md
- specs/intents/draft-payment-intent-subscription-00.md
- specs/methods/draft-stripe-payment-method-00.md

**Normalized I-D.httpauth-payment reference format:**
- Title: `"The 'Payment' HTTP Authentication Scheme"` (quoted with single quotes inside)
- Added `target: https://datatracker.ietf.org/doc/draft-httpauth-payment/`
- Author: `name: Jake Moxey` instead of `ins: J. Moxey`
- Date: `2026-01` instead of `2025`

All specs now match the canonical format used in core and tempo-method specs.