### PR TITLE
ci: add frontmatter linting step

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,6 +33,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Lint frontmatter
+        run: |
+          docker run --rm -v "$(pwd)":/data ietf-spec-tools:latest python3 /data/scripts/lint_frontmatter.py
+
       - name: Build and validate specs
         run: |
           mkdir -p .cache


### PR DESCRIPTION
Adds frontmatter linting to CI as described in #63.

Runs `lint_frontmatter.py` before building specs to catch frontmatter inconsistencies early.