### PR TITLE
fix: add actions:read permission for PR diffs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,6 +12,7 @@ env:
   WRANGLER_SEND_METRICS: false
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 


### PR DESCRIPTION
The `dawidd6/action-download-artifact` action needs `actions: read` permission to list workflow runs and download artifacts from main.

Without this, the diff generation fails with:
```
Resource not accessible by integration
```

This fixes the diff feature in PR previews.