### PR TITLE
fix(stripe): use 402 instead of 401 for payment failures

### DIFF
--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -256,7 +256,7 @@ const paymentIntent = await stripe.paymentIntents.create({
 ~~~
 
 3. If successful, server returns 200 with `Payment-Receipt` header
-4. If failed, server returns 401 with new challenge
+4. If failed, server returns 402 with new challenge
 
 **Settlement timing:**
 


### PR DESCRIPTION
## Summary

Per the core spec (draft-httpauth-payment-00 Section 4.3), all payment-related challenges must use **402 Payment Required**, not 401 Unauthorized.

From the core spec:
> - **402** indicates a payment barrier (initial challenge or retry needed)
> - **401** is reserved for authentication failures unrelated to payment

## Changes

- Fixed `draft-stripe-charge-00.md` line 259: changed "401" → "402" for failed payment credential handling