### PR TITLE
fix: standardize amount as string and currency as lowercase

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -301,7 +301,7 @@ Example decoded `request`:
 ~~~json
 {
   "amount": "1000",
-  "currency": "USD",
+  "currency": "usd",
   "recipient": "acct_123"
 }
 ~~~
@@ -807,7 +807,7 @@ Decoded `request`:
 ~~~json
 {
   "amount": "1000",
-  "currency": "USD",
+  "currency": "usd",
   "invoice": "inv_12345"
 }
 ~~~

--- a/specs/methods/stripe/draft-stripe-authorize-00.md
+++ b/specs/methods/stripe/draft-stripe-authorize-00.md
@@ -488,7 +488,7 @@ Decoded receipt:
 {
   "type": "authorize",
   "paymentIntentId": "pi_1N4Zv32eZvKYlo2CPhVPkJlW",
-  "amount": 100000,
+  "amount": "100000",
   "currency": "usd",
   "status": "requires_capture",
   "captureBefore": "2025-01-22T12:00:00Z"

--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -410,7 +410,7 @@ Content-Type: application/json
 Decoded request:
 ~~~ json
 {
-  "amount": 5000,
+  "amount": "5000",
   "currency": "usd",
   "description": "AI generation"
 }
@@ -457,7 +457,7 @@ Decoded receipt:
 {
   "type": "charge",
   "chargeId": "ch_1N4Zv32eZvKYlo2CPhVPkJlW",
-  "amount": 5000,
+  "amount": "5000",
   "currency": "usd",
   "status": "succeeded"
 }
@@ -479,7 +479,7 @@ WWW-Authenticate: Payment id="ch_b2b_payment",
 Decoded request:
 ~~~ json
 {
-  "amount": 250000,
+  "amount": "250000",
   "currency": "usd",
   "businessNetwork": "bn_1MqDcVKA5fEO2tZvKQm9g8Yj",
   "description": "Supplier payment for order #1234",

--- a/specs/methods/stripe/draft-stripe-subscription-00.md
+++ b/specs/methods/stripe/draft-stripe-subscription-00.md
@@ -582,7 +582,7 @@ Decoded receipt:
 {
   "type": "subscription",
   "subscriptionId": "sub_1N4Zv32eZvKYlo2CPhVPkJlW",
-  "amount": 9900,
+  "amount": "9900",
   "currency": "usd",
   "interval": "month",
   "status": "active",


### PR DESCRIPTION
## Summary

Standardizes field types across all specs per the intent specifications:
- **`amount`**: Must be a string (for arbitrary precision with large numbers)
- **`currency`**: Must be lowercase (per ISO 4217 convention used in intent specs)

## Changes

### Core spec (`draft-httpauth-payment-00.md`)
- Line 304: `"currency": "USD"` → `"currency": "usd"`
- Line 810: `"currency": "USD"` → `"currency": "usd"`

### Stripe charge (`draft-stripe-charge-00.md`)
- Line 413: `"amount": 5000` → `"amount": "5000"`
- Line 460: `"amount": 5000` → `"amount": "5000"`
- Line 482: `"amount": 250000` → `"amount": "250000"`

### Stripe authorize (`draft-stripe-authorize-00.md`)
- Line 491: `"amount": 100000` → `"amount": "100000"`

### Stripe subscription (`draft-stripe-subscription-00.md`)
- Line 585: `"amount": 9900` → `"amount": "9900"`