### PR TITLE
fix: use 'period' consistently instead of 'interval' in Stripe subscription receipt

### DIFF
--- a/specs/methods/stripe/draft-stripe-subscription-00.md
+++ b/specs/methods/stripe/draft-stripe-subscription-00.md
@@ -584,7 +584,7 @@ Decoded receipt:
   "subscriptionId": "sub_1N4Zv32eZvKYlo2CPhVPkJlW",
   "amount": "9900",
   "currency": "usd",
-  "interval": "month",
+  "period": "month",
   "status": "active",
   "currentPeriodEnd": "2025-02-15T12:00:00Z"
 }


### PR DESCRIPTION
## Summary

Fixes inconsistent field naming between intent specs and Stripe subscription receipt examples.

## Problem

- Intent specs define the field as `period` in the request schema
- The Stripe subscription receipt example was using `interval`