### PR TITLE
clarify: failed receipts MUST NOT be returned with 200 in sync flows

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -389,7 +389,7 @@ Decoded credential:
 }
 ~~~
 
-## Payment-Receipt Header
+## Payment-Receipt Header {#payment-receipt-header}
 
 Servers SHOULD include a `Payment-Receipt` header on successful responses:
 
@@ -407,6 +407,24 @@ The decoded JSON object contains:
 | `reference` | string | Method-specific reference (tx hash, invoice id, etc.) |
 
 Payment method specifications MAY define additional fields for receipts.
+
+### Receipt Status Semantics
+
+The `status` field indicates the final settlement status of the payment:
+
+- **"success"**: The payment was verified and settled successfully.
+- **"failed"**: The payment was submitted but failed during settlement.
+
+Servers MUST NOT return a 200 response with a `status: "failed"` receipt
+for synchronous payment flows. When verification determines that a payment
+failed, servers MUST return 402 with a `verification-failed` problem
+(see {{response-status-codes}}).
+
+The `status: "failed"` value is intended for asynchronous notification
+channels where the client has already received a 200 response but the
+payment subsequently failed during settlement. Payment method specifications
+that support asynchronous settlement MUST define how clients are notified
+of failed payments.
 
 # Payment Methods {#payment-methods}
 


### PR DESCRIPTION
## Summary

Adds explicit guidance in the Receipt Status Semantics section clarifying the relationship between HTTP status codes and receipt status values.

## Changes

- Added `{#payment-receipt-header}` anchor for cross-referencing
- Added new "Receipt Status Semantics" subsection under Payment-Receipt Header
- Clarifies that servers MUST return 402 with `verification-failed` when payment fails synchronously
- Clarifies that `status: "failed"` is intended for async notification channels only
- Requires payment methods with async settlement to define failure notification mechanisms

## Motivation

The spec previously defined `status` as either "success" or "failed" but did not specify when each should be used or what HTTP status code should accompany a failed receipt. This led to implementations returning 200 with a failed receipt, which is confusing for clients.

This clarification ensures:
- Synchronous failures always return 402 (allowing retry)
- 200 responses always indicate successful payment
- Async failure notifications are properly scoped to webhook/polling scenarios