### PR TITLE
Remove crypto-specific references from intent spec normative text

### DIFF
--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -146,14 +146,7 @@ payment networks:
 | Format | Example | Description |
 |--------|---------|-------------|
 | ISO 4217 | `"usd"`, `"eur"` | Fiat currencies (lowercase) |
-| Token address | `"0x20c0..."` | ERC-20, TIP-20, or similar token contracts |
-| Well-known symbol | `"sat"`, `"btc"`, `"eth"` | Native blockchain assets |
-
-Clients can detect the format:
-
-- Starts with `0x`: Token contract address
-- Three lowercase letters: ISO 4217 currency code
-- Otherwise: Well-known symbol or method-specific identifier
+| Method-defined | (varies) | Payment method-specific currency identifiers |
 
 Payment method specifications MUST document which currency formats they
 support and how to interpret amounts for each format.


### PR DESCRIPTION
Moves blockchain/token-specific currency format details out of the normative Currency Formats section. These details belong in payment method specifications, not the core intent spec.

**Before:** The Currency Formats table included token addresses, ERC-20, TIP-20, sat, btc, eth, and detection logic for `0x`-prefixed addresses.

**After:** Just ISO 4217 fiat currencies and a generic "method-defined" row that defers to payment method specs.

The examples section still includes blockchain examples, which is appropriate for illustrative purposes.