### PR TITLE
fix: remove stale symlinks causing CI build failures

### DIFF
--- a/site/public/draft-httpauth-payment-00.html
+++ b/site/public/draft-httpauth-payment-00.html
@@ -1,1 +1,0 @@
-../../artifacts/draft-httpauth-payment-00.html

--- a/site/public/draft-httpauth-payment-00.pdf
+++ b/site/public/draft-httpauth-payment-00.pdf
@@ -1,1 +1,0 @@
-../../artifacts/draft-httpauth-payment-00.pdf

--- a/site/public/draft-httpauth-payment-00.txt
+++ b/site/public/draft-httpauth-payment-00.txt
@@ -1,1 +1,0 @@
-../../artifacts/draft-httpauth-payment-00.txt

--- a/site/public/draft-httpauth-payment-00.xml
+++ b/site/public/draft-httpauth-payment-00.xml
@@ -1,1 +1,0 @@
-../../artifacts/draft-httpauth-payment-00.xml

--- a/site/public/draft-payment-discovery-00.html
+++ b/site/public/draft-payment-discovery-00.html
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-discovery-00.html

--- a/site/public/draft-payment-discovery-00.pdf
+++ b/site/public/draft-payment-discovery-00.pdf
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-discovery-00.pdf

--- a/site/public/draft-payment-discovery-00.txt
+++ b/site/public/draft-payment-discovery-00.txt
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-discovery-00.txt

--- a/site/public/draft-payment-discovery-00.xml
+++ b/site/public/draft-payment-discovery-00.xml
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-discovery-00.xml

--- a/site/public/draft-payment-intent-charge-00.html
+++ b/site/public/draft-payment-intent-charge-00.html
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-intent-charge-00.html

--- a/site/public/draft-payment-intent-charge-00.pdf
+++ b/site/public/draft-payment-intent-charge-00.pdf
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-intent-charge-00.pdf

--- a/site/public/draft-payment-intent-charge-00.txt
+++ b/site/public/draft-payment-intent-charge-00.txt
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-intent-charge-00.txt

--- a/site/public/draft-payment-intent-charge-00.xml
+++ b/site/public/draft-payment-intent-charge-00.xml
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-intent-charge-00.xml

--- a/site/public/draft-payment-transport-mcp-00.html
+++ b/site/public/draft-payment-transport-mcp-00.html
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-transport-mcp-00.html

--- a/site/public/draft-payment-transport-mcp-00.pdf
+++ b/site/public/draft-payment-transport-mcp-00.pdf
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-transport-mcp-00.pdf

--- a/site/public/draft-payment-transport-mcp-00.txt
+++ b/site/public/draft-payment-transport-mcp-00.txt
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-transport-mcp-00.txt

--- a/site/public/draft-payment-transport-mcp-00.xml
+++ b/site/public/draft-payment-transport-mcp-00.xml
@@ -1,1 +1,0 @@
-../../artifacts/draft-payment-transport-mcp-00.xml

--- a/site/public/draft-stripe-charge-00.html
+++ b/site/public/draft-stripe-charge-00.html
@@ -1,1 +1,0 @@
-../../artifacts/draft-stripe-charge-00.html

--- a/site/public/draft-stripe-charge-00.pdf
+++ b/site/public/draft-stripe-charge-00.pdf
@@ -1,1 +1,0 @@
-../../artifacts/draft-stripe-charge-00.pdf

--- a/site/public/draft-stripe-charge-00.txt
+++ b/site/public/draft-stripe-charge-00.txt
@@ -1,1 +1,0 @@
-../../artifacts/draft-stripe-charge-00.txt

--- a/site/public/draft-stripe-charge-00.xml
+++ b/site/public/draft-stripe-charge-00.xml
@@ -1,1 +1,0 @@
-../../artifacts/draft-stripe-charge-00.xml

--- a/site/public/draft-tempo-charge-00.html
+++ b/site/public/draft-tempo-charge-00.html
@@ -1,1 +1,0 @@
-../../artifacts/draft-tempo-charge-00.html

--- a/site/public/draft-tempo-charge-00.pdf
+++ b/site/public/draft-tempo-charge-00.pdf
@@ -1,1 +1,0 @@
-../../artifacts/draft-tempo-charge-00.pdf

--- a/site/public/draft-tempo-charge-00.txt
+++ b/site/public/draft-tempo-charge-00.txt
@@ -1,1 +1,0 @@
-../../artifacts/draft-tempo-charge-00.txt

--- a/site/public/draft-tempo-charge-00.xml
+++ b/site/public/draft-tempo-charge-00.xml
@@ -1,1 +1,0 @@
-../../artifacts/draft-tempo-charge-00.xml

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -1,1 +1,0 @@
-../../artifacts/index.html


### PR DESCRIPTION
## Problem

CI build is failing with:
```
tar: ./draft-httpauth-payment-00.txt: File removed before we read it
```

## Cause

Symlinks in `site/public/` were committed to git before the `.gitignore` was updated to ignore them. During CI:

1. `gen.sh` runs with `-P4` (parallel) and recreates symlinks
2. `upload-pages-artifact` runs `tar --dereference` which follows symlinks
3. Race condition: some files get removed/recreated while tar is running

## Fix

Remove the stale committed symlinks. They're already gitignored, so they'll be created fresh during each CI build without any tracking issues.

Fixes: https://github.com/tempoxyz/payment-auth-spec/actions/runs/21601153889