### PR TITLE
fix: change header to Authentication and MCP transport to Informational

### DIFF
--- a/scripts/templates/index.html.j2
+++ b/scripts/templates/index.html.j2
@@ -138,7 +138,7 @@
   </style>
 </head>
 <body>
-  <h1>HTTP <code>Payment</code> Auth Specifications</h1>
+  <h1>HTTP <code>Payment</code> Authentication Specifications</h1>
 
   <div class="tree">
 {%- for domain in domains %}

--- a/specs/extensions/transports/draft-payment-transport-mcp-00.md
+++ b/specs/extensions/transports/draft-payment-transport-mcp-00.md
@@ -3,7 +3,7 @@ title: "Payment Authentication Scheme: MCP Transport"
 abbrev: Payment MCP Transport
 docname: draft-payment-transport-mcp-00
 version: 00
-category: std
+category: info
 ipr: trust200902
 submissiontype: IETF
 consensus: true


### PR DESCRIPTION
- Changes 'HTTP Payment Auth Specifications' header to 'HTTP Payment Authentication Specifications'
- Changes MCP transport document category from Standards Track (`std`) to Informational (`info`)