### PR TITLE
fix: replace folder emoji with ~/ and remove margin-right on format links

### DIFF
--- a/scripts/gen_index.py
+++ b/scripts/gen_index.py
@@ -13,8 +13,8 @@ DOMAINS = [
     {"folder": "core", "name": "Core"},
     {"folder": "extensions", "name": "Extensions"},
     {"folder": "intents", "name": "Intents"},
-    {"folder": "methods/stripe", "name": "Payment Methods / Stripe"},
-    {"folder": "methods/tempo", "name": "Payment Methods / Tempo"},
+    {"folder": "methods/stripe", "name": "Payment Methods/Stripe"},
+    {"folder": "methods/tempo", "name": "Payment Methods/Tempo"},
     {"folder": "extensions/transports", "name": "Transports"},
 ]
 

--- a/scripts/templates/index.html.j2
+++ b/scripts/templates/index.html.j2
@@ -52,7 +52,6 @@
     }
 
     .folder-icon {
-      margin-right: 0.5rem;
     }
 
     .spec-entry {
@@ -98,7 +97,6 @@
     .formats a {
       color: var(--color-link);
       text-decoration: none;
-      margin-right: 0.25rem;
     }
 
     .formats a:hover {
@@ -158,7 +156,7 @@
 
   <div class="tree">
 {%- for domain in domains %}
-    <div class="folder"><span class="folder-icon">📁</span>{{ domain.name }}</div>
+    <div class="folder"><span class="folder-icon">~/</span>{{ domain.name }}</div>
 {%- for spec in domain.specs %}
 {%- set is_last = loop.last %}
     <div class="spec-entry">


### PR DESCRIPTION
- Replaces 📁 folder emoji with `~/` prefix
- Removes margin-right on format links (HTML · TXT · XML · PDF)