### PR TITLE
fix: use snake_case for folder names

### DIFF
--- a/scripts/gen_index.py
+++ b/scripts/gen_index.py
@@ -13,8 +13,8 @@ DOMAINS = [
     {"folder": "core", "name": "Core"},
     {"folder": "extensions", "name": "Extensions"},
     {"folder": "intents", "name": "Intents"},
-    {"folder": "methods/stripe", "name": "Payment Methods/Stripe"},
-    {"folder": "methods/tempo", "name": "Payment Methods/Tempo"},
+    {"folder": "methods/stripe", "name": "Payment_Methods/Stripe"},
+    {"folder": "methods/tempo", "name": "Payment_Methods/Tempo"},
     {"folder": "extensions/transports", "name": "Transports"},
 ]
 


### PR DESCRIPTION
Changes folder display names to use underscores:
- `Payment Methods/Stripe` → `Payment_Methods/Stripe`
- `Payment Methods/Tempo` → `Payment_Methods/Tempo`