### PR TITLE
feat: publish spec artifacts as GitHub Release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: deploy
@@ -39,6 +39,18 @@ jobs:
           name: ietf-specs-${{ github.sha }}
           path: site/public/
           retention-days: 90
+
+      - name: Publish spec artifacts as GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete latest --yes --cleanup-tag 2>/dev/null || true
+          gh release create latest site/public/*.html site/public/*.txt site/public/*.xml site/public/*.pdf \
+            --title "Latest spec artifacts" \
+            --notes "Auto-published spec build artifacts from commit ${{ github.sha }}.
+
+          Contains HTML, TXT, XML, and PDF renderings of all IETF Payment Auth specifications." \
+            --latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Adds a step to the deploy workflow that creates/updates a GitHub Release tagged `latest` with all built spec files (HTML, TXT, XML, PDF) from `site/public/` as release assets.

## Why

The MPP docs site needs to download spec artifacts at build time to host them at `/specs/`. GitHub Actions artifacts expire after 90 days and require authentication to download. A GitHub Release tagged `latest` provides a stable, public URL for fetching the latest spec builds.

## Changes

- **Bumped `permissions.contents` from `read` to `write`** — required for creating releases
- **Added "Publish spec artifacts as GitHub Release" step** after the existing artifact upload:
  1. Deletes the existing `latest` release/tag if it exists
  2. Creates a new `latest` release with all `*.html`, `*.txt`, `*.xml`, and `*.pdf` files from `site/public/`

The existing artifact upload and Cloudflare deploy steps are unchanged.