### PR TITLE
Drop sessionHash from voucher type

### DIFF
--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -1611,7 +1611,7 @@ The `request` decodes to:
   "currency": "0x20c0000000000000000000000000000000000001",
   "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
   "methodDetails": {
-    "escrowContract": "0x7a6357db33731cfb7b9d54aca750507f13a3fec0",
+    "escrowContract": "0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70",
     "chainId": 42431
   }
 }
@@ -1850,7 +1850,7 @@ interface ITempoStreamChannel {
 
 | Network | Chain ID | Contract Address |
 |---------|----------|------------------|
-| Moderato (Testnet) | 42431 | `0x7a6357db33731cfb7b9d54aca750507f13a3fec0` |
+| Moderato (Testnet) | 42431 | `0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70` |
 
 ## Contract Source
 


### PR DESCRIPTION
## Summary

- Remove `sessionHash` from the EIP-712 `Voucher` type definition, reducing it to `Voucher(bytes32 channelId, uint128 cumulativeAmount)`
- Remove `sessionHash` from all contract function signatures (`settle`, `close`, `getVoucherDigest`), credential payload schemas (`open`, `voucher`, `close`), JSON Schema definitions, and all examples
- Replace the "Session and Resource Binding" section with a "Cross-Session Replay Prevention" section explaining why cumulative monotonicity makes `sessionHash` unnecessary

## Rationale

`sessionHash` was intended to prevent cross-session replay attacks by cryptographically binding vouchers to a specific `(challengeId, resourceURI)` pair. However, cumulative monotonicity already provides this guarantee:

1. Each voucher authorizes a **cumulative total** up to `cumulativeAmount`
2. The on-chain contract enforces `cumulativeAmount > channel.settled` (strict monotonicity)
3. Servers track `highestVoucherAmount` per session and reject vouchers that do not advance state

A replayed voucher from session A presented in session B can only authorize funds up to the amount already committed — it cannot extract additional funds because the settlement watermark only moves forward.