### PR TITLE
feat: add versioning strategy for payment methods and intents

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -156,32 +156,41 @@ wire format, register a new scheme name (e.g., `Payment2`).
 RFC 7616), OAuth 2.0 (RFC 6749), JOSE/JWT
 (RFC 7515-7519).
 
-### Payment Methods: Version by Identifier
+### Payment Methods: Version in Method Details
 
 Methods are identified by strings in the IANA Payment
 Methods Registry (e.g., `tempo`, `x402`, `stripe`).
 
-- **Compatible changes** (adding optional fields, defining
-  defaults): made in-place under the same identifier.
-- **Breaking changes** (removing required fields, changing
-  semantics): register a new identifier (e.g.,
-  `tempo-v2`).
-
-Method specs MAY define a `version` field within their
-method-specific details for incremental schema tracking:
+Method specs MAY include a `version` field in their
+`methodDetails`. The absence of a `version` field is
+implicitly version 1:
 
 ```json
 {
-  "version": 1,
   "chainId": 42431,
   "feePayer": true
 }
 ```
 
-**Registry policy:** Changes to an existing method
-identifier MUST be backwards compatible. Removing or
-renaming required fields, or changing the semantics of
-existing fields, requires a new method identifier.
+When a breaking change is needed, the method spec adds
+a `version` field starting at `2`:
+
+```json
+{
+  "version": 2,
+  "chainId": 42431,
+  "feePayer": true
+}
+```
+
+- **Compatible changes** (adding optional fields, defining
+  defaults): made in-place, same version.
+- **Breaking changes** (removing required fields, changing
+  semantics): add or increment `version`.
+
+Methods MAY also register a new identifier (e.g.,
+`tempo-v2`) for changes fundamental enough to warrant a
+distinct name, but this is not required.
 
 ### Payment Intents: No Version
 
@@ -213,5 +222,5 @@ and enables most evolution without version changes.
 | Layer | Versioning | Breaking Change |
 |-------|------------|-----------------|
 | Core | None (stable scheme name) | New scheme (`Payment2`) |
-| Methods | Identifier + `methodDetails.version` | New identifier (`tempo-v2`) |
+| Methods | Optional `methodDetails.version` (absent = v1) | Add/increment version |
 | Intents | None (stable intent identifier) | New identifier (`charge-v2`) |

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -532,6 +532,36 @@ Payment method specifications MUST define:
 5. **Settlement Procedure**: How payment is finalized
 6. **Security Considerations**: Method-specific threats and mitigations
 
+## Versioning {#versioning}
+
+The Payment scheme uses a layered versioning strategy:
+
+### Core Protocol
+
+The `Payment` scheme name is the stable identifier. The core protocol
+does NOT carry a version on the wire, consistent with all deployed HTTP
+authentication schemes (`Basic`, `Bearer`, `Digest`). Evolution happens
+through adding optional parameters and fields; implementations MUST
+ignore unknown parameters and fields. If a future change is truly
+incompatible, a new scheme name (e.g., `Payment2`) would be registered.
+
+### Payment Methods
+
+Payment method specifications MAY include a `version` field in their
+`methodDetails`. The absence of a `version` field is implicitly
+version 1. When a breaking change is needed, the method specification
+adds a `version` field starting at `2`. Compatible changes (adding
+optional fields, defining defaults) do not require a version change.
+Methods MAY also register a new identifier for changes fundamental
+enough to warrant a distinct name.
+
+### Payment Intents
+
+Payment intents do not carry a version. They evolve through the same
+compatibility rules as the core: adding optional fields with defined
+defaults is compatible, and breaking changes require a new intent
+identifier (e.g., `charge-v2`).
+
 ## Custom Parameters
 
 Implementations MAY define additional parameters in challenges:


### PR DESCRIPTION
## Summary

Re-opens #113 off current main.

Adds a formal versioning strategy for the Payment Auth spec, integrated into STYLE.md.

## Two-Layer Versioning

| Layer | Mechanism | Breaking Change |
|-------|-----------|-----------------| 
| **Core Protocol** | No wire version (stable `Payment` scheme name) | New scheme name (`Payment2`) |
| **Payment Methods** | Optional `methodDetails.version` (absent = v1) | Add/increment version |
| **Payment Intents** | None (stable intent identifier) | New identifier (`charge-v2`) |

## Design Rationale

- **Core unversioned**: Matches every deployed HTTP auth scheme (Basic, Bearer, Digest). Core is thin enough that breaking changes are unlikely.
- **Methods version in methodDetails**: `methodDetails.version` is optional — the absence of a version field is implicitly version 1. When a breaking change is needed, the field is added starting at `2`. Compatible changes keep the same version; breaking changes add or increment it. Methods MAY optionally register a new identifier for fundamental changes, but it is not required.
- **Intents unversioned**: Intents evolve via the same "ignore unknown fields" compatibility rule as the core. Breaking changes require a new intent identifier (e.g., `charge-v2`).

Supersedes #113.