### PR TITLE
fix(stream): remove topUp close-cancel requirement to match contract

### DIFF
--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -390,10 +390,7 @@ function settle(
 
 ### topUp
 
-User adds more funds to an existing channel. If a close request is
-pending (`closeRequestedAt != 0`), calling `topUp()` MUST cancel it by
-resetting `closeRequestedAt` to zero and emitting a
-`CloseRequestCancelled` event.
+User adds more funds to an existing channel.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|


### PR DESCRIPTION
The spec states that `topUp()` MUST cancel pending close requests by resetting `closeRequestedAt` to zero and emitting a `CloseRequestCancelled` event.

The deployed contract (`0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70`) does not implement this behavior — `topUp()` only transfers tokens and increases the deposit. It does not check or reset `closeRequestedAt`.

This PR removes the close-cancel requirement to align the spec with the deployed contract. Close-cancel on topUp could be added to a future contract version if desired.