### PR TITLE
fix(stream): correct flow diagram — server broadcasts open tx, not client

### DIFF
--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -121,13 +121,14 @@ The following diagram illustrates the Tempo stream flow:
       |      (includes challengeId) |                             |
       |<--------------------------  |                             |
       |                             |                             |
-      |  (3) Open channel on-chain  |                             |
-      |------------------------------------------------------>    |
-      |                             |                             |
-      |  (4) GET /api/resource      |                             |
+      |  (3) GET /api/resource      |                             |
       |      Authorization: Payment |                             |
       |      action="open"          |                             |
+      |      (includes signed tx)   |                             |
       |-------------------------->  |                             |
+      |                             |                             |
+      |                             |  (4) open(...)               |
+      |                             |-------------------------->  |
       |                             |                             |
       |  (5) 200 OK + Receipt       |                             |
       |      (streaming response)   |                             |


### PR DESCRIPTION
The stream flow diagram (Section 1.2) incorrectly shows the client opening the channel on-chain directly:

```
|  (3) Open channel on-chain  |                             |
|------------------------------------------------------>    |
```

In reality, the client signs the transaction and includes it in the `action="open"` credential payload. The **server** validates the transaction, optionally adds a fee payer signature, and broadcasts it.

This matches the spec's own text in Section 8.3.1:
> "The transaction field contains the complete signed Tempo Transaction... The server broadcasts the transaction."

The corrected diagram shows:
1. Client sends signed tx in the open credential (step 3)
2. Server broadcasts the tx on-chain (step 4)