### PR TITLE
refactor: switch payment token from AlphaUSD to PathUSD

### DIFF
--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -130,7 +130,7 @@ Cache-Control: max-age=300
   "methods": {
     "tempo": {
       "intents": ["charge", "authorize", "subscription"],
-      "assets": ["0x20c0000000000000000000000000000000000001"]
+      "assets": ["0x20c0000000000000000000000000000000000000"]
     },
     "lightning": {
       "intents": ["charge"],

--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -181,7 +181,7 @@ shared fields to users.
 ~~~ json
 {
   "amount": "1000000",
-  "currency": "0x20c0000000000000000000000000000000000001",
+  "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
   "expires": "2025-01-06T12:00:00Z",
   "methodDetails": {

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -152,7 +152,7 @@ base64url-encoded JSON object.
 ~~~json
 {
   "amount": "1000000",
-  "currency": "0x20c0000000000000000000000000000000000001",
+  "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
   "expires": "2025-01-06T12:00:00Z",
   "methodDetails": {
@@ -465,7 +465,7 @@ The `request` decodes to:
 ~~~json
 {
   "amount": "1000000",
-  "currency": "0x20c0000000000000000000000000000000000001",
+  "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
   "expires": "2025-01-06T12:00:00Z",
   "methodDetails": {
@@ -474,7 +474,7 @@ The `request` decodes to:
 }
 ~~~
 
-This requests a transfer of 1.00 alphaUSD (1000000 base units).
+This requests a transfer of 1.00 pathUSD (1000000 base units).
 
 **Credential:**
 

--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -565,7 +565,7 @@ mappings to suggest channel reuse, reducing on-chain transactions.
   "amount": "25",
   "unitType": "llm_token",
   "suggestedDeposit": "10000000",
-  "currency": "0x20c0000000000000000000000000000000000001",
+  "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
   "methodDetails": {
     "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
@@ -583,7 +583,7 @@ deposit of 10.00 tokens. The client generates a random salt locally.
 {
   "amount": "25",
   "unitType": "llm_token",
-  "currency": "0x20c0000000000000000000000000000000000001",
+  "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
   "methodDetails": {
     "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
@@ -1566,7 +1566,7 @@ The `request` decodes to:
   "amount": "25",
   "unitType": "llm_token",
   "suggestedDeposit": "10000000",
-  "currency": "0x20c0000000000000000000000000000000000001",
+  "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
   "methodDetails": {
     "escrowContract": "0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70",
@@ -1579,7 +1579,7 @@ Note: Challenge expiry is in the header `expires` auth-param, not in the
 request JSON. The client generates a random salt locally for new channels.
 
 This requests a price of 0.000025 tokens per LLM token, with a suggested
-deposit of 10.00 alphaUSD (10000000 base units).
+deposit of 10.00 pathUSD (10000000 base units).
 
 ## Open Credential
 


### PR DESCRIPTION
## Summary
Switch all spec examples from AlphaUSD (`0x20c0...0001`) to PathUSD (`0x20c0...0000`). AlphaUSD was a testnet-only fake coin.

## Changes (4 files)
- `draft-tempo-charge-00.md` — addresses + prose
- `draft-tempo-stream-00.md` — addresses + prose
- `draft-payment-intent-charge-00.md` — address
- `draft-payment-discovery-00.md` — address

Thread: https://tempoxyz.slack.com/archives/C0A8YB63Q91/p1770606546055849