### PR TITLE
spec(stream): simplify concurrency model, add mpay-need-voucher SSE event

### DIFF
--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -1218,7 +1218,7 @@ available balance is exhausted:
 
 ~~~
 event: 402-need-voucher
-data: {"channelId":"0x6d0f4fdf...","requiredCumulative":"250025","acceptedCumulative":"250000"}
+data: {"channelId":"0x6d0f4fdf...","requiredCumulative":"250025","acceptedCumulative":"250000","deposit":"500000"}
 ~~~
 
 The `402-need-voucher` event data MUST be a JSON object containing:
@@ -1227,7 +1227,14 @@ The `402-need-voucher` event data MUST be a JSON object containing:
 |-------|------|----------|-------------|
 | `acceptedCumulative` | string | REQUIRED | Current highest accepted voucher amount (base units) |
 | `channelId` | string | REQUIRED | Channel identifier (hex-encoded bytes32) |
+| `deposit` | string | REQUIRED | Current on-chain deposit in the escrow contract (base units) |
 | `requiredCumulative` | string | REQUIRED | Minimum cumulative amount the next voucher must authorize (base units) |
+
+The `deposit` field allows the client to determine the correct recovery
+action. When `requiredCumulative` exceeds `deposit`, the client MUST
+submit `action="topUp"` to increase the on-chain deposit before sending
+a new voucher. When `requiredCumulative` is within `deposit`, the client
+can submit `action="voucher"` directly.
 
 After emitting `402-need-voucher`, the server MUST pause delivery
 until a valid voucher advancing `acceptedCumulative` is accepted.


### PR DESCRIPTION
## Changes

Simplifies the Tempo Stream spec to drop concurrent session support. One channel = one session, one cumulative counter.

### §1.3 Concurrency Model
- Replace concurrent session model with one-session-per-channel semantics
- Remove 409 Conflict option for concurrent streams
- Remove "zero or more concurrent voucher update requests" complexity
- Channel is the unit of concurrency; no session locking needed

### §11.6 Insufficient Balance During Streaming
- Add normative `402-need-voucher` SSE event type
- Format: `event: 402-need-voucher` with JSON data containing `channelId`, `requiredCumulative`, `acceptedCumulative`
- Servers MUST emit when balance exhausted during SSE streaming
- Clients SHOULD respond with a voucher credential to any endpoint on the same handler

### §12.4 Sequential Streams (renamed from Concurrent Streams)
- One channel supports sequential streams with same cumulative counter
- Previous session spending state is irrelevant
- `highestVoucherAmount` is the source of truth

### Unchanged
- `suggestedDeposit` stays as-is
- Credential schema, voucher signing, verification, receipt schema, security considerations, contract interface all unchanged