### PR TITLE
spec(stream): reject vouchers when channel has pending close request

### DIFF
--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -1016,7 +1016,8 @@ On `action="open"`, servers MUST:
    - `channel.token` matches `request.currency`
    - `channel.deposit - channel.settled >= amount` (sufficient available balance)
    - Channel is not finalized
-3. If `cumulativeAmount` and `signature` are provided, verify the initial
+   - `channel.closeRequestedAt == 0` (no pending close request)
+   3. If `cumulativeAmount` and `signature` are provided, verify the initial
    voucher:
    - Recover signer from EIP-712 signature
    - Verify signature uses canonical low-s values (see {{signature-malleability}})
@@ -1047,12 +1048,15 @@ On `action="voucher"`, servers MUST:
 1. Verify voucher signature using EIP-712 recovery
 2. Verify signature uses canonical low-s values (see {{signature-malleability}})
 3. Recover signer and MUST verify it matches expected signer from on-chain state
-4. Verify monotonicity:
+4. Verify `channel.closeRequestedAt == 0` (no pending close request).
+   Servers MUST reject vouchers on channels with a pending forced close
+   to prevent service delivery that cannot be settled.
+5. Verify monotonicity:
    - `cumulativeAmount > highestVoucherAmount`
    - `(cumulativeAmount - highestVoucherAmount) >= minVoucherDelta`
-5. Verify `cumulativeAmount <= channel.deposit`
-6. Persist voucher to durable storage before providing service
-7. Update `highestVoucherAmount = cumulativeAmount`
+6. Verify `cumulativeAmount <= channel.deposit`
+7. Persist voucher to durable storage before providing service
+8. Update `highestVoucherAmount = cumulativeAmount`
 
 Servers MUST derive the expected signer from on-chain channel state by
 querying the escrow contract. The expected signer is `channel.authorizedSigner`


### PR DESCRIPTION
## Problem

A malicious client can exploit the forced-close grace period:

1. Open a channel
2. Call `requestClose()` on-chain (starts 15-min grace period)
3. Wait ~14.9 minutes
4. Send a burst of voucher requests — server accepts and delivers service
5. After 15 minutes, call `withdraw()` — channel finalizes before the server can settle

The server delivered service against vouchers it can never redeem.

## Fix

Add a normative requirement that servers MUST check `channel.closeRequestedAt == 0` before accepting vouchers or opening channels.

### Open Verification (§10.1, step 2)
- Added `channel.closeRequestedAt == 0` (no pending close request) to the on-chain state checks

### Voucher Verification (§10.3)
- Added new step 4: verify `channel.closeRequestedAt == 0`. Servers MUST reject vouchers on channels with a pending forced close to prevent service delivery that cannot be settled.
- Renumbered subsequent steps (5→8)

### Not affected
- **TopUp**: `topUp()` on-chain cancels the pending close (`closeRequestedAt` resets to 0), so no check needed
- **Close**: server should still cooperatively close even with a pending close request