### PR TITLE
fix: align spec with mpay implementation

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -287,6 +287,41 @@ The binding mechanism is implementation-defined. Servers MAY use stateful
 storage (e.g., database lookup) or stateless verification (e.g., HMAC,
 authenticated encryption) to validate the binding.
 
+##### Recommended: HMAC-SHA256 Binding
+
+Servers using HMAC-SHA256 for stateless challenge binding SHOULD compute
+the challenge `id` as follows:
+
+1. Collect the following challenge components in order:
+   - `realm`
+   - `method`
+   - `intent`
+   - base64url-encoded `request` (as it appears on the wire)
+   - `expires` (if present and non-empty)
+   - `digest` (if present and non-empty)
+
+2. Remove any empty or absent components from the list.
+
+3. Join the remaining components with the pipe character (`|`) as
+   delimiter.
+
+4. Compute HMAC-SHA256 over the resulting string using a server secret.
+
+5. Encode the HMAC output as base64url without padding ({{RFC4648}}
+   Section 5).
+
+~~~
+components = [realm, method, intent, request_b64url]
+if expires: components.append(expires)
+if digest: components.append(digest)
+input = "|".join(components)
+id = base64url(HMAC-SHA256(server_secret, input))
+~~~
+
+Absent optional fields (expires, digest) are omitted entirely from the
+HMAC input rather than included as empty strings. This ensures the `id`
+is deterministic regardless of which optional parameters are present.
+
 #### Example Challenge
 
 ~~~http
@@ -405,7 +440,7 @@ The decoded JSON object contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | string | Payment status: "success" or "failed" |
+| `status` | string | `"success"` — receipts are only issued on successful payment |
 | `method` | string | Payment method used |
 | `timestamp` | string | ISO 8601 settlement time |
 | `reference` | string | Method-specific reference (tx hash, invoice id, etc.) |
@@ -414,21 +449,14 @@ Payment method specifications MAY define additional fields for receipts.
 
 ### Receipt Status Semantics
 
-The `status` field indicates the final settlement status of the payment:
+The `status` field MUST be `"success"`, indicating the payment was
+verified and settled successfully. Receipts are only issued on
+successful payment responses (2xx status codes).
 
-- **"success"**: The payment was verified and settled successfully.
-- **"failed"**: The payment was submitted but failed during settlement.
-
-Servers MUST NOT return a 200 response with a `status: "failed"` receipt
-for synchronous payment flows. When verification determines that a payment
-failed, servers MUST return 402 with a `verification-failed` problem
-(see {{response-status-codes}}).
-
-The `status: "failed"` value is intended for asynchronous notification
-channels where the client has already received a 200 response but the
-payment subsequently failed during settlement. Payment method specifications
-that support asynchronous settlement MUST define how clients are notified
-of failed payments.
+Servers MUST NOT return a `Payment-Receipt` header on error responses.
+Payment failures are communicated via HTTP status codes and Problem
+Details {{RFC9457}}. Servers MUST return 402 with a fresh challenge
+and appropriate problem type when payment verification fails.
 
 # Payment Methods {#payment-methods}
 
@@ -504,8 +532,9 @@ responses:
 }
 ~~~
 
-The `type` URI is constructed as `https://paymentauth.org/problems/{code}`
-where `{code}` is the error code from the table below.
+The `type` URI SHOULD correspond to one of the problem types defined
+below. The canonical base URI for problem types is
+`https://paymentauth.org/problems/`.
 
 ## Error Codes
 

--- a/specs/extensions/transports/draft-payment-transport-mcp-00.md
+++ b/specs/extensions/transports/draft-payment-transport-mcp-00.md
@@ -224,7 +224,13 @@ to -32099) per {{JSON-RPC}}:
           "expires": "2025-01-15T12:05:00Z",
           "description": "API call fee"
         }
-      ]
+      ],
+      "problem": {
+        "type": "https://paymentauth.org/problems/payment-required",
+        "title": "Payment Required",
+        "status": 402,
+        "detail": "Payment required for access."
+      }
     }
   }
 }
@@ -239,6 +245,10 @@ transport compatibility.
 The `error.data` object MUST contain:
 
 **`challenges`** (REQUIRED): Array of one or more challenge objects.
+
+**`problem`** (OPTIONAL): An RFC 9457 Problem Details object providing
+  additional error context. When present, contains `type`, `title`,
+  `status`, `detail`, and optionally `challengeId`.
 
 Each challenge object MUST contain:
 
@@ -414,14 +424,10 @@ include a receipt in the response using `_meta` with key
     "_meta": {
       "org.paymentauth/receipt": {
         "status": "success",
-        "challengeId": "qB3wErTyU7iOpAsD9fGhJk",
         "method": "tempo",
         "timestamp": "2025-01-15T12:00:30Z",
         "reference": "tx_abc123...",
-        "settlement": {
-          "amount": "1000",
-          "currency": "usd"
-        }
+        "challengeId": "qB3wErTyU7iOpAsD9fGhJk"
       }
     }
   }
@@ -439,19 +445,16 @@ The `org.paymentauth/receipt` object MUST contain:
 **`status`** (REQUIRED): Settlement status. MUST be `"success"` for
   successful payments.
 
-**`challengeId`** (REQUIRED): The `id` from the fulfilled challenge.
-
 **`method`** (REQUIRED): Payment method that was used.
 
 **`timestamp`** (REQUIRED): {{RFC3339}} timestamp of settlement.
+
+**`challengeId`** (REQUIRED): The `id` from the fulfilled challenge.
 
 The receipt object MAY contain:
 
 **`reference`** (OPTIONAL): Method-specific settlement reference
   (e.g., transaction hash, invoice ID).
-
-**`settlement`** (OPTIONAL): Object containing settlement details
-  such as `amount` and `currency`.
 
 # Covered Operations
 
@@ -566,8 +569,8 @@ Prompt retrieval via `prompts/get` MAY require payment:
 
 ## Error Code Mapping
 
-MCP transport maps payment errors to JSON-RPC error codes within the
-implementation-defined range (-32000 to -32099) per {{JSON-RPC}}:
+Servers MUST map payment errors to JSON-RPC error codes within the
+server error range (-32000 to -32099) per {{JSON-RPC}}:
 
 | Condition | Code | Description |
 |-----------|------|-------------|
@@ -748,8 +751,7 @@ resources or payment processor rate limits. Servers SHOULD:
 This document has no IANA actions. Payment methods and intents are
 registered per {{I-D.httpauth-payment}}.
 
-This specification defines JSON-RPC error codes in the
-implementation-defined range:
+Servers MUST use the following JSON-RPC error codes:
 
 | Code | Name | Description |
 |------|------|-------------|
@@ -757,7 +759,7 @@ implementation-defined range:
 | -32043 | Payment Verification Failed | Payment credential invalid |
 
 These codes are within the JSON-RPC server error range (-32000 to
--32099) and do not require IANA registration.
+-32099). Implementations MUST use these exact codes for interoperability.
 
 --- back
 
@@ -856,14 +858,10 @@ A complete tool call with payment:
     "_meta": {
       "org.paymentauth/receipt": {
         "status": "success",
-        "challengeId": "ch_abc123",
         "method": "tempo",
         "timestamp": "2025-01-15T12:00:15Z",
         "reference": "0xtx789...",
-        "settlement": {
-          "amount": "10",
-          "currency": "usd"
-        }
+        "challengeId": "ch_abc123"
       }
     }
   }

--- a/specs/methods/tempo/draft-tempo-stream-00.md
+++ b/specs/methods/tempo/draft-tempo-stream-00.md
@@ -1,6 +1,6 @@
 ---
-title: Tempo Stream Intent for HTTP Payment Authentication
-abbrev: Tempo Stream
+title: Tempo Session Intent for HTTP Payment Authentication
+abbrev: Tempo Session
 docname: draft-tempo-stream-00
 version: 00
 category: info
@@ -73,7 +73,7 @@ informative:
 
 --- abstract
 
-This document defines the "stream" intent for the "tempo" payment method
+This document defines the "session" intent for the "tempo" payment method
 in the Payment HTTP Authentication Scheme. It specifies unidirectional
 streaming payment channels for incremental, voucher-based payments
 suitable for low-cost metered services.
@@ -84,13 +84,13 @@ suitable for low-cost metered services.
 
 This document is published as Informational but contains normative requirements using BCP 14 keywords {{RFC2119}} {{RFC8174}} to ensure interoperability between implementations. Payment method specifications that reference this document inherit these requirements.
 
-The `stream` intent establishes a unidirectional streaming payment channel
+The `session` intent establishes a unidirectional streaming payment channel
 using on-chain escrow and off-chain {{EIP-712}} vouchers. This enables high-
 frequency, low-cost payments by batching many off-chain voucher signatures
 into periodic on-chain settlements.
 
 Unlike the `charge` intent which requires the full payment amount upfront, the
-`stream` intent allows clients to pay incrementally as they consume
+`session` intent allows clients to pay incrementally as they consume
 services, paying exactly for resources received.
 
 ## Use Case: LLM Token Streaming
@@ -98,7 +98,7 @@ services, paying exactly for resources received.
 Consider an LLM inference API that charges per output token:
 
 1. Client requests a streaming completion (SSE response)
-2. Server returns 402 with a `stream` challenge
+2. Server returns 402 with a `session` challenge
 3. Client opens a payment channel on-chain, depositing funds
 4. Server begins streaming response
 5. As response streams streams, or over incremental requests, client signs vouchers with increasing amounts
@@ -117,7 +117,7 @@ The following diagram illustrates the Tempo stream flow:
       |-------------------------->  |                             |
       |                             |                             |
       |  (2) 402 Payment Required   |                             |
-      |      intent="stream"        |                             |
+      |      intent="session"        |                             |
       |      (includes challengeId) |                             |
       |<--------------------------  |                             |
       |                             |                             |
@@ -510,7 +510,7 @@ base64url-encoded JSON object.
 | `currency` | string | REQUIRED | {{TIP-20}} token address (e.g., `"0x20c0..."`) |
 | `recipient` | string | REQUIRED | Payee address (server's withdrawal address)—equivalent to the on-chain `payee` |
 
-For the `stream` intent, `amount` specifies the price per unit of service
+For the `session` intent, `amount` specifies the price per unit of service
 in base units (6 decimals), not a total charge. Combined with `unitType`,
 this allows clients to estimate costs before streaming begins. The total
 cost depends on consumption: `total = amount × units_consumed`.
@@ -523,14 +523,14 @@ viable deposit is implementation-defined but SHOULD be at least
 
 Challenge expiry is specified via the `expires` auth-param in the
 `WWW-Authenticate` header per {{I-D.httpauth-payment}}, using {{RFC3339}}
-timestamp format. Unlike the `charge` intent, the stream request JSON
+timestamp format. Unlike the `charge` intent, the session request JSON
 does not include an `expires` field—expiry is conveyed solely via the
 HTTP header.
 
 ## Method Details
 
 As of version 00, stream-specific request fields are placed in
-`methodDetails`. A future high-level "stream" intent definition may
+`methodDetails`. A future high-level "session" intent definition may
 promote common fields to the core schema.
 
 | Field | Type | Required | Description |
@@ -597,7 +597,7 @@ already has funds. The `channelId` tells the client to resume this channel.
 
 When a challenge includes `methodDetails.feePayer: true`, the server
 commits to paying transaction fees on behalf of the client. In the
-`stream` intent, `feePayer` affects only the client-originated channel
+`session` intent, `feePayer` affects only the client-originated channel
 funding transactions (`open` and `topUp`).
 
 ## Server-Paid Fees
@@ -727,9 +727,12 @@ to broadcast.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `type` | string | REQUIRED | `"transaction"` |
+| `channelId` | string | REQUIRED | Channel identifier (hex-encoded bytes32) |
 | `transaction` | string | REQUIRED | Signed transaction bytes |
-| `cumulativeAmount` | string | OPTIONAL | Initial amount (typically `"0"`) |
-| `signature` | string | OPTIONAL | EIP-712 voucher signature |
+| `authorizedSigner` | string | OPTIONAL | Address delegated to sign vouchers |
+| `cumulativeAmount` | string | REQUIRED | Initial cumulative amount (typically `"0"`) |
+| `signature` | string | REQUIRED | EIP-712 voucher signature for the initial amount |
 
 The `transaction` field contains the complete signed Tempo Transaction
 (type 0x76) {{TEMPO-TX-SPEC}} serialized as RLP and hex-encoded. The server
@@ -741,11 +744,8 @@ uses it to compute the `channelId` deterministically (see {{channel-state}}).
 The `authorizedSigner` is inferred from the calldata inside `transaction`
 and verified when the transaction is signed.
 
-If `cumulativeAmount` and `signature` are provided, the initial voucher
-proves the client controls the signing key and establishes the voucher chain.
-When omitted, proof of authority is deferred until the first voucher
-submission. This is typical when the initial `cumulativeAmount` would be
-zero.
+The initial voucher (`cumulativeAmount` and `signature`) proves the client
+controls the signing key and establishes the voucher chain.
 
 **Example:**
 
@@ -755,13 +755,17 @@ zero.
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
   "payload": {
     "action": "open",
-    "transaction": "0x76f901...signed transaction bytes..."
+    "type": "transaction",
+    "channelId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+    "transaction": "0x76f901...signed transaction bytes...",
+    "cumulativeAmount": "0",
+    "signature": "0xabcdef1234567890..."
   }
 }
 ~~~
@@ -790,11 +794,10 @@ challenge `id` with problem type `challenge-not-found`.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `type` | string | REQUIRED | `"transaction"` |
 | `channelId` | string | REQUIRED | Channel ID |
 | `transaction` | string | REQUIRED | Signed transaction bytes |
-
-The `additionalDeposit` amount is inferred from the calldata inside
-`transaction`.
+| `additionalDeposit` | string | REQUIRED | Additional amount to deposit in base units |
 
 **Example:**
 
@@ -804,14 +807,16 @@ The `additionalDeposit` amount is inferred from the calldata inside
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
   "payload": {
     "action": "topUp",
+    "type": "transaction",
     "channelId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
-    "transaction": "0x76f901...signed topUp transaction bytes..."
+    "transaction": "0x76f901...signed topUp transaction bytes...",
+    "additionalDeposit": "5000000"
   }
 }
 ~~~
@@ -839,7 +844,7 @@ The `voucher` action submits an updated cumulative voucher during streaming.
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
@@ -876,7 +881,7 @@ to call `close(channelId, cumulativeAmount, signature)` on-chain.
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
@@ -1010,8 +1015,7 @@ On `action="open"`, servers MUST:
    - `channel.deposit - channel.settled >= amount` (sufficient available balance)
    - Channel is not finalized
    - `channel.closeRequestedAt == 0` (no pending close request)
-   3. If `cumulativeAmount` and `signature` are provided, verify the initial
-   voucher:
+   3. Verify the initial voucher (`cumulativeAmount` and `signature`):
    - Recover signer from EIP-712 signature
    - Verify signature uses canonical low-s values (see {{signature-malleability}})
    - Signer matches `channel.payer` or `channel.authorizedSigner`
@@ -1024,15 +1028,15 @@ On `action="open"`, servers MUST:
 On `action="topUp"`, servers MUST:
 
 1. **Transaction verification**: Decode the signed transaction from
-   `transaction`, verify it calls `topUp()` on the expected escrow contract.
-   Infer the `additionalDeposit` amount from the calldata. If
+   `transaction`, verify it calls `topUp()` on the expected escrow contract
+   with the specified `additionalDeposit` amount. If
    `feePayer: true`, add fee payer signature using domain `0x78` (see
    {{fee-payment}}) and broadcast. Otherwise, broadcast as-is.
 2. Query the escrow contract to verify updated channel state:
-   - `channel.deposit` increased by the inferred deposit amount
+   - `channel.deposit` increased by `additionalDeposit`
    - Channel is not finalized
 3. Update server-side accounting:
-   - Increase available balance by the inferred deposit amount
+   - Increase available balance by `additionalDeposit`
 
 ## Voucher Verification {#voucher-verification}
 
@@ -1135,7 +1139,7 @@ available = acceptedCumulative - spent
 
 ## Per-Request Processing
 
-For each request carrying a Payment credential with `intent="stream"`,
+For each request carrying a Payment credential with `intent="session"`,
 servers MUST follow this procedure:
 
 1. **Voucher acceptance** (if a voucher is provided in the credential):
@@ -1328,19 +1332,19 @@ For SSE responses, the final receipt SHOULD be delivered as an event:
 
 ~~~
 event: payment-receipt
-data: {"method":"tempo","intent":"stream","status":"success",...}
+data: {"method":"tempo","intent":"session","status":"success",...}
 ~~~
 
 For chunked responses, the final receipt MAY be delivered as an HTTP
 trailer if the client advertises trailer support via `TE: trailers`.
 
-The base Payment Auth spec defines core receipt fields. The stream intent
+The base Payment Auth spec defines core receipt fields. The session intent
 extends the receipt with balance tracking:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `method` | string | `"tempo"` |
-| `intent` | string | `"stream"` |
+| `intent` | string | `"session"` |
 | `status` | string | `"success"` |
 | `timestamp` | string | {{RFC3339}} response time |
 | `challengeId` | string | Challenge identifier for audit correlation |
@@ -1363,7 +1367,7 @@ cost as `units × amount` from the challenge.
 ~~~json
 {
   "method": "tempo",
-  "intent": "stream",
+  "intent": "session",
   "status": "success",
   "timestamp": "2025-01-06T12:08:30Z",
   "challengeId": "c_8d0e3b5a9f2c1d4e",
@@ -1379,7 +1383,7 @@ cost as `units × amount` from the challenge.
 ~~~json
 {
   "method": "tempo",
-  "intent": "stream",
+  "intent": "session",
   "status": "success",
   "timestamp": "2025-01-06T12:10:00Z",
   "challengeId": "c_8d0e3b5a9f2c1d4e",
@@ -1586,7 +1590,7 @@ Intents" registry established by {{I-D.httpauth-payment}}:
 
 | Intent | Applicable Methods | Description | Reference |
 |--------|-------------------|-------------|-----------|
-| `stream` | `tempo` | Streaming payment channel | This document |
+| `session` | `tempo` | Streaming payment channel | This document |
 
 Contact: Tempo Labs (<contact@tempo.xyz>)
 
@@ -1623,7 +1627,7 @@ HTTP/1.1 402 Payment Required
 WWW-Authenticate: Payment id="kM9xPqWvT2nJrHsY4aDfEb",
   realm="api.llm-service.com",
   method="tempo",
-  intent="stream",
+  intent="session",
   expires="2025-01-06T12:05:00Z",
   request="<base64url-encoded JSON below>"
 ~~~
@@ -1668,13 +1672,17 @@ The credential payload for an open action:
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
   "payload": {
     "action": "open",
-    "transaction": "0x76f901...signed transaction bytes..."
+    "type": "transaction",
+    "channelId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+    "transaction": "0x76f901...signed transaction bytes...",
+    "cumulativeAmount": "0",
+    "signature": "0xabcdef1234567890..."
   }
 }
 ~~~
@@ -1707,7 +1715,7 @@ The credential payload for a voucher update:
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
@@ -1738,7 +1746,7 @@ The credential payload for a close request:
     "id": "kM9xPqWvT2nJrHsY4aDfEb",
     "realm": "api.llm-service.com",
     "method": "tempo",
-    "intent": "stream",
+    "intent": "session",
     "request": "eyJ...",
     "expires": "2025-01-06T12:05:00Z"
   },
@@ -2031,7 +2039,7 @@ and Problem Details.
   "required": ["method", "intent", "status", "timestamp", "challengeId", "channelId", "acceptedCumulative", "spent"],
   "properties": {
     "method": { "const": "tempo" },
-    "intent": { "const": "stream" },
+    "intent": { "const": "session" },
     "status": { "const": "success" },
     "timestamp": {
       "type": "string",


### PR DESCRIPTION
## Summary

Aligns the payment-auth-spec with the latest `wevm/mpay` implementation, which is the source of truth for the protocol.

## Changes

### High Impact (Wire Protocol)
- **Rename `stream` → `session` intent** — mpay uses `intent="session"` on the wire
- **Add `decimals` field** to charge and session request schemas — mpay requires it for amount conversion
- **Receipt is success-only** — `status: "success"` only; failures use 402 + Problem Details
- **HMAC challenge ID** — omit empty optional fields from MAC input (matches mpay's `.filter(Boolean)`)
- **Add `memo`** to Tempo charge `methodDetails`

### Session (formerly Stream) Payload Alignment
- **Open payload**: require `channelId`, `type: "transaction"`, `cumulativeAmount`, `signature` (were optional)
- **TopUp payload**: require explicit `additionalDeposit` and `type: "transaction"` (was inferred from calldata)

### MCP Transport
- Add optional `problem` (RFC 9457) field to error data
- Remove `settlement` from receipt structure
- Make error codes `-32042` / `-32043` normative

### Error URIs
- Canonical base: `https://tempoxyz.github.io/payment-auth-spec/problems/`
- Added full Problem Type URI table to core spec

## Context
Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770913258547769

Prompted by: kartik