### PR TITLE
fix: normalize error codes to kebab-case

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -500,20 +500,20 @@ responses:
 }
 ~~~
 
-The `type` URI SHOULD correspond to the error code from the table
-below (e.g., `https://paymentauth.org/problems/verification-failed`
-for `payment_verification_failed`).
+The `type` URI is constructed as `https://paymentauth.org/problems/{code}`
+where `{code}` is the error code from the table below.
 
 ## Error Codes
 
 | Code | HTTP | Description |
 |------|------|-------------|
-| `payment_required` | 402 | Resource requires payment |
-| `payment_insufficient` | 402 | Amount too low |
-| `payment_expired` | 402 | Challenge or authorization expired |
-| `payment_verification_failed` | 402 | Proof invalid |
-| `payment_method_unsupported` | 400 | Method not accepted |
-| `malformed_proof` | 400 | Invalid proof format |
+| `payment-required` | 402 | Resource requires payment |
+| `payment-insufficient` | 402 | Amount too low |
+| `payment-expired` | 402 | Challenge or authorization expired |
+| `verification-failed` | 402 | Proof invalid |
+| `method-unsupported` | 400 | Method not accepted |
+| `malformed-credential` | 400 | Invalid credential format |
+| `invalid-challenge` | 400 | Challenge ID unknown, expired, or already used |
 
 ## Retry Behavior
 

--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -402,8 +402,10 @@ Cache-Control: no-store
 Content-Type: application/json
 
 {
-  "error": "payment_required",
-  "message": "This resource requires payment"
+  "type": "https://paymentauth.org/problems/payment-required",
+  "title": "Payment Required",
+  "status": 402,
+  "detail": "This resource requires payment"
 }
 ~~~
 


### PR DESCRIPTION
## Summary
Normalize all error codes in the spec to kebab-case and align naming between the §4.2 status codes table and §8.2 error codes table.

## Changes
- Error codes table (§8.2): `payment_required` → `payment-required`, `payment_verification_failed` → `verification-failed`, `malformed_proof` → `malformed-credential`, etc.
- Added `invalid-challenge` to the error codes table (was referenced in §4.2 but missing from §8.2)
- Simplified type URI description to `https://paymentauth.org/problems/{code}`
- Updated Stripe spec example to use RFC 9457 Problem Details format

## Motivation
Error codes were snake_case (`payment_required`) but the type URIs and §4.2 references already used kebab-case (`payment-required`, `verification-failed`). Kebab-case is the correct convention for URI path segments.

Also aligned naming: `malformed_proof` → `malformed-credential` (matches §4.2), `payment_verification_failed` → `verification-failed` (matches existing URL pattern).

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770936800443069

Prompted by: brendan