### PR TITLE
Add specs site link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HTTP Payment Authentication Specifications
 
+📄 **[Read the specs →](https://tempoxyz.github.io/payment-auth-spec/)**
+
 An internet-native payments protocol which enables HTTP resources to require payment before granting access.
 
 ## Overview


### PR DESCRIPTION
Adds a prominent link to the GitHub Pages specs site (tempoxyz.github.io/payment-auth-spec) at the top of the README.