### PR TITLE
Rename to mpp-spec, redesign homepage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker-build build build-docker build-local check shell clean lint test
+.PHONY: docker-build build build-docker build-local check shell clean lint test site
 
 docker-build:
 	docker build -t ietf-spec-tools .
@@ -25,3 +25,6 @@ lint:
 
 test:
 	docker run --rm -v "$$(pwd)":/data -w /data/scripts ietf-spec-tools pytest test_lint_frontmatter.py -v
+
+site: build
+	@python3 scripts/serve.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTTP Payment Authentication Specifications
 
-📄 **[Read the specs →](https://tempoxyz.github.io/payment-auth-spec/)**
+📄 **[Read the specs →](https://tempoxyz.github.io/mpp-spec/)**
 
 An internet-native payments protocol which enables HTTP resources to require payment before granting access.
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Payment Authentication Specifications</title>
+  <title>Machine Payments Protocol Specifications</title>
   <style>
     :root {
       --color-link: #0066cc;
@@ -132,44 +132,31 @@
   </style>
 </head>
 <body>
-  <h1>HTTP <code>Payment</code> Authentication Specifications</h1>
-  <p class="header-links"><a href="https://github.com/tempoxyz/payment-auth-spec">Source</a><span class="sep">·</span><a href="https://github.com/tempoxyz/payment-auth-spec/blob/main/CONTRIBUTING.md">Contributing</a></p>
+  <h1>Machine Payments Protocol Specifications</h1>
+  <p class="header-links"><a href="https://github.com/tempoxyz/mpp-spec">Source</a><span class="sep">·</span><a href="https://github.com/tempoxyz/mpp-spec/blob/main/CONTRIBUTING.md">Contributing</a></p>
 
   <div class="tree">
-    <div class="folder"><span class="folder-icon">~/</span>Core</div>
+    <div class="folder"><span class="folder-icon">~/</span>The &#34;Payment&#34; HTTP Authentication Scheme <span class="formats" style="display:inline;padding-left:0"><a href="draft-ryan-httpauth-payment-00.html">HTML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.txt">TXT</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.xml">XML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.pdf">PDF</a></span></div>
+    <div class="folder"><span class="folder-icon">~/</span>Charge <span class="formats" style="display:inline;padding-left:0"><a href="draft-payment-intent-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.pdf">PDF</a></span></div>
     <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">The &#34;Payment&#34; HTTP Authentication Scheme</span><span class="maturity">Draft</span><span class="category">Standards Track</span>
-      <span class="formats"><a href="draft-ryan-httpauth-payment-00.html">HTML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.txt">TXT</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.xml">XML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.pdf">PDF</a></span>
-    </div>
-    <div class="folder"><span class="folder-icon">~/</span>Extensions</div>
-    <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Discovery Mechanisms for HTTP Payment Authentication</span><span class="maturity">Draft</span><span class="category">Informational</span>
-      <span class="formats"><a href="draft-payment-discovery-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-discovery-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-discovery-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-discovery-00.pdf">PDF</a></span>
-    </div>
-    <div class="folder"><span class="folder-icon">~/</span>Intents</div>
-    <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Charge Intent for HTTP Payment Authentication</span><span class="maturity">Draft</span><span class="category">Informational</span>
-      <span class="formats"><a href="draft-payment-intent-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.pdf">PDF</a></span>
-    </div>
-    <div class="folder"><span class="folder-icon">~/</span>Payment_Methods/Stripe</div>
-    <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Stripe charge Intent for HTTP Payment Authentication</span><span class="maturity">Draft</span><span class="category">Informational</span>
+      <span class="branch">├──</span> <span class="spec-title">Stripe</span>
       <span class="formats"><a href="draft-stripe-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-stripe-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-stripe-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-stripe-charge-00.pdf">PDF</a></span>
     </div>
-    <div class="folder"><span class="folder-icon">~/</span>Payment_Methods/Tempo</div>
     <div class="spec-entry">
-      <span class="branch">├──</span> <span class="spec-title">Tempo charge Intent for HTTP Payment Authentication</span><span class="maturity">Draft</span><span class="category">Informational</span>
+      <span class="branch">└──</span> <span class="spec-title">Tempo</span>
       <span class="formats"><a href="draft-tempo-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-tempo-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-tempo-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-tempo-charge-00.pdf">PDF</a></span>
     </div>
+    <div class="folder"><span class="folder-icon">~/</span>Session</div>
     <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Tempo Stream Intent for HTTP Payment Authentication</span><span class="maturity">Draft</span><span class="category">Informational</span>
+      <span class="branch">└──</span> <span class="spec-title">Tempo</span>
       <span class="formats"><a href="draft-tempo-stream-00.html">HTML</a><span class="sep">·</span><a href="draft-tempo-stream-00.txt">TXT</a><span class="sep">·</span><a href="draft-tempo-stream-00.xml">XML</a><span class="sep">·</span><a href="draft-tempo-stream-00.pdf">PDF</a></span>
     </div>
     <div class="folder"><span class="folder-icon">~/</span>Transports</div>
     <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Payment Authentication Scheme: MCP Transport</span><span class="maturity">Draft</span><span class="category">Informational</span>
+      <span class="branch">└──</span> <span class="spec-title">MCP Transport</span>
       <span class="formats"><a href="draft-payment-transport-mcp-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.pdf">PDF</a></span>
     </div>
+    <div class="folder"><span class="folder-icon">~/</span>Discovery <span class="formats" style="display:inline;padding-left:0"><a href="draft-payment-discovery-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-discovery-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-discovery-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-discovery-00.pdf">PDF</a></span></div>
   </div>
 </body>
 </html>

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Dev server that serves pages/ and artifacts/ directly. No copying needed."""
+
+import http.server
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PAGES = os.path.join(ROOT, "pages")
+ARTIFACTS = os.path.join(ROOT, "artifacts")
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        path = path.strip("/")
+        if path == "" or path == "index.html":
+            return os.path.join(PAGES, "index.html")
+        return os.path.join(ARTIFACTS, path)
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
+    server = http.server.HTTPServer(("", port), Handler)
+    print(f"Serving at http://localhost:{port}")
+    print(f"  pages/    -> index.html")
+    print(f"  artifacts/ -> everything else")
+    server.serve_forever()


### PR DESCRIPTION
## Changes

- Rename all `payment-auth-spec` references to `mpp-spec`
- Retitle to **Machine Payments Protocol Specifications**
- Reorganize homepage layout:
  - Core spec as top-level heading
  - Charge with intent spec inline + Stripe/Tempo methods
  - Session with Tempo method
  - Transports
  - Discovery as single inline heading
- Remove Draft/Standards Track/Informational badges
- Add `make site` with live-reload dev server (`scripts/serve.py`) — edits to `pages/index.html` are reflected on browser refresh without restart