### PR TITLE
chore: clickable spec titles, artifact preview in PR comments

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -69,11 +69,25 @@ jobs:
             fi
           done
 
-      - name: Upload artifacts
+      - name: Upload spec artifacts
+        id: upload-specs
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.number && format('pr-{0}-specs', github.event.number) || format('manual-{0}-specs', github.run_id) }}
-          path: artifacts/
+          path: |
+            artifacts/draft-*.html
+            artifacts/draft-*.txt
+            artifacts/draft-*.xml
+            artifacts/draft-*.pdf
+          retention-days: 30
+
+      - name: Upload diff artifacts
+        id: upload-diffs
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ format('pr-{0}-diffs', github.event.number) }}
+          path: artifacts/diffs/
           retention-days: 30
 
       - name: Comment on PR
@@ -86,6 +100,7 @@ jobs:
 
             const artifactsDir = 'artifacts';
             const diffsDir = path.join(artifactsDir, 'diffs');
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let table = '| Spec | Changed |\n|------|--------|\n';
 
@@ -103,15 +118,15 @@ jobs:
                   changed = 'Yes';
                 }
               }
-              table += `| ${name} | ${changed} |\n`;
+              table += `| \`${name}\` | ${changed} |\n`;
             }
 
             const body = `<!-- ietf-spec-preview -->
-            ## Spec Check
+            ## Spec Preview
 
             ${table}
 
-            Download artifacts from the workflow run for HTML, TXT, XML, and PDF renderings.
+            **[Download spec artifacts](${runUrl}#artifacts)** (HTML, TXT, XML, PDF)
             `;
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/pages/index.html
+++ b/pages/index.html
@@ -69,6 +69,12 @@
       color: #000;
       display: inline-block;
       min-width: 6ch;
+      text-decoration: none;
+    }
+
+    a.spec-title:hover {
+      color: var(--color-link);
+      text-decoration: underline;
     }
 
     .maturity {
@@ -158,27 +164,27 @@
   <p class="header-links"><a href="https://github.com/tempoxyz/mpp-spec">Source</a><span class="sep">·</span><a href="https://github.com/tempoxyz/mpp-spec/blob/main/CONTRIBUTING.md">Contributing</a></p>
 
   <div class="tree">
-    <div class="folder"><span class="folder-icon">~/</span>The &#34;Payment&#34; HTTP Authentication Scheme <span class="formats"><a href="draft-ryan-httpauth-payment-00.html">HTML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.txt">TXT</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.xml">XML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.pdf">PDF</a></span></div>
-    <div class="folder"><span class="folder-icon">~/</span>Charge <span class="formats"><a href="draft-payment-intent-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.pdf">PDF</a></span></div>
+    <div class="folder"><a href="draft-ryan-httpauth-payment-00.html" class="spec-title"><span class="folder-icon">~/</span>The &#34;Payment&#34; HTTP Authentication Scheme</a> <span class="formats"><a href="draft-ryan-httpauth-payment-00.txt">TXT</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.xml">XML</a><span class="sep">·</span><a href="draft-ryan-httpauth-payment-00.pdf">PDF</a></span></div>
+    <div class="folder"><a href="draft-payment-intent-charge-00.html" class="spec-title"><span class="folder-icon">~/</span>Charge</a> <span class="formats"><a href="draft-payment-intent-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-intent-charge-00.pdf">PDF</a></span></div>
     <div class="spec-entry">
-      <span class="branch">├──</span> <span class="spec-title">Stripe</span>
-      <span class="formats"><a href="draft-stripe-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-stripe-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-stripe-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-stripe-charge-00.pdf">PDF</a></span>
+      <span class="branch">├──</span> <a href="draft-stripe-charge-00.html" class="spec-title">Stripe</a>
+      <span class="formats"><a href="draft-stripe-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-stripe-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-stripe-charge-00.pdf">PDF</a></span>
     </div>
     <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Tempo</span>
-      <span class="formats"><a href="draft-tempo-charge-00.html">HTML</a><span class="sep">·</span><a href="draft-tempo-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-tempo-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-tempo-charge-00.pdf">PDF</a></span>
+      <span class="branch">└──</span> <a href="draft-tempo-charge-00.html" class="spec-title">Tempo</a>
+      <span class="formats"><a href="draft-tempo-charge-00.txt">TXT</a><span class="sep">·</span><a href="draft-tempo-charge-00.xml">XML</a><span class="sep">·</span><a href="draft-tempo-charge-00.pdf">PDF</a></span>
     </div>
     <div class="folder"><span class="folder-icon">~/</span>Session</div>
     <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">Tempo</span>
-      <span class="formats"><a href="draft-tempo-stream-00.html">HTML</a><span class="sep">·</span><a href="draft-tempo-stream-00.txt">TXT</a><span class="sep">·</span><a href="draft-tempo-stream-00.xml">XML</a><span class="sep">·</span><a href="draft-tempo-stream-00.pdf">PDF</a></span>
+      <span class="branch">└──</span> <a href="draft-tempo-stream-00.html" class="spec-title">Tempo</a>
+      <span class="formats"><a href="draft-tempo-stream-00.txt">TXT</a><span class="sep">·</span><a href="draft-tempo-stream-00.xml">XML</a><span class="sep">·</span><a href="draft-tempo-stream-00.pdf">PDF</a></span>
     </div>
     <div class="folder"><span class="folder-icon">~/</span>Transports</div>
     <div class="spec-entry">
-      <span class="branch">└──</span> <span class="spec-title">MCP Transport</span>
-      <span class="formats"><a href="draft-payment-transport-mcp-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.pdf">PDF</a></span>
+      <span class="branch">└──</span> <a href="draft-payment-transport-mcp-00.html" class="spec-title">MCP</a>
+      <span class="formats"><a href="draft-payment-transport-mcp-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-transport-mcp-00.pdf">PDF</a></span>
     </div>
-    <div class="folder"><span class="folder-icon">~/</span>Discovery <span class="formats"><a href="draft-payment-discovery-00.html">HTML</a><span class="sep">·</span><a href="draft-payment-discovery-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-discovery-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-discovery-00.pdf">PDF</a></span></div>
+    <div class="folder"><a href="draft-payment-discovery-00.html" class="spec-title"><span class="folder-icon">~/</span>Discovery</a> <span class="formats"><a href="draft-payment-discovery-00.txt">TXT</a><span class="sep">·</span><a href="draft-payment-discovery-00.xml">XML</a><span class="sep">·</span><a href="draft-payment-discovery-00.pdf">PDF</a></span></div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
- Make spec names link to their HTML page (with ~/ prefix included)
- Remove HTML from format links (now just TXT·XML·PDF)
- Add hover style (blue + underline)
- Rename MCP Transport → MCP
- Add artifact download link to PR comments
- Split spec and diff uploads into separate artifacts