### PR TITLE
spec: mandate JCS (RFC 8785) for canonical JSON serialization of request parameter

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -41,6 +41,7 @@ normative:
   RFC8174:
   RFC8259:
   RFC8446:
+  RFC8785:
   RFC9110:
   RFC9111:
   RFC9457:
@@ -255,7 +256,13 @@ auth-param      = token BWS "=" BWS ( token / quoted-string )
 **`request`**: Base64url-encoded {{RFC4648}} JSON {{RFC8259}} containing
   payment-method-specific data needed to complete payment. Structure is
   defined by the payment method specification. Padding characters ("=")
-  MUST NOT be included.
+  MUST NOT be included. The JSON MUST be serialized using JSON
+  Canonicalization Scheme (JCS) {{RFC8785}} to ensure deterministic
+  encoding across implementations. This is critical for challenge binding
+  ({{challenge-binding}}): since the HMAC input includes the base64url-encoded
+  request as it appears on the wire, different JSON serialization orders
+  would produce different HMAC values, breaking cross-implementation
+  interoperability.
 
 ### Optional Parameters
 
@@ -295,7 +302,8 @@ the challenge `id` as follows:
    - `realm`
    - `method`
    - `intent`
-   - base64url-encoded `request` (as it appears on the wire)
+   - base64url-encoded `request` (JCS-serialized per {{RFC8785}},
+     then base64url-encoded)
    - `expires` (if present and non-empty)
    - `digest` (if present and non-empty)
 


### PR DESCRIPTION
## Problem

The `request` parameter is base64url-encoded JSON that feeds into the HMAC-SHA256 challenge ID computation. Without canonical serialization, different implementations may produce different JSON key orderings (e.g., Python dict insertion order vs JavaScript object order), resulting in different HMAC values for the same logical request.

This breaks cross-implementation interoperability: a challenge created by a Python server (pympp) may not be verifiable by a TypeScript client (mppx), or vice versa, if the JSON keys happen to be in a different order.

## Changes

- Adds RFC 8785 (JSON Canonicalization Scheme) as a normative reference
- Requires `request` JSON to be JCS-serialized before base64url encoding
- Updates the HMAC binding section to reference JCS serialization

## What is JCS (RFC 8785)?

JCS defines a deterministic JSON serialization:
- Object keys sorted lexicographically
- No whitespace
- Specific number formatting
- UTF-8 encoding

This ensures all implementations produce byte-identical JSON for the same logical data, making HMAC computation deterministic across languages.