### PR TITLE
fix: improve type scale for clearer visual hierarchy

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -28,7 +28,7 @@
 
     body {
       font-family: "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-      font-size: 10px;
+      font-size: 14px;
       max-width: 900px;
       margin: 2rem auto;
       padding: 0 1rem;
@@ -38,17 +38,18 @@
     }
 
     h1 {
+      font-size: 2rem;
       margin-bottom: 0.25rem;
     }
 
     .tree {
-      font-size: 0.8rem;
+      font-size: 0.9rem;
     }
 
     .folder {
       margin: 1.5rem 0 0.5rem 0;
       font-weight: 600;
-      font-size: 1rem;
+      font-size: 1.15rem;
     }
 
     .spec-entry {


### PR DESCRIPTION
Bump base font-size from 10px to 14px, add explicit h1 size (2rem), and scale .tree and .folder proportionally for a clear h1 > folder > spec-entry hierarchy.