### PR TITLE
fix: update core spec link to match renamed filename

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -39,18 +39,18 @@
     }
 
     h1 {
-      font-size: 1.6rem;
+      font-size: 1.1rem;
       margin-bottom: 0.25rem;
     }
 
     .tree {
-      font-size: 0.9rem;
+      font-size: 0.8rem;
     }
 
     .folder {
       margin: 1.5rem 0 0.5rem 0;
       font-weight: 600;
-      font-size: 1rem;
+      font-size: 0.85rem;
     }
 
     .spec-entry {
@@ -82,7 +82,7 @@
     .maturity {
       padding: 0.1rem 0.4rem;
       border-radius: 3px;
-      font-size: 0.65rem;
+      font-size: 0.55rem;
       margin-left: 0.5rem;
       font-weight: 500;
       background: #e7f3ff;
@@ -93,7 +93,7 @@
     }
 
     .category {
-      font-size: 0.65rem;
+      font-size: 0.55rem;
       color: #666;
       margin-left: 0.5rem;
     }
@@ -101,7 +101,7 @@
     .formats {
       display: inline;
       padding-left: 0.5rem;
-      font-size: 0.6rem;
+      font-size: 0.55rem;
     }
 
     .formats a {
@@ -120,7 +120,7 @@
     }
 
     .header-links {
-      font-size: 0.8rem;
+      font-size: 0.7rem;
       margin-top: 0;
       padding-bottom: 0.5rem;
       border-bottom: 2px solid var(--color-text);


### PR DESCRIPTION
The spec was renamed from `draft-ryan-httpauth-payment-00` to `draft-httpauth-payment-00` but `pages/index.html` still referenced the old name, causing a 404 on GitHub Pages for the core spec link.