### PR TITLE
ci: add CI Gate job for branch protection

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,6 +14,18 @@ permissions:
   pull-requests: write
 
 jobs:
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [build-and-check]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+
   build-and-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a single `CI Gate` job to `pr-check.yml` that `needs: [build-and-check]` with `if: always()`. This lets branch protection require only `CI Gate` instead of maintaining individual job names.

After merging, set `CI Gate` as the required status check on `main`.