### PR TITLE
fix(discovery): align with core spec and address gaps

### DIFF
--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -1,5 +1,5 @@
 ---
-title: Discovery Mechanisms for HTTP Payment Authentication
+title: Payment Method Discovery Mechanisms for HTTP Payment Authentication
 abbrev: Payment Discovery
 docname: draft-payment-discovery-00
 version: 00
@@ -39,7 +39,7 @@ normative:
 This document defines discovery mechanisms for the "Payment" HTTP
 authentication scheme {{I-D.httpauth-payment}}. It specifies how clients
 can discover a server's payment capabilities before initiating requests,
-including supported payment methods, assets, and intents.
+including supported payment methods, accepted currencies, and intents.
 
 --- middle
 
@@ -65,13 +65,19 @@ client experience. Clients MUST NOT require discovery to function; the
 
 # Terminology
 
+Currency
+: An identifier for an accepted unit of value, using the same formats
+  defined in the "charge" intent specification's Currency Formats
+  section. This includes ISO 4217 codes (e.g., `"usd"`) and
+  method-defined identifiers (e.g., token contract addresses).
+
 Discovery
 : The process by which a client learns a server's payment capabilities
   before initiating a request that may require paid access.
 
 Payment Capabilities
-: The set of payment methods, intents, and assets that a server
-  accepts as payment.
+: The set of payment methods, intents, and accepted currencies that a
+  server accepts as payment.
 
 # Well-Known Endpoint
 
@@ -105,6 +111,7 @@ The response MUST use `Content-Type: application/json`.
 |-------|------|----------|-------------|
 | `version` | integer | REQUIRED | Schema version. Currently `1`. |
 | `realm` | string | OPTIONAL | Default realm for payment challenges. |
+| `description` | string | OPTIONAL | Human-readable description of the service. |
 | `methods` | object | REQUIRED | Map of supported payment methods. |
 
 **Method Object Schema:**
@@ -115,7 +122,7 @@ is an object with:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `intents` | array | REQUIRED | Supported intent types. |
-| `assets` | array | REQUIRED | Accepted asset identifiers (method-specific). |
+| `currencies` | array | REQUIRED | Accepted currency identifiers, using the formats defined by the payment method specification (e.g., ISO 4217 codes, token addresses). |
 
 **Example Response:**
 
@@ -127,14 +134,15 @@ Cache-Control: max-age=300
 {
   "version": 1,
   "realm": "api.example.com",
+  "description": "AI inference API",
   "methods": {
     "tempo": {
-      "intents": ["charge", "authorize", "subscription"],
-      "assets": ["0x20c0000000000000000000000000000000000000"]
+      "intents": ["charge", "session"],
+      "currencies": ["0x20c0000000000000000000000000000000000000"]
     },
     "lightning": {
       "intents": ["charge"],
-      "assets": ["BTC"]
+      "currencies": ["sat"]
     }
   }
 }
@@ -154,6 +162,14 @@ Longer durations (e.g., `max-age=3600`) MAY be used for capabilities that
 change infrequently. Clients SHOULD respect cache headers and refetch
 when capabilities may have changed (e.g., after receiving an unexpected
 402 challenge for a method not in the cached discovery response).
+
+## Version Handling
+
+Clients MUST check the `version` field before processing the response.
+If the `version` value is higher than the version the client supports,
+the client SHOULD treat the response as unsupported and fall back to
+the 402 challenge flow. Clients MUST NOT assume forward compatibility
+with unknown schema versions.
 
 ## Error Handling
 
@@ -178,6 +194,15 @@ accept discovery information over unencrypted HTTP.
 
 Discovery endpoints reveal payment capabilities to unauthenticated clients.
 Servers should consider whether this information disclosure is acceptable.
+
+## Cross-Origin Requests
+
+Browser-based clients (e.g., wallets, payment agents) may need to access
+the discovery endpoint cross-origin. Servers that intend to support
+browser-based clients SHOULD include appropriate CORS headers
+(e.g., `Access-Control-Allow-Origin`) on responses to
+`/.well-known/payment`. This aligns with the cross-origin considerations
+in Section 11.11 of {{I-D.httpauth-payment}}.
 
 # IANA Considerations
 


### PR DESCRIPTION
Aligns the discovery spec with the core Payment auth spec and fixes several issues:

## Changes

- **Title**: Renamed to "Payment Method Discovery Mechanisms for HTTP Payment Authentication"
- **`Asset` terminology defined**: New Terminology entry explains assets are method-specific value identifiers (contract addresses, ticker symbols, etc.) and links back to the core spec's `currency`/`request` fields
- **Phantom intents fixed**: Example used `authorize` and `subscription` which don't exist in the intent registry — replaced with `charge` and `session` to match the actual intent specs
- **`description` field added**: Optional human-readable service description on the response schema
- **Version Handling section**: Clients MUST check `version`, SHOULD fall back to 402 flow on unknown versions
- **Cross-Origin Requests section**: New security consideration for browser-based CORS access, aligning with core spec Section 11.11
- **`assets` description clarified**: Format is defined by the payment method specification