### PR TITLE
fix: use fixed positional slots for HMAC-SHA256 challenge binding

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -307,17 +307,23 @@ authenticated encryption) to validate the binding.
 Servers using HMAC-SHA256 for stateless challenge binding SHOULD compute
 the challenge `id` as follows:
 
-1. Construct an ordered list of exactly seven fixed positional slots:
+The HMAC input is constructed from exactly seven fixed positional
+slots. Required fields supply their string value; optional fields use
+an empty string (`""`) when absent. The slots are:
 
-   | Slot | Field | Value |
-   |------|-------|-------|
-   | 0 | `realm` | Required. String value. |
-   | 1 | `method` | Required. String value. |
-   | 2 | `intent` | Required. String value. |
-   | 3 | `request` | Required. JCS-serialized per {{RFC8785}}, then base64url-encoded. |
-   | 4 | `expires` | Optional. String value if present; empty string (`""`) if absent. |
-   | 5 | `digest` | Optional. String value if present; empty string (`""`) if absent. |
-   | 6 | `opaque` | Optional. JCS-serialized per {{RFC8785}}, then base64url-encoded if present; empty string (`""`) if absent. |
+| Slot | Field | Value |
+|------|-------|-------|
+| 0 | `realm` | Required. String value. |
+| 1 | `method` | Required. String value. |
+| 2 | `intent` | Required. String value. |
+| 3 | `request` | Required. JCS-serialized per {{RFC8785}}, then base64url-encoded. |
+| 4 | `expires` | Optional. String value if present; empty string if absent. |
+| 5 | `digest` | Optional. String value if present; empty string if absent. |
+| 6 | `opaque` | Optional. JCS-serialized per {{RFC8785}}, then base64url-encoded if present; empty string if absent. |
+
+The computation proceeds as follows:
+
+1. Populate all seven slots as described above.
 
 2. Join all seven slots with the pipe character (`|`) as delimiter.
    Every slot is always present in the joined string; absent optional


### PR DESCRIPTION
## Summary

The spec's recommended HMAC-SHA256 binding algorithm (§5.1.2.1) previously said to **omit** absent optional fields from the HMAC input. All three SDK implementations use **fixed positional slots with empty strings** instead.

## Problem

The omit-absent approach creates ambiguity. For example, with the old spec:
- Challenge with `expires` only → `realm|method|intent|request|expires`
- Challenge with `digest` only → `realm|method|intent|request|digest`

A malicious client could potentially confuse an expires value with a digest value since they occupy the same positional slot. The old spec relied on field content being distinguishable, which is fragile.

## Fix

Switch to fixed 7-slot layout where every optional field always occupies its designated position:

```
realm | method | intent | request_b64url | expires_or_empty | digest_or_empty | opaque_b64url_or_empty
```

This matches all SDK implementations:
- **mppx** (`Challenge.ts:439-447`): `[realm, method, intent, request, expires ?? '', digest ?? '', opaque ?? ''].join('|')`
- **pympp** (`__init__.py:98-104`): same fixed-slot approach
- **mpp-rs** (`challenge.rs:441-450`): same fixed-slot approach

Cross-SDK golden test vectors already validate this behavior.

## Why fixed slots are better

1. **No ambiguity** — each field has a dedicated position
2. **Forward-compatible** — adding a new optional slot doesn't change existing HMACs (new slot defaults to empty)
3. **Simpler** — no conditional logic needed