### PR TITLE
fix: align core, tempo-charge, and charge-intent specs with mppx implementation

### DIFF
--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -118,7 +118,7 @@ The `request` parameter for a "charge" intent is a JSON object with
 shared fields defined by this specification and optional method-specific
 extensions in the `methodDetails` field. The `request` JSON MUST be
 serialized using JSON Canonicalization Scheme (JCS) and base64url-encoded
-without padding per Section 5.1.2 of {{I-D.httpauth-payment}}.
+without padding per {{I-D.httpauth-payment}}.
 
 ## Shared Fields
 
@@ -220,7 +220,7 @@ for their implementation of the "charge" intent.
 
 ## Payload
 
-The credential structure follows Section 5.2 of {{I-D.httpauth-payment}},
+The credential structure follows {{I-D.httpauth-payment}},
 containing `challenge`, `payload`, and an optional `source` field
 identifying the payer. The `payload` for a "charge" intent MUST contain
 proof that payment has been made or authorized. The proof type is

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -132,7 +132,7 @@ Fee Payer
 The `request` parameter in the `WWW-Authenticate` challenge contains a
 base64url-encoded JSON object. The JSON MUST be serialized using JSON
 Canonicalization Scheme (JCS) {{RFC8785}} before base64url encoding,
-per Section 5.1.2 of {{I-D.httpauth-payment}}.
+per {{I-D.httpauth-payment}}.
 
 ## Shared Fields
 
@@ -413,7 +413,7 @@ The receipt payload for Tempo charge:
 | `reference` | string | Transaction hash of the settlement transaction |
 | `status` | string | `"success"` |
 | `timestamp` | string | {{RFC3339}} settlement time |
-| `externalId` | string | OPTIONAL. Echoed from credential payload |
+| `externalId` | string | OPTIONAL. Echoed from the challenge request |
 
 # Security Considerations
 


### PR DESCRIPTION
## Summary

Cross-reference consistency fixes between the mpp-specs and the mppx TypeScript implementation. Follows the Stripe charge spec (PR #155) as the gold standard for compliant method specs.

Builds on top of PRs #154 (HMAC fixed positional slots + opaque parameter) and #155 (Stripe charge alignment).

## Changes

### Core Spec (residual from C3/C7)
- **C3**: Add `opaque` to the credential challenge echo table (§5.2)
- **C7**: Fix ABNF comment to list all optional parameters: `expires`, `digest`, `description`, `opaque`

### Tempo Charge Spec (T1–T8)
- **T1** HIGH: Add JCS (RFC 8785) serialization requirement + normative ref
- **T2** HIGH: Add `memo` field to methodDetails table (`transferWithMemo` routing)
- **T3** MED: Add optional `externalId` to receipt table (matches `mppx/src/Receipt.ts`)
- **T4** MED: Add `description` to shared request fields
- **T5** MED: Add `externalId` to shared request fields
- **T6** MED: Add ABNF appendix (matching Stripe gold standard)
- **T7** MED: Add `Cache-Control: no-store` to 402 example
- **T8** MED: Add transaction verification subsection matching mppx settlement logic (`matchTransferCall`, `matchTransferLog`, event log verification)

### Charge Intent Spec (I1–I10)
- **I1** HIGH: Change `expires` from "ISO 8601" to RFC 3339 format
- **I2** HIGH: Add missing normative refs (RFC 3339, RFC 4648, RFC 8259)
- **I3** HIGH: Fix wrong Stripe example (`businessNetwork`/`destination` → `networkId`/`paymentMethodTypes`)
- **I4** MED: Add cross-reference to core spec JCS/encoding requirements
- **I5** MED: Add note that methods MAY elevate OPTIONAL fields to REQUIRED
- **I6** MED: Add token address format to currency table
- **I7** MED: Reference core spec credential structure for `source` field
- **I8** MED: Soften recipient verification (not all methods expose explicit recipient)
- **I9** MED: Add TLS requirement + currency verification to security considerations
- **I10** MED: Add registrant contact to IANA section

## Cross-reference files
- `mppx/src/Challenge.ts` — HMAC slots, opaque field
- `mppx/src/Receipt.ts` — receipt schema with externalId
- `mppx/src/Credential.ts` — credential structure with source
- `mppx/src/tempo/Methods.ts` — charge request schema (memo, feePayer, description, externalId)
- `mppx/src/tempo/server/Charge.ts` — settlement verification (matchTransferCall, matchTransferLog)
- `mppx/src/stripe/Methods.ts` — networkId, paymentMethodTypes fields