### PR TITLE
Add CNAME for paymentauth.org custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
           cp pages/index.html _site/
           cp pages/fonts/*.woff2 _site/fonts/
           cp artifacts/*.html artifacts/*.txt artifacts/*.xml artifacts/*.pdf _site/
+          echo "paymentauth.org" > _site/CNAME
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Adds a CNAME file to the GitHub Pages deployment so we can point paymentauth.org to this site.

**After merging, DNS records still need to be configured:**
- A records for apex: 185.199.108.153, 185.199.109.153, 185.199.110.153, 185.199.111.153
- CNAME www → tempoxyz.github.io
- Enable custom domain + HTTPS in repo Settings → Pages