### PR TITLE
spec(core): include opaque in credential challenge echo fields

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -428,6 +428,7 @@ The `challenge` object contains the parameters from the original challenge:
 | `method` | string | Payment method identifier |
 | `intent` | string | Payment intent type |
 | `request` | string | Base64url-encoded payment request |
+| `opaque` | string | Base64url-encoded server correlation data (if present in challenge) |
 | `digest` | string | Content digest  |
 | `expires` | string | Challenge expiration timestamp |
 


### PR DESCRIPTION
## Summary
- add `opaque` to the credential challenge echo field table
- clarify that `opaque` is part of echoed challenge parameters when present

## Files
- specs/core/draft-httpauth-payment-00.md
