### PR TITLE
Remove sub-method from payment method identifier format

### DIFF
--- a/examples/method-template.md
+++ b/examples/method-template.md
@@ -127,17 +127,6 @@ This specification registers the following payment method identifier:
 
 The identifier is case-sensitive and MUST be lowercase.
 
-### 4.1. Sub-methods (if applicable)
-
-[If your method has variants, describe them here]
-
-| Sub-method | Description |
-|------------|-------------|
-| `{network}:variant1` | Description |
-| `{network}:variant2` | Description |
-
----
-
 ## 5. Supported Intents
 
 This method supports the following intents:

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -498,16 +498,10 @@ and appropriate problem type when payment verification fails.
 Payment methods are identified by lowercase ASCII strings:
 
 ~~~abnf
-payment-method-id = method-name [ ":" sub-method ]
-method-name       = 1*LOWERALPHA
-sub-method        = 1*( LOWERALPHA / DIGIT / "-" )
+payment-method-id = 1*LOWERALPHA
 ~~~
 
 Method identifiers are case-sensitive and MUST be lowercase.
-
-The optional `sub-method` component allows payment methods to specify
-variants, networks, or chains. Payment method specifications MUST define
-the semantics of their sub-methods.
 
 ## Method Registry
 
@@ -863,9 +857,7 @@ Payment-Receipt = base64url-nopad
 base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
 
 ; Payment method identifier (lowercase only)
-payment-method-id   = method-name [ ":" sub-method ]
-method-name         = 1*LOWERALPHA
-sub-method          = 1*( LOWERALPHA / DIGIT / "-" )
+payment-method-id   = 1*LOWERALPHA
 LOWERALPHA          = %x61-7A  ; a-z
 
 ; Payment intent


### PR DESCRIPTION
## Summary

Removes the `sub-method` concept (`method-name:sub-method`) from the payment method identifier format.

## Motivation

The sub-method is unused by any payment method spec and redundant with `methodDetails`, which already handles network/chain selection within each method (e.g., `methodDetails.chainId` for Tempo).

## Changes

- **`specs/core/draft-httpauth-payment-00.md`**: Simplified `payment-method-id` ABNF from `method-name [ ":" sub-method ]` to `1*LOWERALPHA` (both inline definition and collected ABNF appendix). Removed explanatory paragraph.
- **`examples/method-template.md`**: Removed "Sub-methods (if applicable)" section from the method template.