### PR TITLE
docs: remove hardcoded external section refs and document stable-reference rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Before submitting a PR:
 1. **Build succeeds**: `make check` passes
 2. **Lint passes**: `make lint` passes
 3. **Version bumped**: If modifying a spec, increment the version number in the filename and frontmatter
+4. **References are stable**: Avoid new hardcoded external references like `Section X.Y of {{I-D...}}`
 
 ### Types of Changes
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -91,6 +91,15 @@ WWW-Authenticate: Payment id="pay_abc123",
   request="eyJ..."
 ```
 
+### Cross-References
+
+Prefer stable references over hardcoded section numbers.
+
+- For internal references, use labels/anchors (e.g., `{{payment-receipt-header}}`).
+- For external drafts, prefer section-agnostic wording like "defined in
+  {{I-D.httpauth-payment}}".
+- Avoid `Section X.Y of {{I-D...}}` unless there is no practical alternative.
+
 ### Security Considerations
 
 Never leave this section empty. Address at minimum:

--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -202,7 +202,7 @@ the discovery endpoint cross-origin. Servers that intend to support
 browser-based clients SHOULD include appropriate CORS headers
 (e.g., `Access-Control-Allow-Origin`) on responses to
 `/.well-known/payment`. This aligns with the cross-origin considerations
-in Section 11.11 of {{I-D.httpauth-payment}}.
+defined in {{I-D.httpauth-payment}}.
 
 # IANA Considerations
 

--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -101,7 +101,7 @@ The following diagram illustrates the Stripe charge payment flow:
 ## Relationship to the Payment Scheme
 
 This document is a payment method intent specification as defined in
-Section 10.1 of {{I-D.httpauth-payment}}. It defines the `request` and
+{{I-D.httpauth-payment}}. It defines the `request` and
 `payload` structures for the `charge` intent of the `stripe` payment
 method, along with verification and settlement procedures.
 
@@ -156,7 +156,7 @@ payment immediately upon receiving the SPT.
 The `request` parameter in the `WWW-Authenticate` challenge contains a
 base64url-encoded JSON object with the following fields. The JSON MUST
 be serialized using JSON Canonicalization Scheme (JCS) {{RFC8785}} before
-base64url encoding, per Section 5.1.2 of {{I-D.httpauth-payment}}.
+base64url encoding, per {{I-D.httpauth-payment}}.
 
 ## Shared Fields
 
@@ -295,7 +295,7 @@ even if final fund settlement to the merchant is pending.
 ## Receipt Generation
 
 Upon successful settlement, servers MUST return a `Payment-Receipt` header
-per Section 5.3 of {{I-D.httpauth-payment}}. Servers MUST NOT include a
+per {{I-D.httpauth-payment}}. Servers MUST NOT include a
 `Payment-Receipt` header on error responses; failures are communicated via
 HTTP status codes and Problem Details.
 
@@ -316,7 +316,7 @@ The receipt payload for Stripe charge:
 SPTs are single-use tokens. Stripe automatically prevents SPT reuse at
 the API level, and idempotency keys ({{charge-settlement}}) prevent
 duplicate PaymentIntent creation. Servers MUST enforce single-use
-challenge IDs per Section 5.1.3 of {{I-D.httpauth-payment}} and SHOULD
+challenge IDs per {{I-D.httpauth-payment}} and SHOULD
 use Stripe idempotency keys to prevent repeated charges. Servers MAY
 additionally maintain a local replay cache of consumed challenge IDs.
 
@@ -349,7 +349,7 @@ only be transmitted over HTTPS connections.
 ## Payment Intent Registration
 
 This specification registers the "charge" intent for the "stripe" payment
-method in the Payment Intent Registry per Section 13.4 of
+method in the Payment Intent Registry established by
 {{I-D.httpauth-payment}}:
 
 - **Intent**: charge

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -181,7 +181,7 @@ MUST set `fee_token` and pay fees themselves.
 # Credential Schema
 
 The credential in the `Authorization` header contains a base64url-encoded
-JSON object per Section 5.2 of {{I-D.httpauth-payment}}.
+JSON object per {{I-D.httpauth-payment}}.
 
 ## Credential Structure
 
@@ -383,7 +383,7 @@ the transaction. The server verifies the transaction onchain:
 ## Receipt Generation
 
 Upon successful settlement, servers MUST return a `Payment-Receipt` header
-per Section 5.3 of {{I-D.httpauth-payment}}. Servers MUST NOT include a
+per {{I-D.httpauth-payment}}. Servers MUST NOT include a
 `Payment-Receipt` header on error responses; failures are communicated via
 HTTP status codes and Problem Details.
 

--- a/specs/methods/tempo/draft-tempo-session-00.md
+++ b/specs/methods/tempo/draft-tempo-session-00.md
@@ -668,7 +668,7 @@ When acting as fee payer for `open` or `topUp`:
 # Credential Schema
 
 The credential in the `Authorization` header contains a base64url-encoded
-JSON object per Section 5.2 of {{I-D.httpauth-payment}}.
+JSON object per {{I-D.httpauth-payment}}.
 
 ## Credential Structure
 
@@ -776,7 +776,7 @@ When provided, the `signature` field is the EIP-712 voucher signature
 (65 bytes r‖s‖v or 64 bytes EIP-2098 compact).
 
 The `challenge` object MUST echo the challenge parameters from the server's
-`WWW-Authenticate` header per Section 5.2 of {{I-D.httpauth-payment}}.
+`WWW-Authenticate` header per {{I-D.httpauth-payment}}.
 
 ### TopUp Payload {#topup-payload}
 


### PR DESCRIPTION
## Summary

Cleans up brittle hardcoded external section references across specs and adds guidance to avoid reintroducing them.

## Changes

- Replaced `Section X.Y of {{I-D.httpauth-payment}}` phrasing with stable, section-agnostic references in:
  - `specs/extensions/draft-payment-discovery-00.md`
  - `specs/methods/stripe/draft-stripe-charge-00.md`
  - `specs/methods/tempo/draft-tempo-charge-00.md`
  - `specs/methods/tempo/draft-tempo-session-00.md`
- Added cross-reference guidance to `STYLE.md`:
  - prefer internal anchors/labels
  - prefer section-agnostic wording for external drafts
- Added PR checklist reminder to `CONTRIBUTING.md` to avoid new hardcoded external section refs.

## Validation

- Verified no remaining `Section X.Y of {{I-D...}}` patterns in specs or docs in this branch.
