### PR TITLE
fix(spec): consolidate expires into challenge auth-param only

### DIFF
--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -24,6 +24,7 @@ author:
 
 normative:
   RFC2119:
+  RFC3339:
   RFC8174:
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
@@ -133,10 +134,13 @@ consistently across methods.
 | Field | Type | Description |
 |-------|------|-------------|
 | `recipient` | string | Payment recipient in method-native format |
-| `expires` | string | Expiry timestamp in ISO 8601 format |
 | `description` | string | Human-readable payment description |
 | `externalId` | string | Merchant's reference (order ID, invoice number, etc.) |
 | `methodDetails` | object | Method-specific extension data |
+
+Challenge expiry is conveyed by the `expires` auth-param in
+`WWW-Authenticate` per {{I-D.httpauth-payment}}, using {{RFC3339}}
+format. Request objects MUST NOT duplicate the expiry value.
 
 ## Currency Formats {#currency-formats}
 
@@ -183,7 +187,6 @@ shared fields to users.
   "amount": "1000000",
   "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-  "expires": "2025-01-06T12:00:00Z",
   "methodDetails": {
     "chainId": 42431,
     "feePayer": true
@@ -197,7 +200,6 @@ shared fields to users.
 {
   "amount": "100000",
   "currency": "sat",
-  "expires": "2025-01-15T12:05:00Z",
   "methodDetails": {
     "invoice": "lnbc1000n1pj9..."
   }

--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -166,7 +166,6 @@ base64url encoding, per {{I-D.httpauth-payment}}.
 | `currency` | string | REQUIRED | Three-letter ISO currency code (e.g., `"usd"`) |
 | `description` | string | OPTIONAL | Human-readable payment description |
 | `externalId` | string | OPTIONAL | Merchant's identifier (e.g., order ID, cart ID) |
-| `expires` | string | OPTIONAL | Expiry timestamp in {{RFC3339}} format |
 | `recipient` | string | OPTIONAL | Payment recipient identifier |
 
 ## Method Details

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -67,8 +67,8 @@ on the Tempo blockchain.
 # Introduction
 
 The `charge` intent represents a one-time payment of a specified amount.
-The server may submit the signed transaction any time before the `expires`
-timestamp.
+The server may submit the signed transaction any time before the
+challenge `expires` auth-param timestamp.
 
 This specification defines the request schema, credential formats, and
 settlement procedures for charge transactions on Tempo.
@@ -138,11 +138,9 @@ base64url-encoded JSON object.
 | `amount` | string | REQUIRED | Amount in base units (stringified number) |
 | `currency` | string | REQUIRED | TIP-20 token address (e.g., `"0x20c0..."`) |
 | `recipient` | string | REQUIRED | Recipient address |
-| `expires` | string | REQUIRED | Expiry timestamp in {{RFC3339}} format |
 
-The `expires` field in the request JSON MUST match the `expires`
-auth-param in the `WWW-Authenticate` header when both are present.
-Clients SHOULD use the auth-param value for expiry checks.
+Challenge expiry is conveyed by the `expires` auth-param in
+`WWW-Authenticate` per {{I-D.httpauth-payment}}.
 
 ## Method Details
 
@@ -158,7 +156,6 @@ Clients SHOULD use the auth-param value for expiry checks.
   "amount": "1000000",
   "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-  "expires": "2025-01-06T12:00:00Z",
   "methodDetails": {
     "chainId": 42431,
     "feePayer": true
@@ -169,7 +166,7 @@ Clients SHOULD use the auth-param value for expiry checks.
 The client fulfills this by signing a Tempo Transaction with
 `transfer(recipient, amount)` or `transferWithMemo(recipient, amount, memo)`
 on the specified `currency` (token address),
-with `validBefore` set to `expires`. The client SHOULD use a dedicated
+with `validBefore` set to the challenge `expires` auth-param. The client SHOULD use a dedicated
 `nonceKey` (2D nonce lane) for payment transactions to avoid blocking
 other account activity if the transaction is not immediately settled.
 
@@ -462,7 +459,8 @@ WWW-Authenticate: Payment id="kM9xPqWvT2nJrHsY4aDfEb",
   realm="api.example.com",
   method="tempo",
   intent="charge",
-  request="eyJhbW91bnQiOiIxMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJyZWNpcGllbnQiOiIweDc0MmQzNUNjNjYzNEMwNTMyOTI1YTNiODQ0QmM5ZTc1OTVmOGZFMDAiLCJleHBpcmVzIjoiMjAyNS0wMS0wNlQxMjowMDowMFoiLCJtZXRob2REZXRhaWxzIjp7ImNoYWluSWQiOjQyNDMxfX0"
+  request="eyJhbW91bnQiOiIxMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJyZWNpcGllbnQiOiIweDc0MmQzNUNjNjYzNEMwNTMyOTI1YTNiODQ0QmM5ZTc1OTVmOGZFMDAiLCJtZXRob2REZXRhaWxzIjp7ImNoYWluSWQiOjQyNDMxfX0",
+  expires="2025-01-06T12:00:00Z"
 ~~~
 
 The `request` decodes to:
@@ -472,7 +470,6 @@ The `request` decodes to:
   "amount": "1000000",
   "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-  "expires": "2025-01-06T12:00:00Z",
   "methodDetails": {
     "chainId": 42431
   }


### PR DESCRIPTION
## Summary

Removes `expires` from the charge-intent request schema and method-level request schemas. Expiry is now conveyed exclusively via the `expires` auth-param in `WWW-Authenticate` per the core spec.

### Motivation

`expires` was duplicated in two places — inside the `request` body AND as a challenge auth-param. This created ambiguity about which value is authoritative. Expiry is a property of the **challenge lifecycle**, not the payment request content. The request describes *what* to pay; the challenge controls *how long you have* to pay it.

### Changes

- **charge-intent**: Remove `expires` from optional fields table; add normative note that request objects MUST NOT duplicate expiry; add RFC3339 normative ref
- **tempo-charge**: Remove `expires` from shared fields (was REQUIRED); update prose to reference challenge auth-param; update all examples
- **stripe-charge**: Remove `expires` from shared fields (was OPTIONAL)

### SDK Impact

All three SDKs (mppx, pympp, mpp-rs) have `expires` in their charge request schemas and need corresponding updates tracked separately.