### PR TITLE
Service Discovery for HTTP Payment Authentication

### DIFF
--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -17,6 +17,14 @@ author:
     ins: J. Moxey
     email: jake@tempo.xyz
     org: Tempo Labs
+  - name: Ryan Sproule
+    ins: R. Sproule
+    email: ryan@merit.systems
+    org: Merit Systems
+  - name: Sam Ragsdale
+    ins: S. Ragsdale
+    email: sam@merit.systems
+    org: Merit Systems
 
 normative:
   RFC2119:
@@ -136,17 +144,11 @@ surface, including payment-enabled operations.
 
 ## Document Location
 
-The OpenAPI document MUST be accessible at one of the
-following locations, tried in order:
+The OpenAPI document MUST be accessible at:
 
 ~~~
 GET /openapi.json
-GET /.well-known/openapi.json
 ~~~
-
-Clients MUST try `/openapi.json` first. If that returns
-a non-2xx response, clients SHOULD try
-`/.well-known/openapi.json`.
 
 The document MUST be served over HTTPS with
 `Content-Type: application/json`.


### PR DESCRIPTION
## Overview

Introduces **draft-payment-discovery-00**, a discovery spec for the Payment HTTP authentication scheme.

Services publish an OpenAPI 3.x document at `/openapi.json` (or `/.well-known/openapi.json`) annotated with two extensions:

- **`x-service-info`** (top-level): service categories and documentation links (homepage, llms.txt, API reference)
- **`x-payment-info`** (per-operation): payment intent (`charge` or `session`), method, amount, and currency

OpenAPI provides both payment metadata and input schemas, enabling agents to discover and invoke endpoints from a single document. The runtime 402 challenge remains authoritative for all payment parameters.

An informative appendix covers registry and aggregator guidance for indexing payment-enabled services at scale.