### PR TITLE
Restore authorize and subscription intents with Tempo implementations

### DIFF
--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -1,0 +1,342 @@
+---
+title: Authorize Intent for HTTP Payment Authentication
+abbrev: Payment Intent Authorize
+docname: draft-payment-intent-authorize-00
+version: 00
+category: info
+ipr: trust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Jake Moxey
+    ins: J. Moxey
+    email: jake@tempo.xyz
+    org: Tempo Labs
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    org: Tempo Labs
+  - name: Tom Meagher
+    ins: T. Meagher
+    email: thomas@tempo.xyz
+    org: Tempo Labs
+
+normative:
+  RFC2119:
+  RFC8174:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+---
+
+--- abstract
+
+This document defines the "authorize" payment intent for use with the
+Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. The "authorize"
+intent represents a pre-authorization where the payer grants the server
+permission to charge up to a specified amount within a time window,
+without immediate payment.
+
+--- middle
+
+# Introduction
+
+The "authorize" intent enables pre-authorized payments where the payer
+grants the server permission to charge up to a specified amount at a
+later time. This is useful for:
+
+- **Metered billing**: Pay-per-use APIs where total cost is unknown upfront
+- **Delayed fulfillment**: Services where delivery occurs after authorization
+- **Spending caps**: User-controlled limits on automated spending
+
+Unlike the "charge" intent which requires immediate payment, "authorize"
+creates a payment capability that the server can exercise later.
+
+## Relationship to Payment Methods
+
+Payment methods implement "authorize" using their native authorization
+mechanisms:
+
+| Method | Implementation |
+|--------|----------------|
+| Tempo | Access Keys with spending limits |
+| Stripe | SetupIntent + saved PaymentMethod |
+| EVM | ERC-20 `approve()` or EIP-3009 authorization |
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+Authorization
+: A grant of permission for a server to initiate payments up to a
+  specified limit within a specified time window, without requiring
+  immediate payment.
+
+Spending Limit
+: The maximum amount that can be charged against an authorization
+  before it is exhausted.
+
+Revocation
+: The act of canceling an authorization before its natural expiry,
+  preventing further charges.
+
+# Intent Semantics
+
+## Definition
+
+The "authorize" intent represents a request for the payer to grant
+permission for the server to initiate payments up to a specified limit,
+within a specified time window.
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Intent Identifier** | `authorize` |
+| **Payment Timing** | Deferred (server-initiated later) |
+| **Idempotency** | Reusable within limits |
+| **Reversibility** | Revocable before use |
+
+## Flow
+
+~~~
+   Client                           Server                    Payment Network
+      │                                │                              │
+      │  (1) GET /resource             │                              │
+      ├───────────────────────────────>│                              │
+      │                                │                              │
+      │  (2) 402 Payment Required      │                              │
+      │      intent="authorize"        │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+      │  (3) Sign authorization        │                              │
+      │                                │                              │
+      │  (4) Authorization: Payment    │                              │
+      ├───────────────────────────────>│                              │
+      │                                │                              │
+      │                                │  (5) Register authorization  │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+      │  (6) 200 OK (authorized)       │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+      │        ... later ...           │                              │
+      │                                │                              │
+      │  (7) GET /resource             │                              │
+      ├───────────────────────────────>│                              │
+      │                                │  (8) Charge via auth         │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+      │  (9) 200 OK + Receipt          │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+~~~
+
+## Non-Atomicity
+
+Unlike "charge", the "authorize" intent is non-atomic:
+
+- Authorization registration is separate from payment collection
+- Multiple charges may occur against a single authorization
+- Total charges MUST NOT exceed the authorized limit
+
+# Request Schema
+
+The `request` parameter for an "authorize" intent is a JSON object with
+shared fields defined by this specification and optional method-specific
+extensions in the `methodDetails` field.
+
+## Shared Fields
+
+All payment methods implementing the "authorize" intent MUST support these
+shared fields, enabling clients to parse and display authorization requests
+consistently across methods.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `amount` | string | Maximum authorization amount in base units |
+| `currency` | string | Currency or asset identifier (see {{currency-formats}}) |
+| `expires` | string | Authorization expiry timestamp in ISO 8601 format |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recipient` | string | Payment recipient in method-native format |
+| `description` | string | Human-readable authorization description |
+| `externalId` | string | Merchant's reference (order ID, etc.) |
+| `methodDetails` | object | Method-specific extension data |
+
+## Currency Formats {#currency-formats}
+
+The `currency` field supports multiple formats to accommodate different
+payment networks:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| ISO 4217 | `"usd"`, `"eur"` | Fiat currencies (lowercase) |
+| Token address | `"0x20c0..."` | ERC-20, TIP-20, or similar token contracts |
+| Well-known symbol | `"sat"`, `"btc"`, `"eth"` | Native blockchain assets |
+
+Clients can detect the format:
+
+- Starts with `0x`: Token contract address
+- Three lowercase letters: ISO 4217 currency code
+- Otherwise: Well-known symbol or method-specific identifier
+
+## Method Extensions
+
+Payment methods MAY define additional fields in the `methodDetails` object.
+These fields are method-specific and MUST be documented in the payment
+method specification.
+
+## Examples
+
+### Traditional Payment Processor (Stripe)
+
+~~~ json
+{
+  "amount": "100000",
+  "currency": "usd",
+  "expires": "2025-01-22T12:00:00Z",
+  "description": "Pre-authorization for metered API usage",
+  "methodDetails": {
+    "captureMethod": "manual"
+  }
+}
+~~~
+
+### Blockchain Payment (Tempo)
+
+~~~ json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "expires": "2025-02-05T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431
+  }
+}
+~~~
+
+# Credential Requirements
+
+## Payload
+
+The credential `payload` for an "authorize" intent contains the
+authorization grant. The format is method-specific:
+
+| Authorization Type | Description | Example Methods |
+|-------------------|-------------|-----------------|
+| Signed Key Auth | Delegated signing key | Tempo Access Keys |
+| Token Approval | On-chain approval | EVM ERC-20 approve |
+| Saved Payment Method | Stored card/account | Stripe SetupIntent |
+
+## Reusability
+
+Unlike "charge" credentials, "authorize" credentials may enable multiple
+subsequent charges. The authorization persists until:
+
+- The expiry timestamp is reached
+- The spending limit is exhausted
+- The payer explicitly revokes it
+
+# Authorization Lifecycle
+
+## Registration
+
+When the server receives an "authorize" credential:
+
+1. Verify the authorization signature/proof
+2. Store the authorization for future use
+3. Return success (200) to indicate authorization accepted
+4. Optionally return `Payment-Authorization` for session reuse
+
+## Charging
+
+When charging against an authorization:
+
+1. Verify the authorization is still valid (not expired, not revoked)
+2. Verify sufficient limit remains
+3. Execute the charge via method-specific mechanism
+4. Decrement the remaining limit
+5. Return `Payment-Receipt` with charge details
+
+## Revocation
+
+Payers SHOULD be able to revoke authorizations before expiry. Revocation
+mechanisms are method-specific:
+
+| Method | Revocation Mechanism |
+|--------|---------------------|
+| Tempo | Remove Access Key from account |
+| EVM | Set approval to zero |
+| Stripe | Detach PaymentMethod from Customer |
+
+## Expiry
+
+Servers MUST NOT charge against expired authorizations. Servers SHOULD
+provide a mechanism for payers to query authorization status.
+
+# Security Considerations
+
+## Limit Verification
+
+Clients MUST verify the requested limit is acceptable before signing.
+Authorizations grant future spending capability without further user
+interaction.
+
+## Expiry Windows
+
+Clients SHOULD prefer short authorization windows. Long-lived
+authorizations increase risk if credentials are compromised.
+
+Recommended maximum windows:
+
+| Use Case | Recommended Max |
+|----------|-----------------|
+| Single session | 1 hour |
+| Daily usage | 24 hours |
+| Monthly billing | 30 days |
+
+## Revocation Capability
+
+Payment methods implementing "authorize" SHOULD provide revocation
+mechanisms. Payers MUST be able to revoke authorizations if they suspect
+compromise.
+
+## Authorization Scope
+
+Authorizations SHOULD be scoped as narrowly as possible:
+
+- Specific recipient address (not "any address")
+- Specific asset/currency
+- Reasonable limits and expiry
+
+## Server Accountability
+
+Servers holding authorizations are responsible for:
+
+- Secure storage of authorization data
+- Not exceeding authorized limits
+- Providing transaction records to payers
+- Honoring revocation requests
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the "authorize" intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Description | Reference |
+|--------|-------------|-----------|
+| `authorize` | Pre-authorization for future charges | This document |

--- a/specs/intents/draft-payment-intent-subscription-00.md
+++ b/specs/intents/draft-payment-intent-subscription-00.md
@@ -1,0 +1,392 @@
+---
+title: Subscription Intent for HTTP Payment Authentication
+abbrev: Payment Intent Subscription
+docname: draft-payment-intent-subscription-00
+version: 00
+category: info
+ipr: trust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Jake Moxey
+    ins: J. Moxey
+    email: jake@tempo.xyz
+    org: Tempo Labs
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    org: Tempo Labs
+  - name: Tom Meagher
+    ins: T. Meagher
+    email: thomas@tempo.xyz
+    org: Tempo Labs
+
+normative:
+  RFC2119:
+  RFC8174:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+---
+
+--- abstract
+
+This document defines the "subscription" payment intent for use with the
+Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. The
+"subscription" intent represents a recurring payment authorization where
+the payer grants the server permission to charge a specified amount on
+a periodic basis.
+
+--- middle
+
+# Introduction
+
+The "subscription" intent enables recurring payments where the payer
+authorizes periodic charges. Unlike "authorize" which grants a total
+spending limit, "subscription" grants a per-period spending limit that
+resets each billing cycle.
+
+Common use cases:
+
+- **SaaS subscriptions**: Monthly/annual service fees
+- **API subscriptions**: Per-month API access
+- **Streaming services**: Recurring content access
+- **Metered services**: Usage-based billing with periodic caps
+
+## Relationship to "authorize"
+
+The "subscription" intent is conceptually similar to "authorize" but
+with periodic limit resets:
+
+| Intent | Limit Scope | Resets |
+|--------|-------------|--------|
+| `authorize` | Total until expiry | Never |
+| `subscription` | Per period | Each period |
+
+## Relationship to Payment Methods
+
+Payment methods implement "subscription" using their native recurring
+payment mechanisms:
+
+| Method | Implementation |
+|--------|----------------|
+| Tempo | Access Keys with periodic spending limits |
+| Stripe | Stripe Subscriptions API |
+| Traditional | Recurring card-on-file charges |
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+Subscription
+: A recurring payment authorization where the payer grants the server
+  permission to charge a specified amount on a periodic basis.
+
+Billing Period
+: The interval at which subscription charges occur (e.g., daily,
+  weekly, monthly, yearly).
+
+Billing Cycle
+: A single instance of a billing period. A subscription with 12 monthly
+  cycles runs for one year.
+
+Renewal
+: The automatic continuation of a subscription into a new billing
+  period, typically accompanied by a charge.
+
+Cancellation
+: The act of ending a subscription, stopping future charges while
+  typically allowing access through the current billing period.
+
+# Intent Semantics
+
+## Definition
+
+The "subscription" intent represents a request for the payer to grant
+permission for the server to initiate recurring payments of a specified
+amount per billing period.
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Intent Identifier** | `subscription` |
+| **Payment Timing** | Recurring (server-initiated per period) |
+| **Idempotency** | Reusable within period limits |
+| **Reversibility** | Cancellable |
+
+## Flow
+
+~~~
+   Client                           Server                    Payment Network
+      │                                │                              │
+      │  (1) GET /resource             │                              │
+      ├───────────────────────────────>│                              │
+      │                                │                              │
+      │  (2) 402 Payment Required      │                              │
+      │      intent="subscription"     │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+      │  (3) Sign subscription auth    │                              │
+      │                                │                              │
+      │  (4) Authorization: Payment    │                              │
+      ├───────────────────────────────>│                              │
+      │                                │                              │
+      │                                │  (5) Register subscription   │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+      │                                │  (6) Charge first period     │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+      │  (7) 200 OK + Receipt          │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+      │        ... 30 days ...         │                              │
+      │                                │                              │
+      │                                │  (8) Charge next period      │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+~~~
+
+## Billing Periods
+
+See {{period-formats}} for supported period values and their durations.
+
+# Request Schema
+
+The `request` parameter for a "subscription" intent is a JSON object with
+shared fields defined by this specification and optional method-specific
+extensions in the `methodDetails` field.
+
+## Shared Fields
+
+All payment methods implementing the "subscription" intent MUST support these
+shared fields, enabling clients to parse and display subscription requests
+consistently across methods.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `amount` | string | Amount per billing period in base units |
+| `currency` | string | Currency or asset identifier (see {{currency-formats}}) |
+| `period` | string | Billing period: `"day"`, `"week"`, `"month"`, `"year"`, or seconds as string |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recipient` | string | Payment recipient in method-native format |
+| `expires` | string | Subscription end date in ISO 8601 format |
+| `cycles` | number | Maximum number of billing cycles |
+| `description` | string | Human-readable subscription description |
+| `externalId` | string | Merchant's reference (subscription ID, etc.) |
+| `methodDetails` | object | Method-specific extension data |
+
+## Currency Formats {#currency-formats}
+
+The `currency` field supports multiple formats to accommodate different
+payment networks:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| ISO 4217 | `"usd"`, `"eur"` | Fiat currencies (lowercase) |
+| Token address | `"0x20c0..."` | ERC-20, TIP-20, or similar token contracts |
+| Well-known symbol | `"sat"`, `"btc"`, `"eth"` | Native blockchain assets |
+
+Clients can detect the format:
+
+- Starts with `0x`: Token contract address
+- Three lowercase letters: ISO 4217 currency code
+- Otherwise: Well-known symbol or method-specific identifier
+
+## Period Formats {#period-formats}
+
+The `period` field supports named periods or explicit durations:
+
+| Value | Duration |
+|-------|----------|
+| `"day"` | 1 day (86400 seconds) |
+| `"week"` | 7 days (604800 seconds) |
+| `"month"` | ~30 days (2592000 seconds) |
+| `"year"` | ~365 days (31536000 seconds) |
+| `"86400"` | Explicit seconds as string |
+
+Payment method specifications MAY define additional period formats.
+
+## Method Extensions
+
+Payment methods MAY define additional fields in the `methodDetails` object.
+These fields are method-specific and MUST be documented in the payment
+method specification.
+
+## Examples
+
+### Traditional Payment Processor (Stripe)
+
+~~~ json
+{
+  "amount": "9900",
+  "currency": "usd",
+  "period": "month",
+  "description": "Pro Plan",
+  "methodDetails": {
+    "trialDays": 14,
+    "cancelAtPeriodEnd": false
+  }
+}
+~~~
+
+### Blockchain Payment (Tempo)
+
+~~~ json
+{
+  "amount": "10000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "period": "month",
+  "expires": "2026-01-06T00:00:00Z",
+  "methodDetails": {
+    "chainId": 42431
+  }
+}
+~~~
+
+### With Explicit Period and Cycle Limit
+
+~~~ json
+{
+  "amount": "5000",
+  "currency": "usd",
+  "period": "604800",
+  "cycles": 52,
+  "description": "Weekly digest subscription"
+}
+~~~
+
+# Credential Requirements
+
+## Payload
+
+The credential `payload` for a "subscription" intent contains the
+recurring authorization grant. The format is method-specific:
+
+| Authorization Type | Description | Example Methods |
+|-------------------|-------------|-----------------|
+| Periodic Key Auth | Key with periodic limits | Tempo |
+| Subscription Setup | Recurring billing setup | Stripe |
+| Signed Mandate | Recurring payment mandate | SEPA, ACH |
+
+## Persistence
+
+Subscription authorizations persist across billing periods until:
+
+- The subscription end date is reached
+- The maximum cycles are exhausted
+- The payer cancels the subscription
+- Payment fails (method-specific retry policies apply)
+
+# Subscription Lifecycle
+
+## Activation
+
+When the server receives a "subscription" credential:
+
+1. Verify the subscription authorization
+2. Create the subscription record
+3. Optionally charge the first period immediately
+4. Return success with subscription details
+
+## Renewal
+
+At each billing period boundary:
+
+1. Server initiates charge for the period amount
+2. If successful, continue subscription
+3. If failed, apply retry policy (method-specific)
+4. Notify payer of payment status
+
+## Cancellation
+
+Payers MUST be able to cancel subscriptions. Cancellation:
+
+- Stops future charges
+- Does NOT refund past charges (unless method-specific)
+- Takes effect at end of current period (unless immediate)
+
+Cancellation mechanisms are method-specific:
+
+| Method | Cancellation |
+|--------|-------------|
+| Tempo | Remove periodic Access Key |
+| Stripe | Cancel Subscription via API |
+| Traditional | Contact merchant |
+
+## Modification
+
+Some payment methods support subscription modification:
+
+- Upgrade/downgrade amount
+- Change billing period
+- Update payment method
+
+Modifications require payer consent for increases.
+
+# Security Considerations
+
+## Recurring Charge Awareness
+
+Clients MUST clearly communicate to users that they are authorizing
+recurring charges. User interfaces SHOULD:
+
+- Display the amount per period prominently
+- Show the total commitment if cycles are limited
+- Indicate when the subscription expires (or if it's perpetual)
+
+## Period Amount Verification
+
+Clients MUST verify:
+
+- The amount per period is acceptable
+- The billing period matches expectations
+- The total commitment is understood
+
+## Cancellation Rights
+
+Payers MUST have clear cancellation mechanisms. Servers MUST:
+
+- Provide documentation on how to cancel
+- Honor cancellation requests promptly
+- Not impose unreasonable cancellation barriers
+
+## Failed Payment Handling
+
+Servers SHOULD define clear policies for failed payments:
+
+- Number of retry attempts
+- Grace period before service suspension
+- Notification to payer
+
+## Price Changes
+
+If a server intends to change subscription pricing:
+
+- Existing subscriptions SHOULD continue at original price
+- Price increases require new authorization
+- Payers MUST be notified of upcoming changes
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the "subscription" intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Description | Reference |
+|--------|-------------|-----------|
+| `subscription` | Recurring periodic payment authorization | This document |

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -1,0 +1,514 @@
+---
+title: Tempo authorize Intent for HTTP Payment Authentication
+abbrev: Tempo Authorize
+docname: draft-tempo-authorize-00
+version: 00
+category: info
+ipr: trust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Jake Moxey
+    ins: J. Moxey
+    email: jake@tempo.xyz
+    organization: Tempo Labs
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    organization: Tempo Labs
+  - name: Tom Meagher
+    ins: T. Meagher
+    email: thomas@tempo.xyz
+    organization: Tempo Labs
+
+normative:
+  RFC2119:
+  RFC4648:
+  RFC8174:
+  RFC8259:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+
+informative:
+  EIP-2718:
+    title: "Typed Transaction Envelope"
+    target: https://eips.ethereum.org/EIPS/eip-2718
+    author:
+      - name: Micah Zoltu
+    date: 2020-10
+  EIP-55:
+    title: "Mixed-case checksum address encoding"
+    target: https://eips.ethereum.org/EIPS/eip-55
+    author:
+      - name: Vitalik Buterin
+    date: 2016-01
+  TEMPO-TX-SPEC:
+    title: "Tempo Transaction Specification"
+    target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
+    author:
+      - org: Tempo Labs
+---
+
+--- abstract
+
+This document defines the "authorize" intent for the "tempo" payment method
+in the Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. It
+specifies how clients grant servers spending limits with expiry on the
+Tempo blockchain.
+
+--- middle
+
+# Introduction
+
+The `authorize` intent represents a payment authorization. The payer grants
+the server permission to charge up to the specified amount before the
+expiry timestamp.
+
+This specification defines the request schema, credential formats, and
+settlement procedures for authorization on Tempo.
+
+## Authorize Flow
+
+The following diagram illustrates the Tempo authorize flow:
+
+~~~
+   Client                        Server                     Tempo Network
+      |                             |                             |
+      |  (1) GET /api/resource      |                             |
+      |-------------------------->  |                             |
+      |                             |                             |
+      |  (2) 402 Payment Required   |                             |
+      |      intent="authorize"     |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |  (3) Sign keyAuthorization  |                             |
+      |      or approve tx          |                             |
+      |                             |                             |
+      |  (4) Authorization: Payment |                             |
+      |-------------------------->  |                             |
+      |                             |  (5) Store keyAuth or       |
+      |                             |      broadcast approve      |
+      |  (6) 200 OK (approved)      |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |         ... later ...       |                             |
+      |                             |  (7) Charge with keyAuth    |
+      |                             |      or transferFrom        |
+      |                             |-------------------------->  |
+      |                             |  (8) Transfer complete      |
+      |                             |<--------------------------  |
+      |                             |                             |
+~~~
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+TIP-20
+: Tempo's enshrined token standard, implemented as precompiles rather
+  than smart contracts. TIP-20 tokens use 6 decimal places and provide
+  `transfer`, `transferFrom`, and `approve` operations.
+
+Tempo Transaction
+: An EIP-2718 transaction with type prefix `0x76`, supporting batched
+  calls, multiple signature types (secp256k1, P256, WebAuthn), 2D nonces,
+  and validity windows.
+
+Access Key
+: A delegated signing key. Access keys may have an expiry timestamp and
+  a per-token spending limit. The server holds the access key and can
+  sign transactions on behalf of the payer within the authorized limits.
+
+2D Nonce
+: Tempo's nonce system where each account has multiple independent nonce
+  lanes (`nonce_key`), enabling parallel transaction submission.
+
+Fee Payer
+: An account that pays transaction fees on behalf of another account.
+  Tempo Transactions support fee payment via a separate signature
+  domain (`0x78`), allowing the server to pay for fees while the client
+  only signs the payment authorization.
+
+# Request Schema
+
+The `request` parameter in the `WWW-Authenticate` challenge contains a
+base64url-encoded JSON object.
+
+## Shared Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | string | REQUIRED | Maximum spend amount in base units |
+| `currency` | string | REQUIRED | TIP-20 token address |
+| `expires` | string | REQUIRED | Expiry timestamp in ISO 8601 format |
+| `recipient` | string | OPTIONAL | Authorized spender address (required for transaction fulfillment) |
+
+## Method Details
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID (default: 42431) |
+| `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees (default: `false`) |
+| `methodDetails.validFrom` | string | OPTIONAL | Start timestamp in ISO 8601 format |
+
+**Example:**
+
+~~~json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "expires": "2025-02-05T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431,
+    "feePayer": true,
+    "validFrom": "2025-01-06T00:00:00Z"
+  }
+}
+~~~
+
+The client fulfills this by either:
+
+1. Signing a Tempo Transaction with `approve(recipient, amount)` on the
+   specified `currency` (token address), with `validBefore` set to `expires`
+   and optionally `validAfter` set to `methodDetails.validFrom`. The
+   `recipient` field MUST be present in the request when using transaction
+   fulfillment.
+
+2. Signing a Key Authorization with expiry = `expires` and a spending limit
+   = `amount` for the specified token.
+
+If `methodDetails.feePayer` is `true`, the client signs with
+`fee_payer_signature` set to `0x00` and `fee_token` empty. If `feePayer`
+is `false` or omitted, the client MUST NOT sign a key authorization; the
+client MUST sign a transaction with `fee_token` set to pay fees themselves.
+
+# Credential Schema
+
+The credential in the `Authorization` header contains a base64url-encoded
+JSON object per Section 5.2 of {{I-D.httpauth-payment}}.
+
+## Credential Structure
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `challenge` | object | REQUIRED | Echo of the challenge from the server |
+| `payload` | object | REQUIRED | Tempo-specific payload object |
+| `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
+
+## Transaction Payload (type="transaction")
+
+When `type` is `"transaction"`, `signature` contains the complete signed
+Tempo Transaction (type 0x76) serialized as RLP and hex-encoded with
+`0x` prefix. The transaction MUST contain an `approve(spender, amount)`
+call on the TIP-20 token.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed transaction |
+| `type` | string | REQUIRED | `"transaction"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0x76f901...signed transaction bytes...",
+    "type": "transaction"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+The transaction contains `approve(recipient, amount)` on the TIP-20 token.
+The server broadcasts this transaction to register the allowance onchain,
+then later calls `transferFrom` to collect payment.
+
+## Key Authorization Payload (type="keyAuthorization")
+
+When `type` is `"keyAuthorization"`, `signature` contains the complete signed
+Key Authorization serialized as RLP and hex-encoded with `0x` prefix. The
+authorization is signed by the root account and grants the access key
+permission to sign transactions on its behalf.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed key authorization |
+| `type` | string | REQUIRED | `"keyAuthorization"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0xf8b2...signed authorization bytes...",
+    "type": "keyAuthorization"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+## Hash Payload (type="hash")
+
+When `type` is `"hash"`, the client has already broadcast an `approve`
+transaction to the Tempo network. The `hash` field contains the transaction
+hash for the server to verify onchain.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `hash` | string | REQUIRED | Transaction hash with `0x` prefix |
+| `type` | string | REQUIRED | `"hash"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "hash": "0x9f8e7d6c5b4a3210fedcba0987654321fedcba0987654321fedcba0987654321",
+    "type": "hash"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+The client constructs and broadcasts an `approve(recipient, amount)` transaction
+to Tempo, then submits the hash. The server verifies the approval was registered
+onchain before granting access.
+
+# Settlement Procedure
+
+## Settlement via Allowance (Transaction)
+
+For `intent="authorize"` fulfilled via transaction, the client signs an
+`approve` transaction granting the server a spending allowance. If
+`feePayer: true`, the server adds its fee payer signature before broadcasting:
+
+~~~
+   Client                           Server                        Tempo Network
+      |                                |                                |
+      |  (1) Authorization:            |                                |
+      |      Payment <credential>      |                                |
+      |------------------------------->|                                |
+      |                                |                                |
+      |                                |  (2) If feePayer: true,        |
+      |                                |      add fee payment signature |
+      |                                |                                |
+      |                                |  (3) eth_sendRawTxSync         |
+      |                                |------------------------------->|
+      |                                |                                |
+      |                                |  (4) Approval granted          |
+      |                                |<-------------------------------|
+      |                                |                                |
+      |  (5) 200 OK                    |                                |
+      |      Payment-Receipt: <txHash> |                                |
+      |<-------------------------------|                                |
+      |                                |                                |
+      |         ... later, when service is consumed ...                 |
+      |                                |                                |
+      |                                |  (6) transferFrom(client,      |
+      |                                |      server, amount)           |
+      |                                |------------------------------->|
+      |                                |                                |
+      |                                |  (7) Transfer executed         |
+      |                                |<-------------------------------|
+      |                                |                                |
+~~~
+
+1. Client submits credential containing signed `approve` transaction
+2. If `feePayer: true`, server adds fee sponsorship (signs with `0x78` domain)
+3. Server broadcasts transaction; approval registered onchain
+4. Server returns receipt (approval is now active)
+5. Later, when the server needs to charge, it calls `transferFrom`
+6. Charges can occur up to the approved limit before expiry
+
+## Settlement via Key Authorization
+
+For `intent="authorize"` fulfilled via key authorization, the client signs
+an authorization granting the server permission to charge up to a limit:
+
+~~~
+   Client                        Server                     Tempo Network
+      |                             |                             |
+      |  (1) Authorization:         |                             |
+      |      Payment <credential>   |                             |
+      |      (signed keyAuth)       |                             |
+      |-------------------------->  |                             |
+      |                             |                             |
+      |                             |  (2) Store keyAuth          |
+      |                             |                             |
+      |  (3) 200 OK                 |                             |
+      |      (approval active)      |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |         ... later, when service is consumed ...           |
+      |                             |                             |
+      |                             |  (4) Construct tx with:     |
+      |                             |      - keyAuthorization     |
+      |                             |      - transfer(amt) call   |
+      |                             |                             |
+      |                             |  (5) eth_sendRawTxSync      |
+      |                             |-------------------------->  |
+      |                             |                             |
+      |                             |  (6) Key registered +       |
+      |                             |      transfer executed      |
+      |                             |<--------------------------  |
+      |                             |                             |
+~~~
+
+1. Client submits credential containing signed key authorization
+2. Server stores the authorization for future use
+3. Server grants access (approval is now active)
+4. Later, when the server needs to charge, it constructs a transaction
+   with the `keyAuthorization` and `transfer` call
+5. Charges can occur up to the authorized limit before expiry
+
+## Receipt Generation
+
+Upon successful settlement, servers MUST return a `Payment-Receipt` header
+per Section 5.3 of {{I-D.httpauth-payment}}.
+
+The receipt payload for Tempo authorize:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `"tempo"` |
+| `reference` | string | Transaction hash of the approval transaction (if applicable) |
+| `status` | string | `"success"` or `"failed"` |
+| `timestamp` | string | ISO 8601 settlement time |
+
+# Security Considerations
+
+## Access Key Security
+
+Access keys present additional security considerations:
+
+**Destination Scoping**: For `authorize` intent, clients SHOULD include
+destination restrictions to limit the addresses the key can transfer to.
+This prevents key compromise from enabling transfers to attacker-controlled
+addresses.
+
+**Spending Limits**: Access key spending limits are enforced by the
+AccountKeychain precompile onchain. Servers cannot exceed the authorized
+limits even if compromised.
+
+**Key Revocation**: Users can revoke access keys at any time via the
+AccountKeychain precompile. Servers SHOULD handle revocation gracefully
+by requesting new authorization.
+
+## Amount Verification
+
+Clients MUST parse and verify the `request` payload before signing:
+
+1. Verify `amount` is reasonable for the service
+2. Verify `currency` is the expected token address
+3. Verify `expires` is not unreasonably far in the future
+
+## Source Verification
+
+If a credential includes the optional `source` field (a DID identifying the
+payer), servers MUST NOT trust this value without verification.
+
+Servers MUST verify the payer identity by:
+
+- For `type="transaction"`: Recovering the signer address from the
+  transaction signature using standard ECDSA recovery
+- For `type="keyAuthorization"`: Deriving the address from the `publicKey`
+  field in the key authorization
+- For `type="hash"`: Retrieving the `from` address from the transaction
+  receipt onchain
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|--------|-------------------|-------------|-----------|
+| `authorize` | `tempo` | Payment authorization with spending limits | This document |
+
+--- back
+
+# Example
+
+**Challenge:**
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="nR5tYuLpS8mWvXzQ1eCgHj",
+  realm="api.example.com",
+  method="tempo",
+  intent="authorize",
+  request="eyJhbW91bnQiOiI1MDAwMDAwMCIsImN1cnJlbmN5IjoiMHgyMGMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxIiwiZXhwaXJlcyI6IjIwMjUtMDItMDVUMTI6MDA6MDBaIiwibWV0aG9kRGV0YWlscyI6eyJjaGFpbklkIjo0MjQzMX19"
+~~~
+
+The `request` decodes to:
+
+~~~json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "expires": "2025-02-05T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431
+  }
+}
+~~~
+
+This requests approval for up to 50.00 alphaUSD (50000000 base units).
+
+**Credential (via Key Authorization):**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0xf8b2...signed authorization bytes...",
+    "type": "keyAuthorization"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+# Acknowledgements
+
+The authors thank the Tempo community for their feedback on this
+specification.

--- a/specs/methods/tempo/draft-tempo-subscription-00.md
+++ b/specs/methods/tempo/draft-tempo-subscription-00.md
@@ -1,0 +1,440 @@
+---
+title: Tempo subscription Intent for HTTP Payment Authentication
+abbrev: Tempo Subscription
+docname: draft-tempo-subscription-00
+version: 00
+category: info
+ipr: trust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Jake Moxey
+    ins: J. Moxey
+    email: jake@tempo.xyz
+    organization: Tempo Labs
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    organization: Tempo Labs
+  - name: Tom Meagher
+    ins: T. Meagher
+    email: thomas@tempo.xyz
+    organization: Tempo Labs
+
+normative:
+  RFC2119:
+  RFC4648:
+  RFC8174:
+  RFC8259:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+
+informative:
+  EIP-2718:
+    title: "Typed Transaction Envelope"
+    target: https://eips.ethereum.org/EIPS/eip-2718
+    author:
+      - name: Micah Zoltu
+    date: 2020-10
+  EIP-55:
+    title: "Mixed-case checksum address encoding"
+    target: https://eips.ethereum.org/EIPS/eip-55
+    author:
+      - name: Vitalik Buterin
+    date: 2016-01
+  TEMPO-TX-SPEC:
+    title: "Tempo Transaction Specification"
+    target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
+    author:
+      - org: Tempo Labs
+---
+
+--- abstract
+
+This document defines the "subscription" intent for the "tempo" payment method
+in the Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. It
+specifies how clients grant servers recurring payment authorization with
+periodic limits on the Tempo blockchain.
+
+--- middle
+
+# Introduction
+
+The `subscription` intent represents a recurring payment authorization. The
+payer grants the server permission to charge a specified amount per period
+(e.g., daily, weekly, monthly).
+
+This specification defines the request schema, credential format, and
+settlement procedures for subscriptions on Tempo.
+
+**Important**: Tempo Transactions cannot fulfill subscription intents because
+ERC-20 style approvals do not support periodic limit semantics. Only Key
+Authorization credentials are valid for subscriptions.
+
+## Subscription Flow
+
+The following diagram illustrates the Tempo subscription flow:
+
+~~~
+   Client                        Server                     Tempo Network
+      |                             |                             |
+      |  (1) GET /api/resource      |                             |
+      |-------------------------->  |                             |
+      |                             |                             |
+      |  (2) 402 Payment Required   |                             |
+      |      intent="subscription"  |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |  (3) Sign keyAuthorization  |                             |
+      |      (periodic limits)      |                             |
+      |                             |                             |
+      |  (4) Authorization: Payment |                             |
+      |-------------------------->  |                             |
+      |                             |  (5) Register + charge      |
+      |                             |-------------------------->  |
+      |                             |  (6) First period paid      |
+      |                             |<--------------------------  |
+      |  (7) 200 OK + Receipt       |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |         ... 30 days ...     |                             |
+      |                             |  (8) Charge next period     |
+      |                             |-------------------------->  |
+      |                             |  (9) Transfer complete      |
+      |                             |<--------------------------  |
+      |                             |                             |
+~~~
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+TIP-20
+: Tempo's enshrined token standard, implemented as precompiles rather
+  than smart contracts. TIP-20 tokens use 6 decimal places and provide
+  `transfer`, `transferFrom`, and `approve` operations.
+
+Access Key
+: A delegated signing key. Access keys may have an expiry timestamp and
+  a per-token spending limit. For subscriptions, access keys include
+  periodic limits that reset after each billing period.
+
+AccountKeychain Precompile
+: The Tempo precompile contract that manages access key registration,
+  spending limits, and periodic limit enforcement. The precompile tracks
+  spending per period and resets limits automatically.
+
+2D Nonce
+: Tempo's nonce system where each account has multiple independent nonce
+  lanes (`nonce_key`), enabling parallel transaction submission.
+
+# Request Schema
+
+The `request` parameter in the `WWW-Authenticate` challenge contains a
+base64url-encoded JSON object.
+
+## Shared Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | string | REQUIRED | Amount per period in base units |
+| `currency` | string | REQUIRED | TIP-20 token address |
+| `period` | string | REQUIRED | Billing period |
+| `expires` | string | REQUIRED | Subscription end timestamp in ISO 8601 format |
+
+## Period Values
+
+The `period` field accepts the following values:
+
+| Value | Description |
+|-------|-------------|
+| `"day"` | Daily billing (86400 seconds) |
+| `"week"` | Weekly billing (604800 seconds) |
+| `"month"` | Monthly billing (~30 days, 2592000 seconds) |
+| `"year"` | Yearly billing (~365 days, 31536000 seconds) |
+| `"<seconds>"` | Custom period in seconds as a string (e.g., `"2592000"`) |
+
+## Method Details
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID (default: 42431) |
+| `methodDetails.validFrom` | string | OPTIONAL | Start timestamp in ISO 8601 format |
+
+**Example:**
+
+~~~json
+{
+  "amount": "10000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "period": "month",
+  "expires": "2026-01-06T00:00:00Z",
+  "methodDetails": {
+    "chainId": 42431,
+    "validFrom": "2025-01-06T00:00:00Z"
+  }
+}
+~~~
+
+This requests a subscription for 10.00 alphaUSD (10000000 base units) per
+month, expiring on January 6, 2026.
+
+The client fulfills this by signing a Key Authorization with:
+
+- Expiry = `expires`
+- Periodic spending limit = `amount` per `period` for the specified `currency`
+
+# Credential Schema
+
+The credential in the `Authorization` header contains a base64url-encoded
+JSON object per Section 5.2 of {{I-D.httpauth-payment}}.
+
+## Credential Structure
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `challenge` | object | REQUIRED | Echo of the challenge from the server |
+| `payload` | object | REQUIRED | Tempo-specific payload object |
+| `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
+
+## Key Authorization Payload (type="keyAuthorization")
+
+Subscriptions MUST use `type="keyAuthorization"`. The `signature` field
+contains the complete signed Key Authorization serialized as RLP and
+hex-encoded with `0x` prefix. The authorization is signed by the root
+account and grants the access key permission to sign transactions on its
+behalf with periodic spending limits.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed key authorization |
+| `type` | string | REQUIRED | `"keyAuthorization"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "qT8wErYuI3oPlKjH6gFdSa",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "subscription",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0xf8c1...signed authorization bytes...",
+    "type": "keyAuthorization"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+**Note**: Tempo Transactions (`type="transaction"`) and transaction hashes
+(`type="hash"`) cannot fulfill subscription intents because ERC-20 style
+approvals do not support periodic limit semantics.
+
+# Settlement Procedure
+
+## Periodic Charging via AccountKeychain
+
+For `intent="subscription"` fulfilled via key authorization, the client
+signs an authorization granting the server permission to charge periodically:
+
+~~~
+   Client                        Server                     Tempo Network
+      |                             |                             |
+      |  (1) Authorization:         |                             |
+      |      Payment <credential>   |                             |
+      |      (signed keyAuth)       |                             |
+      |-------------------------->  |                             |
+      |                             |                             |
+      |                             |  (2) Construct tx with:     |
+      |                             |      - keyAuthorization     |
+      |                             |      - transfer(amt) call   |
+      |                             |                             |
+      |                             |  (3) eth_sendRawTxSync      |
+      |                             |-------------------------->  |
+      |                             |                             |
+      |                             |  (4) Key registered +       |
+      |                             |      transfer executed      |
+      |                             |<--------------------------  |
+      |                             |                             |
+      |  (5) 200 OK                 |                             |
+      |      Payment-Receipt:       |                             |
+      |      <txHash>               |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |         ... 30 days pass ...                              |
+      |                             |                             |
+      |                             |  (6) Construct tx with:     |
+      |                             |      - transfer(amt) call   |
+      |                             |      (key already registered)|
+      |                             |                             |
+      |                             |  (7) eth_sendRawTxSync      |
+      |                             |-------------------------->  |
+      |                             |                             |
+      |                             |  (8) Transfer executed      |
+      |                             |<--------------------------  |
+      |                             |                             |
+      |         ... repeat each period until expiry ...           |
+      |                             |                             |
+~~~
+
+1. Client submits credential containing signed key authorization
+2. Server constructs transaction with `keyAuthorization` and first `transfer`
+3. Transaction registers the key and executes the first charge
+4. Server returns receipt (subscription is now active)
+5. When each period elapses, server charges using the registered key
+6. Process repeats each period until authorization expires
+
+## Periodic Limit Enforcement
+
+The AccountKeychain precompile enforces periodic spending limits:
+
+1. **Period tracking**: The precompile tracks when each period started
+   and how much has been spent in the current period.
+
+2. **Automatic reset**: When a new period begins (based on the configured
+   period duration), the spending counter resets to zero.
+
+3. **Limit enforcement**: Each transfer is checked against the remaining
+   allowance for the current period. Transfers exceeding the limit revert.
+
+4. **Expiry enforcement**: After the authorization expiry timestamp, all
+   transfers using the key are rejected.
+
+## Receipt Generation
+
+Upon successful settlement, servers MUST return a `Payment-Receipt` header
+per Section 5.3 of {{I-D.httpauth-payment}}.
+
+The receipt payload for Tempo subscription:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `"tempo"` |
+| `reference` | string | Transaction hash of the key registration transaction |
+| `status` | string | `"success"` or `"failed"` |
+| `timestamp` | string | ISO 8601 settlement time |
+
+# Security Considerations
+
+## Access Key Security
+
+Access keys for subscriptions present additional security considerations:
+
+**Periodic Limit Boundaries**: Clients SHOULD understand that periodic limits
+reset at fixed intervals. A server could charge the full period amount just
+before a reset, then charge again immediately after. Clients accepting
+subscriptions implicitly accept this behavior.
+
+**Destination Scoping**: Clients SHOULD include destination restrictions to
+limit the addresses the key can transfer to. This prevents key compromise
+from enabling transfers to attacker-controlled addresses.
+
+**Spending Limits**: Access key spending limits are enforced by the
+AccountKeychain precompile onchain. Servers cannot exceed the authorized
+per-period limits even if compromised.
+
+**Key Revocation**: Users can revoke access keys at any time via the
+AccountKeychain precompile. Servers SHOULD handle revocation gracefully
+and notify the user that their subscription has been cancelled.
+
+## Amount Verification
+
+Clients MUST parse and verify the `request` payload before signing:
+
+1. Verify `amount` is reasonable for the service per period
+2. Verify `currency` is the expected token address
+3. Verify `period` matches expectations
+4. Verify `expires` is not unreasonably far in the future
+
+## No Transaction or Hash Fulfillment
+
+Unlike `charge` and `authorize` intents, the `subscription` intent does NOT
+support `type="transaction"` or `type="hash"` credentials. Servers MUST
+reject subscription credentials with these types.
+
+This restriction exists because:
+
+- ERC-20 `approve` does not support periodic limits
+- Periodic limit enforcement requires the AccountKeychain precompile
+- Only Key Authorization credentials can configure periodic limits
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|--------|-------------------|-------------|-----------|
+| `subscription` | `tempo` | Recurring payment authorization with periodic limits | This document |
+
+--- back
+
+# Example
+
+**Challenge:**
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="qT8wErYuI3oPlKjH6gFdSa",
+  realm="api.example.com",
+  method="tempo",
+  intent="subscription",
+  request="eyJhbW91bnQiOiIxMDAwMDAwMCIsImN1cnJlbmN5IjoiMHgyMGMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxIiwicGVyaW9kIjoibW9udGgiLCJleHBpcmVzIjoiMjAyNi0wMS0wNlQwMDowMDowMFoiLCJtZXRob2REZXRhaWxzIjp7ImNoYWluSWQiOjQyNDMxfX0"
+~~~
+
+The `request` decodes to:
+
+~~~json
+{
+  "amount": "10000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "period": "month",
+  "expires": "2026-01-06T00:00:00Z",
+  "methodDetails": {
+    "chainId": 42431
+  }
+}
+~~~
+
+This requests a subscription for 10.00 alphaUSD (10000000 base units) per month.
+
+**Credential:**
+
+~~~json
+{
+  "challenge": {
+    "id": "qT8wErYuI3oPlKjH6gFdSa",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "subscription",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0xf8c1...signed authorization bytes...",
+    "type": "keyAuthorization"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+Note: Periodic limit enforcement for subscriptions is configured when
+registering the key with the AccountKeychain precompile.
+
+# Acknowledgements
+
+The authors thank the Tempo community for their feedback on this
+specification.


### PR DESCRIPTION
Restores the core intent specs and Tempo method implementations that were removed in #88.

**Files restored:**
- `specs/intents/draft-payment-intent-authorize-00.md` — Authorize intent (core)
- `specs/intents/draft-payment-intent-subscription-00.md` — Subscription intent (core)
- `specs/methods/tempo/draft-tempo-authorize-00.md` — Tempo authorize implementation
- `specs/methods/tempo/draft-tempo-subscription-00.md` — Tempo subscription implementation

Stripe implementations (`draft-stripe-authorize-00.md`, `draft-stripe-subscription-00.md`) will follow in a separate PR.