### PR TITLE
feat: extract Jinja partials for head meta, base styles, and gtag

### DIFF
--- a/pages/templates/base-styles.html
+++ b/pages/templates/base-styles.html
@@ -1,0 +1,20 @@
+:root {
+  --color-link: #0066cc;
+  --color-text: #333;
+}
+
+body {
+  font-family: "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 16px;
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  line-height: 1.6;
+  color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+}
+
+.sep {
+  color: #999;
+  margin: 0 0.25rem;
+}

--- a/pages/templates/gtag.html
+++ b/pages/templates/gtag.html
@@ -1,0 +1,8 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T1SCQME4VF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T1SCQME4VF');
+</script>

--- a/pages/templates/head-meta.html
+++ b/pages/templates/head-meta.html
@@ -1,0 +1,4 @@
+<meta charset="UTF-8">
+{% include "gtag.html" %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☰</text></svg>">

--- a/pages/templates/index.html
+++ b/pages/templates/index.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☰</text></svg>">
+  {% include "head-meta.html" %}
   <title>Machine Payments Protocol Specifications</title>
   <style>
     @font-face {
@@ -22,21 +20,7 @@
       font-display: swap;
     }
 
-    :root {
-      --color-link: #0066cc;
-      --color-text: #333;
-    }
-
-    body {
-      font-family: "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-      font-size: 16px;
-      max-width: 900px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-      line-height: 1.6;
-      color: var(--color-text);
-      -webkit-font-smoothing: antialiased;
-    }
+    {% include "base-styles.html" %}
 
     h1 {
       font-size: 2rem;
@@ -93,11 +77,6 @@
 
     .formats a:hover {
       text-decoration: underline;
-    }
-
-    .sep {
-      color: #999;
-      margin: 0 0.25rem;
     }
 
     .header-links {

--- a/pages/templates/problem.html
+++ b/pages/templates/problem.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☰</text></svg>">
+  {% include "head-meta.html" %}
   <title>{{ title }} – Payment Auth Problem Type</title>
   <style>
     @font-face {
@@ -22,21 +20,7 @@
       font-display: swap;
     }
 
-    :root {
-      --color-link: #0066cc;
-      --color-text: #333;
-    }
-
-    body {
-      font-family: "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-      font-size: 16px;
-      max-width: 900px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-      line-height: 1.6;
-      color: var(--color-text);
-      -webkit-font-smoothing: antialiased;
-    }
+    {% include "base-styles.html" %}
 
     h1 {
       font-size: 1.6rem;
@@ -55,11 +39,6 @@
 
     .breadcrumb a:hover {
       text-decoration: underline;
-    }
-
-    .sep {
-      color: #999;
-      margin: 0 0.25rem;
     }
 
     table {

--- a/pages/templates/problems_index.html
+++ b/pages/templates/problems_index.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>☰</text></svg>">
+  {% include "head-meta.html" %}
   <title>Problem Types – Payment Auth</title>
   <style>
     @font-face {
@@ -22,21 +20,7 @@
       font-display: swap;
     }
 
-    :root {
-      --color-link: #0066cc;
-      --color-text: #333;
-    }
-
-    body {
-      font-family: "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-      font-size: 16px;
-      max-width: 900px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-      line-height: 1.6;
-      color: var(--color-text);
-      -webkit-font-smoothing: antialiased;
-    }
+    {% include "base-styles.html" %}
 
     h1 {
       font-size: 2rem;
@@ -63,11 +47,6 @@
 
     .header-links a:hover {
       text-decoration: underline;
-    }
-
-    .sep {
-      color: #999;
-      margin: 0 0.25rem;
     }
 
     table {


### PR DESCRIPTION
Adds Google Analytics (G-T1SCQME4VF) and extracts shared template boilerplate into reusable Jinja partials:

- **`gtag.html`** — Google Analytics tag
- **`head-meta.html`** — charset, viewport, favicon, gtag include
- **`base-styles.html`** — CSS custom properties, body reset, `.sep` class

All three page templates (`index.html`, `problem.html`, `problems_index.html`) now use these partials instead of duplicating the markup.