### PR TITLE
Solana charge intent specification

### DIFF
--- a/specs/methods/solana/draft-solana-charge-00.md
+++ b/specs/methods/solana/draft-solana-charge-00.md
@@ -397,7 +397,10 @@ splits
   greater than zero. Servers MUST reject challenges
   where splits consume the entire amount. Servers MUST
   verify each split transfer on-chain during credential
-  verification.
+  verification. If the same recipient appears more than
+  once in `splits`, each occurrence is a distinct
+  payment leg and MUST be verified separately; servers
+  MUST NOT implicitly aggregate such entries.
 
   This mechanism is a Solana-specific extension to the
   base `charge` intent. It can be used for fee payer cost
@@ -782,6 +785,12 @@ the server MUST:
    additional System Program `transfer` instruction whose
    `destination` and `lamports` fields match that split.
 
+   Each required payment leg MUST be matched to a
+   distinct transfer instruction. A single transfer
+   instruction MUST NOT satisfy more than one required
+   payment leg, even if multiple legs share the same
+   recipient.
+
 If any required transfer instruction is missing, the
 server MUST reject the credential.
 
@@ -812,6 +821,12 @@ not `"sol"`), the server MUST:
    verify that at least one additional `transferChecked`
    instruction uses that ATA as `destination` and has
    `tokenAmount.amount` equal to the split amount.
+
+   Each required payment leg MUST be matched to a
+   distinct `transferChecked` instruction. A single
+   instruction MUST NOT satisfy more than one required
+   payment leg, even if multiple legs resolve to the
+   same destination ATA.
 
 If any required `transferChecked` instruction is missing,
 the server MUST reject the credential.


### PR DESCRIPTION
##  Summary

  Defines the **charge** intent for the **solana** payment method within the HTTP Payment Authentication Scheme. Supports
  one-time payments in native SOL and SPL tokens (including Token-2022).

###  Settlement modes

  - Pull mode (type="transaction", default): client signs, server broadcasts. Enables fee sponsorship and server-side
  retry.
  - Push mode (type="signature", fallback): client broadcasts and presents the confirmed signature.

###  Key features

  - Fee sponsorship — server co-signs as fee payer; client only signs the transfer authority
  - Payment splits — multiple recipients in a single transaction (ex: platform fees, revenue sharing, fee recovery)
  - Optional Server-provided blockhash — recentBlockhash in the challenge eliminates client RPC dependency in pull mode
  - Transaction simulation — servers SHOULD simulate before broadcast to prevent wasted fees
  - Token program auto-detection — tokenProgram is a hint; clients resolve from the mint if absent (supports PYUSD,
  Token-2022, etc.)
  - externalId as memo — written on-chain via Memo Program for auditing and reconciliation
 
### Request schema

**Shared fields**: amount, currency, recipient, description, externalId

**Method details**: network, splToken, decimals, tokenProgram, reference, feePayer, feePayerKey, splits, recentBlockhash

---

###  Reference implementation

 [solana-mpp-sdk](https://github.com/solana-foundation/solana-mpp-sdk) - includes unit tests, integration tests, and an interactive demo.

  ---
  AI assistance (**Claude** + **Codex**) were used in drafting this specification. All content has been reviewed for accuracy and RFC compliance.