### PR TITLE
feat: add no-modification copyright clause to all specs except core

### DIFF
--- a/examples/extension-template.md
+++ b/examples/extension-template.md
@@ -4,7 +4,7 @@ abbrev: "{Feature}" Extension
 docname: draft-payment-{feature}-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/examples/intent-template.md
+++ b/examples/intent-template.md
@@ -4,7 +4,7 @@ abbrev: "{name}" Intent
 docname: draft-payment-intent-{name}-00
 version: 00
 category: std
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/examples/method-template.md
+++ b/examples/method-template.md
@@ -4,7 +4,7 @@ abbrev: "{Network}" Payment Method
 docname: draft-{network}-payment-method-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/extensions/draft-payment-discovery-00.md
+++ b/specs/extensions/draft-payment-discovery-00.md
@@ -4,7 +4,7 @@ abbrev: Payment Discovery
 docname: draft-payment-discovery-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/extensions/transports/draft-payment-transport-mcp-00.md
+++ b/specs/extensions/transports/draft-payment-transport-mcp-00.md
@@ -4,7 +4,7 @@ abbrev: Payment JSON-RPC & MCP Transport
 docname: draft-payment-transport-mcp-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Payment Intent Charge
 docname: draft-payment-intent-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/methods/card/draft-card-charge-00.md
+++ b/specs/methods/card/draft-card-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Card Charge
 docname: draft-card-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/methods/lightning/draft-lightning-charge-00.md
+++ b/specs/methods/lightning/draft-lightning-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Lightning Charge Intent
 docname: draft-lightning-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: independent
 consensus: false
 

--- a/specs/methods/lightning/draft-lightning-session-00.md
+++ b/specs/methods/lightning/draft-lightning-session-00.md
@@ -4,7 +4,7 @@ abbrev: Lightning Session Intent
 docname: draft-lightning-session-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: independent
 consensus: false
 

--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Stripe Charge
 docname: draft-stripe-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Tempo Charge
 docname: draft-tempo-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/methods/tempo/draft-tempo-session-00.md
+++ b/specs/methods/tempo/draft-tempo-session-00.md
@@ -4,7 +4,7 @@ abbrev: Tempo Session
 docname: draft-tempo-session-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 


### PR DESCRIPTION
## Summary

Re-applies the change from #186

Changes `ipr` from `trust200902` to `noModificationTrust200902` for all method, intent, and extension specs, plus the three templates.

This causes xml2rfc to append the following paragraph to the Copyright Notice section:

> *This document may not be modified, and derivative works of it may not be created, except to format it for publication as an RFC or to translate it into languages other than English.*

The core spec (`draft-httpauth-payment-00`) retains `trust200902` (standard IETF license).