### PR TITLE
fix: split PR comment into separate workflow for fork PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,7 +11,6 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
 
 jobs:
   ci-gate:
@@ -106,66 +105,14 @@ jobs:
           path: artifacts/diffs/
           retention-days: 30
 
-      - name: Comment on PR
+      - name: Save PR number
         if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        run: echo "${{ github.event.number }}" > artifacts/pr-number.txt
+
+      - name: Upload PR metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            const artifactsDir = 'artifacts';
-            const diffsDir = path.join(artifactsDir, 'diffs');
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            let table = '| Spec | Changed |\n|------|--------|\n';
-
-            const htmlFiles = fs.readdirSync(artifactsDir)
-              .filter(f => f.startsWith('draft-') && f.endsWith('.html'))
-              .sort();
-
-            for (const file of htmlFiles) {
-              const name = file.replace('.html', '');
-              const diffFile = path.join(diffsDir, `${name}-diff.txt`);
-              let changed = '-';
-              if (fs.existsSync(diffFile)) {
-                const content = fs.readFileSync(diffFile, 'utf8');
-                if (content.trim() && !content.includes('New spec')) {
-                  changed = 'Yes';
-                }
-              }
-              table += `| \`${name}\` | ${changed} |\n`;
-            }
-
-            const body = `<!-- ietf-spec-preview -->
-            ## Spec Preview
-
-            ${table}
-
-            **[Download spec artifacts](${runUrl}#artifacts)** (HTML, TXT, XML, PDF)
-            `;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existingComment = comments.find(c => c.body.includes('<!-- ietf-spec-preview -->'));
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
+          name: pr-metadata
+          path: artifacts/pr-number.txt
+          retention-days: 5

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,108 @@
+name: PR Spec Preview Comment
+
+on:
+  workflow_run:
+    workflows: ["Check Specs"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post spec preview
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download PR metadata
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-metadata
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Download spec artifacts
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name_is_regexp: true
+          name: pr-${{ steps.pr.outputs.number }}-.*
+          path: /tmp/pr-artifacts
+        continue-on-error: true
+
+      - name: Comment on PR
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.event.workflow_run.id }}`;
+
+            // Find spec artifacts
+            const specsDir = fs.readdirSync('/tmp/pr-artifacts').find(d => d.includes('specs'));
+            const diffsDir = fs.readdirSync('/tmp/pr-artifacts').find(d => d.includes('diffs'));
+
+            let table = '| Spec | Changed |\n|------|--------|\n';
+
+            if (specsDir) {
+              const specsPath = path.join('/tmp/pr-artifacts', specsDir);
+              const htmlFiles = fs.readdirSync(specsPath)
+                .filter(f => f.startsWith('draft-') && f.endsWith('.html'))
+                .sort();
+
+              for (const file of htmlFiles) {
+                const name = file.replace('.html', '');
+                let changed = '-';
+                if (diffsDir) {
+                  const diffFile = path.join('/tmp/pr-artifacts', diffsDir, `${name}-diff.txt`);
+                  if (fs.existsSync(diffFile)) {
+                    const content = fs.readFileSync(diffFile, 'utf8');
+                    if (content.trim() && !content.includes('New spec')) {
+                      changed = 'Yes';
+                    }
+                  }
+                }
+                table += `| \`${name}\` | ${changed} |\n`;
+              }
+            }
+
+            const body = `<!-- ietf-spec-preview -->
+            ## Spec Preview
+
+            ${table}
+
+            **[Download spec artifacts](${runUrl}#artifacts)** (HTML, TXT, XML, PDF)
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingComment = comments.find(c => c.body.includes('<!-- ietf-spec-preview -->'));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }


### PR DESCRIPTION
Fixes the 403 `Resource not accessible by integration` error when fork PRs trigger the spec preview comment.

## Problem

The `pull_request` event doesn't grant write permissions to fork PRs, so the "Comment on PR" step fails with 403.

## Solution

Split into two workflows:

| Workflow | Trigger | Permissions | Purpose |
|---|---|---|---|
| `pr-check.yml` | `pull_request` | read-only | Build, lint, diff, upload artifacts |
| `pr-comment.yml` | `workflow_run` | `pull-requests: write` | Download artifacts, post preview comment |

The comment workflow runs in the base repo's context after `pr-check` completes, so it has write access even for fork PRs. It never checks out or executes fork code — it only reads uploaded artifacts.

PR number is passed between workflows via a small `pr-metadata` artifact.