### PR TITLE
spec: upgrade hash+feePayer limitation to BCP 14 language

### DIFF
--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -379,8 +379,9 @@ the transaction. The server verifies the transaction onchain:
 
 **Limitations:**
 
-- Cannot be used with `feePayer: true` (client must pay their own fees)
-- Server cannot modify or enhance the transaction
+- Clients MUST NOT use `type="hash"` when `methodDetails.feePayer` is
+  `true`. Servers MUST reject such credentials.
+- Server cannot modify or enhance the transaction.
 
 ## Transaction Verification {#transaction-verification}
 


### PR DESCRIPTION
Upgrades the informal hash settlement limitation from plain text to proper RFC 2119 keywords.

**Before:** "Cannot be used with `feePayer: true` (client must pay their own fees)"

**After:**
- Clients MUST NOT use `type="hash"` when `methodDetails.feePayer` is `true`
- Servers MUST reject such credentials

This makes the rule testable and unambiguous for implementers.