### PR TITLE
feat: Add Sei charge payment method

### DIFF
--- a/specs/methods/sei/draft-sei-charge-00.md
+++ b/specs/methods/sei/draft-sei-charge-00.md
@@ -153,7 +153,7 @@ Supported chain IDs:
 | Chain ID | Network |
 |----------|---------|
 | 1329 | Sei Mainnet |
-| 713715 | Sei Testnet |
+| 1238 | Sei Testnet |
 
 **Example:**
 


### PR DESCRIPTION
Adds payment method spec for Sei, an EVM-compatible L1 with sub-second finality.

Supports the `charge` intent with standard ERC-20 token transfers. Both `hash` and `transaction` credential types supported

Sei chain IDs: 1329 (mainnet), 1328 (testnet)