### PR TITLE
Add escrow intent with PoB and card method bindings

### DIFF
--- a/specs/intents/draft-payment-intent-escrow-00.md
+++ b/specs/intents/draft-payment-intent-escrow-00.md
@@ -1,0 +1,414 @@
+---
+title: '"Escrow" Intent for HTTP Payment Authentication'
+abbrev: Escrow Intent
+docname: draft-payment-intent-escrow-00
+version: 00
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Ryuji Ishiguro
+    ins: R. Ishiguro
+    email: r2ishiguro@gmail.com
+
+normative:
+  RFC2119:
+  RFC4648:
+  RFC8174:
+  RFC8259:
+  RFC8785:
+  RFC9457:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+
+informative:
+  MPP-CHARGE:
+    title: "Charge Intent for HTTP Payment Authentication"
+    target: https://github.com/tempoxyz/mpp-specs/blob/main/specs/intents/draft-payment-intent-charge-00.md
+    author:
+      - name: Jake Moxey
+      - name: Brendan Ryan
+      - name: Tom Meagher
+    date: 2026-03
+  EMV-PREAUTH:
+    title: "EMV Contactless Specifications for Payment Systems"
+    target: https://www.emvco.com/emv-technologies/contactless/
+    author:
+      - org: EMVCo
+    date: 2023
+---
+
+--- abstract
+
+This document defines the "escrow" payment intent for use with the
+Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. The
+"escrow" intent represents a two-phase payment where the payer first
+places a hold on funds up to a maximum amount, and the merchant later
+settles or releases that hold when the final amount is known.
+
+--- middle
+
+# Introduction
+
+The "charge" intent {{MPP-CHARGE}} covers immediate, one-time payment
+for resource access. Some services cannot determine the final amount
+at authorization time. A parking session may end early, a fueling
+transaction depends on dispensed volume, and a metered compute job
+depends on resources actually consumed.
+
+The "escrow" intent addresses those cases by separating payment into
+two phases:
+
+- A **hold** phase, where funds are reserved up to a maximum amount.
+- A **settlement** phase, where the merchant later settles the final
+  amount or releases the hold in full.
+
+This pattern is well established in traditional payment systems as
+preauthorization and capture {{EMV-PREAUTH}}. The "escrow" intent
+brings the same semantics to HTTP-native machine payments.
+
+## Use Cases
+
+- **Parking**: An agent authorizes a hold for a maximum parking
+  duration. When the vehicle departs, the operator settles the actual
+  amount and releases any remainder.
+- **Fueling**: A fueling service authorizes a hold before pump access.
+  The operator later settles the final dispensed amount.
+- **Metered compute**: A scheduler places a hold before a job starts
+  and later settles based on measured resource usage.
+- **Reservations with cancellation**: A booking service places a hold
+  at reservation time and later either settles or releases it.
+
+## Relationship to Payment Methods
+
+This document defines the abstract semantics of the "escrow" intent.
+Payment method specifications define how to implement the hold,
+settle, and release phases using their own payment infrastructure.
+
+| Method | Example Implementation |
+|--------|------------------------|
+| Smart-contract method | Hold through an escrow contract, settle or release with later contract calls |
+| Card method | Preauthorize through a processor, then capture or reverse later |
+| Custodial method | Lock balance in an internal ledger, then transfer or unlock later |
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+Hold
+: An operation that reserves funds up to a maximum amount. The funds
+  are locked and unavailable to the payer but not yet transferred to
+  the merchant.
+
+Settle
+: An operation where the merchant captures a final amount less than
+  or equal to the held amount. Any remainder is returned to the
+  payer.
+
+Release
+: An operation where the full held amount is returned to the payer
+  without any settlement. This is the escrow equivalent of voiding
+  a preauthorization.
+
+Hold Identifier
+: A method-specific value that uniquely identifies a held balance.
+  Used to associate a Payment credential with later settlement or
+  release operations.
+
+# Intent Semantics
+
+## Definition
+
+The "escrow" intent represents a request to reserve funds up to a
+maximum amount, with final settlement or release occurring after the
+HTTP 402 exchange completes. The 402 exchange authorizes the hold
+only; it does not itself imply final settlement.
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| Intent Identifier | `escrow` |
+| Payment Timing | Deferred |
+| Idempotency | Single-use per challenge |
+| Reversibility | Full release before settlement |
+
+## Flow {#escrow-flow}
+
+~~~
+ Client           Server          Merchant       Network
+   |                 |                |              |
+   | (1) POST        |                |              |
+   |---------------->|                |              |
+   |                 |                |              |
+   | (2) 402         |                |              |
+   |  intent=escrow  |                |              |
+   |<----------------|                |              |
+   |                 |                |              |
+   | (3) Create hold |                |              |
+   |------------------------------------------------>|
+   |                 |                |              |
+   | (4) POST +cred  |                |              |
+   |---------------->|                |              |
+   |                 | (5) Verify     |              |
+   |                 |------------------------------>|
+   |                 |                |              |
+   | (6) 200 OK      |                |              |
+   |  + Receipt      |                |              |
+   |<----------------|                |              |
+   |                 |                |              |
+   |                 |  (7) settle or release later  |
+   |                 |                |------------->|
+~~~
+
+## Atomicity and Compensating Actions
+
+The "escrow" intent does NOT imply atomic exchange between hold
+verification and service delivery. The hold guarantees fund
+reservation; service delivery and final settlement are separate
+operations. Servers SHOULD implement compensating actions, such as
+release, if service delivery fails after a hold has been verified.
+
+## Hold Expiry
+
+Payment method specifications MUST define how holds expire or
+otherwise become reclaimable by the payer. Challenge lifetime
+(the `expires` parameter in the Payment challenge) and hold lifetime
+are separate concerns. A challenge may expire in minutes while the
+hold persists for hours or days.
+
+# Request Schema
+
+The `request` parameter for an "escrow" intent MUST contain a
+JCS-canonicalized {{RFC8785}}, base64url-encoded {{RFC4648}} JSON
+object {{RFC8259}} with the following fields.
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `amount` | string | Maximum hold amount in base units |
+| `currency` | string | Currency or asset identifier |
+| `recipient` | string | Settlement recipient in method-native format |
+
+The `amount` field represents the maximum amount that MAY later be
+settled, not the final charge.
+
+## Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | Human-readable purpose (max 256 UTF-8 bytes) |
+| `externalId` | string | Merchant reference such as order or session ID (max 566 bytes) |
+| `methodDetails` | object | Payment method-specific extension data |
+
+Payment method specifications MAY define additional fields inside
+`methodDetails`, such as hold deadlines, settlement authority, or
+fee handling rules.
+
+## Example
+
+~~~json
+{
+  "amount": "5000000",
+  "currency": "0x20c0000000000000000000000000000000000000",
+  "recipient":
+    "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+  "description": "Parking hold — up to $5.00",
+  "externalId": "parking_session_42",
+  "methodDetails": {
+    "chainId": 42431,
+    "escrowContract":
+      "0x1111111111111111111111111111111111111111",
+    "decimals": 6
+  }
+}
+~~~
+
+# Credential Requirements
+
+## Payload
+
+The credential `payload` for an "escrow" intent MUST contain proof
+that a hold has been created or authorized. The exact proof format
+is defined by the payment method specification.
+
+## Proof Types
+
+Acceptable proof types are method-specific.
+
+| Proof Type | Description | Example Methods |
+|------------|-------------|-----------------|
+| Signed transaction | Signed hold transaction for server broadcast | Smart-contract methods |
+| Transaction hash | Hash of a confirmed on-chain hold | Smart-contract methods |
+| Authorization reference | Processor preauthorization reference | Card methods |
+| Internal confirmation | Custodial hold confirmation | Custodial methods |
+
+## Reusability and Validity
+
+Each credential MUST be usable only once per challenge. Servers MUST
+reject replayed credentials. Servers MUST also prevent a single hold
+identifier from being accepted as proof for multiple independent
+challenges.
+
+# Verification
+
+## Server Responsibilities
+
+Servers verifying an "escrow" credential MUST:
+
+1. Verify the `id` matches an outstanding challenge.
+2. Verify the challenge has not expired.
+3. Verify the hold proof using method-specific procedures.
+4. Verify the held amount is greater than or equal to the requested
+   `amount`.
+5. Verify the hold recipient matches the requested `recipient`.
+6. Verify the hold is active and has not already been settled,
+   released, or expired.
+7. Record the hold identifier so it can be associated with later
+   settlement or release.
+
+When verification fails, the server MUST respond with 402 and a
+fresh challenge. The response body SHOULD contain a Problem Details
+object {{RFC9457}}.
+
+## Settlement
+
+Settlement occurs outside the 402 challenge-response flow. The
+merchant backend, or another merchant-authorized settlement
+component, MUST settle or release every successfully verified hold.
+
+The final settled amount MUST be less than or equal to the held
+amount. Payment method specifications MUST document:
+
+- Whether partial settlement is supported.
+- How release works when funds remain unused.
+- How settlement and release requests are authenticated.
+- How retries are made idempotent.
+
+The `Payment-Receipt` returned after successful verification
+indicates that the hold was accepted. It does not imply that final
+settlement has already occurred.
+
+## Receipt
+
+The `Payment-Receipt` header for an escrow intent SHOULD include
+a hold identifier that the merchant backend can use for later
+settlement or release. The receipt structure follows
+{{I-D.httpauth-payment}} with the addition of method-specific
+fields for the hold reference.
+
+# Security Considerations
+
+## Hold Amount Manipulation
+
+Clients MUST verify the requested `amount` is appropriate before
+authorizing a hold. Malicious servers could request excessive holds
+to lock payer funds.
+
+## Replay Protection
+
+Servers MUST implement replay protection for both challenge IDs and
+hold identifiers. A single hold MUST NOT authorize access to
+multiple independent requests.
+
+## Stale Holds and Settlement Races
+
+Payment method specifications MUST define how stale holds expire or
+become reclaimable. They MUST also define atomic settlement
+semantics so that settle and release cannot both succeed for the
+same hold.
+
+## Recipient and Currency Verification
+
+Clients SHOULD verify the `recipient` and `currency` fields before
+authorizing a hold. Malicious servers could request a hold for an
+unexpected recipient or asset.
+
+## Finality
+
+The finality of a verified hold depends on the payment method.
+Servers SHOULD understand the finality guarantees of accepted
+methods before granting access to high-value or irreversible
+operations.
+
+## Agent Authorization Scope
+
+When autonomous agents hold funds on behalf of users, their
+authority SHOULD be bounded by policy, including maximum hold size,
+aggregate exposure, permitted recipients, and hold duration limits.
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP
+Payment Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Description | Reference |
+|--------|-------------|-----------|
+| `escrow` | Two-phase hold-then-settle payment | This document |
+
+--- back
+
+# Comparison with Other Intents
+
+| Property | Charge | Session | Escrow |
+|----------|--------|---------|--------|
+| Final amount known at 402 time | Yes | Per-unit | No |
+| Payment timing | Immediate | Streaming | Deferred |
+| Reversibility | None | Partial refund | Full release |
+| Settlement actor | Server (at 402 time) | Server (periodic) | Merchant (later) |
+| Typical use | API call, download | Metered streaming | Parking, fueling, reservation |
+
+# Implementation Guidance
+
+## For Payment Method Authors
+
+When defining an escrow binding for a payment method, the method
+specification MUST address:
+
+1. How the hold is created (transaction, API call, ledger lock).
+2. How the server verifies the hold is active and matches the
+   challenge parameters.
+3. How the hold identifier is communicated in the receipt.
+4. How settle and release are authorized and authenticated.
+5. How holds expire or become reclaimable.
+6. Whether partial settlement is supported.
+7. Replay protection for hold identifiers.
+
+## For Server Implementers
+
+Servers SHOULD:
+
+- Set `holdExpiry` (or equivalent) in `methodDetails` to communicate
+  the expected service window.
+- Implement a background process to release stale holds that were
+  never settled.
+- Log all hold, settle, and release events for audit and dispute
+  resolution.
+
+## For Client and Agent Implementers
+
+Clients and agents SHOULD:
+
+- Enforce a maximum acceptable hold amount per service category.
+- Enforce a maximum acceptable hold duration.
+- Track aggregate held funds across all active holds.
+- Alert the user or operator when policy limits are approached.
+
+# Acknowledgements
+
+The HTTP Payment Authentication Scheme and the intent-method
+layering model are defined by the MPP specifications at
+paymentauth.org. The escrow pattern draws from EMV
+preauthorization and capture semantics used in traditional payment
+card networks.

--- a/specs/methods/card/draft-card-escrow-00.md
+++ b/specs/methods/card/draft-card-escrow-00.md
@@ -164,13 +164,19 @@ The shared fields are identical to those in {{I-D.card-charge}}:
 |-------|------|----------|-------------|
 | `amount` | string | REQUIRED | Maximum preauthorization amount in smallest currency unit |
 | `currency` | string | REQUIRED | ISO 4217 code, lowercase |
-| `recipient` | string | OPTIONAL | Merchant identifier at the Server Enabler |
+| `recipient` | string | REQUIRED | Merchant identifier at the Server Enabler (e.g. processor merchant ID, `acct_` reference) |
 | `description` | string | OPTIONAL | Human-readable description of the hold |
 | `externalId` | string | OPTIONAL | Merchant reference |
 
 The `amount` field represents the maximum hold, not the final
 charge. Clients SHOULD verify the amount is reasonable before
 authorizing.
+
+The `recipient` field identifies the merchant account that will
+receive captured funds. For card payments this is typically a
+processor merchant ID or platform account reference. Clients
+SHOULD verify the recipient matches the expected merchant before
+authorizing a hold.
 
 ## Method Details
 

--- a/specs/methods/card/draft-card-escrow-00.md
+++ b/specs/methods/card/draft-card-escrow-00.md
@@ -1,0 +1,596 @@
+---
+title: Card Network Escrow Intent for HTTP Payment Authentication
+abbrev: Card Escrow
+docname: draft-card-escrow-00
+version: 00
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Ryuji Ishiguro
+    ins: R. Ishiguro
+    email: r2ishiguro@gmail.com
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC4648:
+  RFC7516:
+  RFC7517:
+  RFC8174:
+  RFC8259:
+  RFC9457:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+  I-D.payment-intent-escrow:
+    title: "'Escrow' Intent for HTTP Payment Authentication"
+    target: https://github.com/tempoxyz/mpp-specs
+    author:
+      - name: Ryuji Ishiguro
+    date: 2026-03
+  I-D.card-charge:
+    title: "Card Network Charge Intent for HTTP Payment Authentication"
+    target: https://github.com/tempoxyz/mpp-specs
+    author:
+      - name: Jacob Brans
+    date: 2026-03
+
+---
+
+--- abstract
+
+This document defines the "card" payment method's implementation of
+the "escrow" intent within the Payment HTTP Authentication Scheme
+{{I-D.httpauth-payment}}. It specifies how clients and servers
+exchange card preauthorizations as escrow holds, with subsequent
+capture or void operations mapping to settlement and release.
+
+--- middle
+
+# Introduction
+
+The card charge specification {{I-D.card-charge}} defines one-time
+card payments where the full amount is captured immediately. Many
+services cannot determine the final charge at authorization time.
+A parking session depends on departure time. A fueling transaction
+depends on the amount dispensed. A hotel stay may include incidental
+charges.
+
+The "escrow" intent {{I-D.payment-intent-escrow}} addresses those
+cases by separating payment into a hold phase and a settlement
+phase. This document specifies how to implement the escrow intent
+using standard card network preauthorization, capture, and void
+operations.
+
+Card preauthorization and capture is one of the oldest payment
+patterns in electronic commerce. Every major card processor already
+supports these operations through existing APIs. This specification
+defines how to surface that functionality through the MPP 402
+challenge-response flow.
+
+## Card Escrow Flow
+
+The card escrow flow proceeds in two stages.
+
+**Hold stage** (within the 402 exchange):
+
+1. Client requests a resource without credentials.
+2. Server responds with 402 and a Payment challenge containing the
+   maximum hold amount, currency, accepted networks, and
+   encryption key.
+3. Client forwards the challenge to its Client Enabler (CE).
+4. CE provisions a network token and cryptogram, encrypts the
+   result with the server's key, and returns the credential.
+5. Client resubmits the request with a Payment credential.
+6. Server Enabler submits a preauthorization (not a charge) to
+   the card network for the hold amount.
+7. Server returns 200 with a Payment-Receipt containing the
+   preauthorization reference.
+
+**Settlement stage** (out of band, after service delivery):
+
+8. Merchant captures the final amount against the preauthorization
+   (settle). The capture amount MUST be less than or equal to
+   the preauthorized amount.
+9. Alternatively, the merchant voids the preauthorization
+   (release) to return the full hold to the cardholder.
+
+## Relationship to Other Specifications
+
+This document is a method-specific binding of the abstract escrow
+intent defined in {{I-D.payment-intent-escrow}}. It inherits the
+intent semantics, flow, and security requirements from that
+specification.
+
+This document reuses the credential format, encryption scheme,
+Client Enabler profile, and verification procedures defined in the
+card charge specification {{I-D.card-charge}}. The key differences
+are:
+
+- The `intent` field is `"escrow"` instead of `"charge"`.
+- The Server Enabler submits a preauthorization instead of a
+  charge.
+- Settlement (capture) and release (void) occur out of band.
+- The receipt includes a preauthorization reference for later
+  capture or void.
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+This document inherits all terminology from {{I-D.card-charge}}
+including Payment Data, Client Enabler, Server Enabler, Payment
+Service Provider, Network Token, and Cryptogram.
+
+The following additional terms apply:
+
+Preauthorization
+: A card network authorization that reserves funds on the
+  cardholder's account without capturing them. The hold reduces
+  the cardholder's available credit or balance. Also known as an
+  "auth-only" transaction.
+
+Capture
+: A subsequent request to the card network to collect funds
+  against a prior preauthorization. The capture amount MUST be
+  less than or equal to the preauthorized amount. Partial capture
+  is supported by most processors.
+
+Void
+: A request to cancel a preauthorization before capture. The
+  hold is removed and the cardholder's available balance is
+  restored. Also known as an "authorization reversal."
+
+# Request Schema
+
+The server issues an HTTP 402 response with a WWW-Authenticate:
+Payment header per {{I-D.httpauth-payment}}. The request parameter
+is a base64url-encoded {{RFC4648}} JSON object {{RFC8259}} using
+JCS canonicalization.
+
+## Shared Fields
+
+The shared fields are identical to those in {{I-D.card-charge}}:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | string | REQUIRED | Maximum preauthorization amount in smallest currency unit |
+| `currency` | string | REQUIRED | ISO 4217 code, lowercase |
+| `recipient` | string | OPTIONAL | Merchant identifier at the Server Enabler |
+| `description` | string | OPTIONAL | Human-readable description of the hold |
+| `externalId` | string | OPTIONAL | Merchant reference |
+
+The `amount` field represents the maximum hold, not the final
+charge. Clients SHOULD verify the amount is reasonable before
+authorizing.
+
+## Method Details
+
+The `methodDetails` fields are identical to those in
+{{I-D.card-charge}}:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `acceptedNetworks` | array | REQUIRED | Card networks accepted |
+| `merchantName` | string | REQUIRED | Human-readable merchant name |
+| `encryptionJwk` | object | CONDIT. | Embedded JWK {{RFC7517}} with RSA public key |
+| `jwksUri` | string | OPTIONAL | HTTPS URI of a JWK Set |
+| `kid` | string | CONDIT. | Key ID for JWKS lookup |
+| `billingRequired` | boolean | OPTIONAL | Whether billing info is needed |
+
+The following field is added for the escrow intent:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `holdExpiry` | string | OPTIONAL | {{RFC3339}} timestamp indicating when the preauthorization may expire |
+
+Card network preauthorizations typically expire after 7 days for
+most merchant category codes. The `holdExpiry` field communicates
+the expected hold window to the client. Clients SHOULD reject
+challenges where `holdExpiry` exceeds their policy maximum.
+
+Encryption key resolution follows the same procedure defined in
+{{I-D.card-charge}}.
+
+## Example
+
+~~~ json
+{
+  "amount": "15000",
+  "currency": "usd",
+  "recipient": "merch_fuel_456",
+  "description": "Fuel pump preauthorization",
+  "externalId": "pump_session_789",
+  "methodDetails": {
+    "acceptedNetworks": ["visa", "mastercard"],
+    "merchantName": "FuelCo Station #42",
+    "encryptionJwk": {
+      "kty": "RSA",
+      "kid": "enc-2026-03",
+      "use": "enc",
+      "alg": "RSA-OAEP-256",
+      "n": "0vx7agoebGcQSuu...",
+      "e": "AQAB"
+    },
+    "holdExpiry": "2026-04-02T14:00:00Z"
+  }
+}
+~~~
+
+# Credential Schema
+
+The credential format is identical to {{I-D.card-charge}}. The
+client obtains an encrypted network token from its Client Enabler
+and submits it in an Authorization: Payment header.
+
+## Credential Structure
+
+The decoded credential follows the standard MPP format:
+
+~~~ json
+{
+  "challenge": {
+    "id": "ch_F2kL9mN4xR7q",
+    "realm": "api.fuelco.example.com",
+    "method": "card",
+    "intent": "escrow",
+    "request": "eyJhbW91bnQiOiIxNTAwMCIs...",
+    "expires": "2026-03-26T14:10:00Z"
+  },
+  "payload": {
+    "encryptedPayload": "<JWE compact serialization>",
+    "network": "visa",
+    "panLastFour": "4242",
+    "panExpirationMonth": "06",
+    "panExpirationYear": "2028"
+  }
+}
+~~~
+
+The `challenge.intent` field MUST be `"escrow"`. The `payload`
+fields are identical to those defined in {{I-D.card-charge}}.
+
+# Verification Procedure
+
+The verification procedure follows {{I-D.card-charge}} with one
+critical difference: the Server Enabler submits a
+**preauthorization** (auth-only) instead of a charge.
+
+1. Decode the credential: base64url-decode the token from the
+   Authorization: Payment header and parse as JSON.
+
+2. Verify challenge binding: confirm `challenge.id` matches an
+   outstanding challenge issued by this server.
+
+3. Verify the challenge has not expired.
+
+4. Verify the method: confirm `challenge.method` equals `"card"`.
+
+5. Verify the intent: confirm `challenge.intent` equals
+   `"escrow"`.
+
+6. Verify network acceptance: confirm `payload.network` is in the
+   `acceptedNetworks` list from methodDetails.
+
+7. Reject replays: confirm this `challenge.id` has not been
+   previously fulfilled. Mark it as consumed.
+
+8. Forward the credential to the Server Enabler for
+   **preauthorization** (not capture). The Server Enabler
+   decrypts the JWE {{RFC7516}} using the corresponding private
+   key and submits an auth-only request to the card network.
+
+9. Verify the preauthorization was approved by the issuing bank.
+
+10. Record the preauthorization reference for later capture or
+    void.
+
+If the preauthorization is declined, the server MUST return 402
+with a fresh challenge and a Problem Details {{RFC9457}} response
+body.
+
+## Error Responses
+
+| type suffix | Condition |
+|-------------|-----------|
+| `malformed-credential` | Credential cannot be decoded or is missing fields |
+| `invalid-challenge` | Challenge ID is unknown, expired, or consumed |
+| `network-declined` | Issuing bank declined the preauthorization |
+| `verification-failed` | Credential verification failed |
+
+## Receipt Generation
+
+Upon successful preauthorization, the server MUST return a
+`Payment-Receipt` header per {{I-D.httpauth-payment}}.
+
+~~~ json
+{
+  "method": "card",
+  "intent": "escrow",
+  "challengeId": "ch_F2kL9mN4xR7q",
+  "status": "success",
+  "timestamp": "2026-03-26T14:05:30Z",
+  "reference": "preauth_visa_xyz789",
+  "externalId": "pump_session_789",
+  "holdAmount": "15000",
+  "holdCurrency": "usd"
+}
+~~~
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `method` | string | REQUIRED | `"card"` |
+| `intent` | string | REQUIRED | `"escrow"` |
+| `challengeId` | string | REQUIRED | The challenge ID that was fulfilled |
+| `status` | string | REQUIRED | `"success"` |
+| `timestamp` | string | REQUIRED | {{RFC3339}} timestamp of the preauthorization |
+| `reference` | string | REQUIRED | Preauthorization reference from the Server Enabler |
+| `externalId` | string | OPTIONAL | Echo of `externalId` from the request |
+| `holdAmount` | string | OPTIONAL | Preauthorized amount in base units |
+| `holdCurrency` | string | OPTIONAL | ISO 4217 currency code |
+
+The `reference` field is the preauthorization identifier that the
+merchant backend uses for later capture or void operations.
+
+# Settlement Procedure
+
+Settlement occurs outside the HTTP 402 flow. The merchant backend
+communicates directly with its Server Enabler (PSP) using the
+preauthorization reference from the receipt.
+
+## Capture (Settle)
+
+The merchant submits a capture request to the Server Enabler:
+
+- The `reference` from the receipt identifies the preauthorization.
+- The capture `amount` MUST be less than or equal to the
+  preauthorized `holdAmount`.
+- Partial capture is supported: the merchant captures only the
+  final amount and the remainder is automatically released by the
+  card network.
+
+Most card processors expose capture as a single API call:
+
+~~~
+POST /v1/payments/{reference}/capture
+{
+  "amount": "3247"
+}
+~~~
+
+The Server Enabler submits the capture to the card network. Upon
+success, the captured amount is transferred from the cardholder to
+the merchant during the next settlement cycle (typically 1-2
+business days).
+
+## Void (Release)
+
+If the merchant does not need to capture any amount, it submits a
+void (authorization reversal):
+
+~~~
+POST /v1/payments/{reference}/void
+~~~
+
+The Server Enabler submits the reversal to the card network. The
+hold is removed from the cardholder's account immediately (or
+within the network's processing window).
+
+## Timing Constraints
+
+Card network preauthorizations have limited lifetimes:
+
+- Most merchant category codes: 7 days
+- Hotels and car rentals: up to 31 days
+- Some processors allow extensions
+
+If the merchant does not capture within the preauthorization
+window, the hold expires automatically and the funds are returned
+to the cardholder. The capture will fail.
+
+Merchants MUST capture or void within the preauthorization window.
+The `holdExpiry` field in `methodDetails` communicates this window
+to the client.
+
+## Idempotency
+
+Capture and void are idempotent at the processor level. A second
+capture request for the same preauthorization reference returns the
+same result. A void after capture fails. A capture after void
+fails. These are standard card network semantics.
+
+## Capture and Void Are Mutually Exclusive
+
+A preauthorization can be either captured or voided, but not both.
+Attempting to void a captured preauthorization will fail.
+Attempting to capture a voided preauthorization will fail. This
+satisfies the atomicity requirement of
+{{I-D.payment-intent-escrow}}.
+
+# Security Considerations
+
+## Transport Security
+
+All MPP exchanges MUST occur over TLS 1.2 or higher (TLS 1.3
+recommended). Plain HTTP MUST be rejected. This requirement is
+inherited from {{I-D.httpauth-payment}} and {{I-D.card-charge}}.
+
+## Credential Security
+
+The credential format, encryption scheme, and key management
+requirements are identical to {{I-D.card-charge}}. The
+`encryptedPayload` is a JWE {{RFC7516}} compact serialization
+encrypted with RSA-OAEP-256 and AES-256-GCM. Only the Server
+Enabler can decrypt it.
+
+## Hold Amount Verification
+
+Clients MUST verify the requested `amount` is appropriate before
+authorizing a preauthorization. Malicious servers could request
+excessive holds that reduce the cardholder's available credit.
+Client Enablers and agents SHOULD enforce per-transaction and
+aggregate hold limits.
+
+## Preauthorization Expiry
+
+Unlike on-chain escrow contracts, card preauthorizations expire
+according to card network rules, not a field in the challenge.
+The `holdExpiry` field is advisory. Merchants MUST NOT rely on the
+hold persisting beyond the network's standard authorization
+window. If the hold expires before capture, the merchant loses the
+ability to collect payment.
+
+## Capture Authorization
+
+Capture requests are authenticated between the merchant and its
+Server Enabler (PSP) using the PSP's standard API authentication.
+The preauthorization reference is not a bearer token — knowing the
+reference alone is not sufficient to capture funds. The PSP
+verifies that the capture request comes from the merchant
+associated with the original preauthorization.
+
+## Replay Protection
+
+Per {{I-D.payment-intent-escrow}}, each credential MUST be usable
+only once per challenge. Servers MUST track consumed challenge IDs.
+The card network provides additional replay protection: a
+cryptogram can only be used for one authorization.
+
+## Billing Data Handling
+
+The billing data handling requirements from {{I-D.card-charge}}
+apply equally to the escrow intent. Billing information,
+`cardholderFullName`, and `paymentAccountReference` are PII and
+SHOULD be handled in accordance with applicable privacy
+regulations.
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP
+Payment Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|--------|-------------------|-------------|-----------|
+| `escrow` | `card` | Card preauthorization with deferred capture | This document, {{I-D.payment-intent-escrow}} |
+
+--- back
+
+# ABNF Collected
+
+~~~abnf
+card-escrow-challenge = "Payment" 1*SP
+  "id=" quoted-string ","
+  "realm=" quoted-string ","
+  "method=" DQUOTE "card" DQUOTE ","
+  "intent=" DQUOTE "escrow" DQUOTE ","
+  "request=" base64url-nopad
+  [ "," "expires=" quoted-string ]
+
+card-escrow-credential = "Payment" 1*SP base64url-nopad
+
+; Base64url encoding without padding per RFC 4648 Section 5
+base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
+~~~
+
+# Example
+
+## Fueling Example
+
+**Step 1: Client requests pump access**
+
+~~~ http
+POST /api/pump/unlock HTTP/1.1
+Host: api.fuelco.example.com
+Content-Type: application/json
+
+{"pumpId": "7", "vehicleId": "ABC-1234"}
+~~~
+
+**Step 2: Server issues escrow challenge**
+
+~~~ http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment
+  id="ch_F2kL9mN4xR7q",
+  realm="api.fuelco.example.com",
+  method="card",
+  intent="escrow",
+  expires="2026-03-26T14:10:00Z",
+  request="eyJhbW91bnQiOiIxNTAwMCIsImN1cnJlbmN5Ijoi
+    dXNkIiwicmVjaXBpZW50IjoibWVyY2hfZnVlbF80NTYiLC
+    JkZXNjcmlwdGlvbiI6IkZ1ZWwgcHVtcCBwcmVhdXRob3Jp
+    emF0aW9uIiwiZXh0ZXJuYWxJZCI6InB1bXBfc2Vzc2lvbl
+    83ODkiLCJtZXRob2REZXRhaWxzIjp7ImFjY2VwdGVkTmV0
+    d29ya3MiOlsidmlzYSIsIm1hc3RlcmNhcmQiXSwibWVyY2
+    hhbnROYW1lIjoiRnVlbENvIFN0YXRpb24gIzQyIn19"
+Cache-Control: no-store
+Content-Type: application/problem+json
+
+{"type": "about:blank", "title": "Payment Required", "status": 402}
+~~~
+
+**Step 3: Client obtains credential and retries**
+
+~~~ http
+POST /api/pump/unlock HTTP/1.1
+Host: api.fuelco.example.com
+Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJjaF9G
+  MmtMOW1ONHhSN3EiLCJyZWFsbSI6ImFwaS5mdWVsY28uZXhh
+  bXBsZS5jb20iLCJtZXRob2QiOiJjYXJkIiwiaW50ZW50Ijoi
+  ZXNjcm93In0sInBheWxvYWQiOnsiZW5jcnlwdGVkUGF5bG9h
+  ZCI6IjxKV0UgY29tcGFjdD4iLCJuZXR3b3JrIjoidmlzYSIs
+  InBhbkxhc3RGb3VyIjoiNDI0MiJ9fQ
+Content-Type: application/json
+
+{"pumpId": "7", "vehicleId": "ABC-1234"}
+~~~
+
+**Step 4: Server preauthorizes and unlocks pump**
+
+~~~ http
+HTTP/1.1 200 OK
+Payment-Receipt: eyJtZXRob2QiOiJjYXJkIiwiaW50ZW50Ijoi
+  ZXNjcm93IiwiY2hhbGxlbmdlSWQiOiJjaF9GMmtMOW1ONHhS
+  N3EiLCJzdGF0dXMiOiJzdWNjZXNzIiwidGltZXN0YW1wIjoiMj
+  AyNi0wMy0yNlQxNDowNTozMFoiLCJyZWZlcmVuY2UiOiJwcm
+  VhdXRoX3Zpc2FfeHl6Nzg5In0
+Cache-Control: private
+Content-Type: application/json
+
+{"pumpId": "7", "status": "unlocked", "maxAmount": "$150.00"}
+~~~
+
+**Step 5: Customer fuels, merchant captures actual amount**
+
+After the customer finishes fueling ($47.23 dispensed), the
+merchant backend captures the actual amount:
+
+~~~
+POST /v1/payments/preauth_visa_xyz789/capture
+Host: api.psp.example.com
+Authorization: Bearer <psp_api_key>
+Content-Type: application/json
+
+{"amount": "4723"}
+~~~
+
+The remaining $102.77 hold is automatically released by the
+card network.
+
+# Acknowledgements
+
+The card charge specification {{I-D.card-charge}} defines the
+credential format, encryption scheme, and Client Enabler profile
+reused in this document. The escrow intent
+{{I-D.payment-intent-escrow}} defines the abstract hold, settle,
+and release semantics implemented here.

--- a/specs/methods/pob/draft-pob-escrow-00.md
+++ b/specs/methods/pob/draft-pob-escrow-00.md
@@ -1,0 +1,815 @@
+---
+title: PoB Escrow Intent for HTTP Payment Authentication
+abbrev: PoB Escrow
+docname: draft-pob-escrow-00
+version: 00
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Ryuji Ishiguro
+    ins: R. Ishiguro
+    email: r2ishiguro@gmail.com
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC4648:
+  RFC8174:
+  RFC8259:
+  RFC8785:
+  RFC9457:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+  I-D.payment-intent-escrow:
+    title: "'Escrow' Intent for HTTP Payment Authentication"
+    target: https://github.com/tempoxyz/mpp-specs
+    author:
+      - name: Ryuji Ishiguro
+    date: 2026-03
+
+informative:
+  EIP-20:
+    title: "Token Standard"
+    target: https://eips.ethereum.org/EIPS/eip-20
+    author:
+      - name: Fabian Vogelsteller
+      - name: Vitalik Buterin
+    date: 2015-11
+  EIP-55:
+    title: "Mixed-case checksum address encoding"
+    target: https://eips.ethereum.org/EIPS/eip-55
+    author:
+      - name: Vitalik Buterin
+    date: 2016-01
+  EIP-155:
+    title: "Simple replay attack protection"
+    target: https://eips.ethereum.org/EIPS/eip-155
+    author:
+      - name: Vitalik Buterin
+    date: 2016-11
+---
+
+--- abstract
+
+This document specifies the "escrow" intent for the "pob" payment
+method within the Payment HTTP Authentication Scheme
+{{I-D.httpauth-payment}}. It enables gating access to HTTP resources
+behind escrow-based payments using PoBERC20 tokens on a
+Proof-of-Balance (PoB) blockchain.
+
+The client places a hold on funds through an on-chain escrow contract.
+The server verifies the hold and grants access. The merchant later
+settles or releases the held funds when the final amount is known.
+This pattern maps to preauthorization and capture in traditional
+payment systems and is intended for autonomous machine-to-machine
+payments where the final cost is not known at authorization time.
+
+--- middle
+
+# Introduction
+
+The "charge" intent covers one-time payments where the final amount
+is known at authorization time. Many real-world services cannot
+determine the final price when access is first requested. A parking
+session depends on departure time. A fueling transaction depends on
+the amount dispensed. A metered compute job depends on resources
+consumed.
+
+The "escrow" intent {{I-D.payment-intent-escrow}} addresses those
+cases by splitting payment into a hold phase and a settlement phase.
+This document specifies how to implement the escrow intent using
+PoBERC20 tokens and the MerchantBase escrow contract on a PoB chain.
+
+## Escrow Flow
+
+The PoB escrow flow proceeds in two stages.
+
+**Hold stage** (within the 402 exchange):
+
+1. Client requests a resource without credentials.
+2. Server responds with 402 and a Payment challenge containing the
+   hold amount, merchant contract, and merchant wallet.
+3. Client calls `approve()` on the PoBERC20Escrow token to grant
+   the merchant contract a spending allowance.
+4. Client calls `hold()` on the MerchantBase contract to create
+   the escrow.
+5. Client resubmits the request with a Payment credential
+   containing proof of the hold.
+6. Server verifies the hold on-chain via `getHeldBalance()` and
+   returns 200 with a Payment-Receipt.
+
+**Settlement stage** (out of band, after service delivery):
+
+7. Merchant calls `settle(txId, finalAmount)` on the MerchantBase
+   contract to capture the actual charge and refund the remainder.
+   Alternatively, the merchant calls `release(txId)` to return all
+   held funds to the customer.
+
+## Relationship to the Escrow Intent
+
+This document is a method-specific binding of the abstract escrow
+intent defined in {{I-D.payment-intent-escrow}}. It inherits the
+intent semantics, flow, and security requirements from that
+specification and adds PoB-specific request schemas, credential
+payloads, verification procedures, and settlement mechanics.
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+PoBERC20
+: An ERC-20 compatible token {{EIP-20}} on a PoB chain. Each token
+  transfer is accompanied by a zero-knowledge Proof of Balance that
+  proves the sender has sufficient funds without revealing the
+  actual balance.
+
+PoBERC20Escrow
+: A PoBERC20 token contract extended with escrow capabilities. It
+  provides `hold`, `settle`, and `release` operations and maintains
+  a mapping from transaction identifiers to held balances.
+
+MerchantBase
+: An abstract smart contract deployed by a merchant that wraps
+  PoBERC20Escrow calls. It generates transaction identifiers,
+  enforces settlement authorization, and applies merchant-specific
+  reward and fee calculations.
+
+Transaction Identifier (txId)
+: A `bytes32` value derived from `keccak256(abi.encodePacked(
+  msg.sender, block.timestamp, block.number))` at hold time. It
+  uniquely identifies a held balance for later settlement or
+  release.
+
+Hold
+: An on-chain escrow operation that transfers tokens from the
+  customer to the escrow contract and records the held balance,
+  merchant wallet, merchant owner, and customer address.
+
+Settle
+: An on-chain operation where the merchant wallet captures a final
+  amount less than or equal to the held amount. The contract
+  distributes funds to the merchant wallet, merchant owner (reward),
+  and fee wallet, and refunds any remainder to the customer.
+
+Release
+: An on-chain operation where the merchant owner returns all held
+  funds to the customer without settlement.
+
+# Request Schema
+
+The `request` auth-param in the Payment challenge MUST contain a
+JCS-canonicalized {{RFC8785}}, base64url-encoded {{RFC4648}} JSON
+object {{RFC8259}} with the following fields.
+
+## Shared Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | string | Yes | Maximum hold amount in base units |
+| `currency` | string | Yes | EIP-55 {{EIP-55}} address of the PoBERC20Escrow token |
+| `recipient` | string | Yes | EIP-55 address of the merchant wallet that will receive settled funds |
+| `description` | string | No | Human-readable purpose (max 256 UTF-8 bytes) |
+| `externalId` | string | No | Merchant reference such as a session or order identifier (max 566 bytes) |
+
+The `amount` field represents the maximum hold, not the final
+charge. The `currency` field MUST be a checksummed Ethereum address
+pointing to a contract that implements both PoBERC20 and
+PoBERC20Escrow interfaces.
+
+## Method Details
+
+The `methodDetails` sub-object contains PoB-specific fields.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `chainId` | number | Yes | PoB chain identifier, used for EIP-155 {{EIP-155}} replay protection |
+| `merchantContract` | string | Yes | EIP-55 address of the MerchantBase contract |
+| `merchantOwner` | string | Yes | EIP-55 address of the merchant owner (authorized to release) |
+| `decimals` | number | Yes | Token decimal places (MUST match the token contract) |
+| `tokenName` | string | No | Human-readable token name for display |
+| `holdExpiry` | string | No | RFC 3339 {{RFC3339}} timestamp after which the hold MAY be reclaimed by the payer (see {{hold-expiry}}) |
+
+Servers MUST include `chainId`, `merchantContract`, `merchantOwner`,
+and `decimals`. Clients MUST verify `chainId` matches their expected
+network before signing any transaction.
+
+## Example
+
+~~~json
+{
+  "amount": "5000000",
+  "currency": "0x20c0000000000000000000000000000000000000",
+  "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+  "description": "Parking hold — up to $5.00",
+  "externalId": "parking_session_42",
+  "methodDetails": {
+    "chainId": 42431,
+    "merchantContract":
+      "0x1111111111111111111111111111111111111111",
+    "merchantOwner":
+      "0x5555555555555555555555555555555555555555",
+    "decimals": 6,
+    "tokenName": "PoBUSD",
+    "holdExpiry": "2026-03-26T18:00:00Z"
+  }
+}
+~~~
+
+# Credential Schema
+
+## Credential Structure
+
+The Authorization header carries a base64url-encoded JSON object
+with the structure defined by {{I-D.httpauth-payment}}.
+
+~~~
+{
+  "challenge": { ... },
+  "source": "did:pkh:eip155:42431:0xAbC123...",
+  "payload": { ... }
+}
+~~~
+
+The `challenge` object echoes all challenge parameters from the
+server. The `source` field is RECOMMENDED and SHOULD use the
+`did:pkh` format with the PoB chain namespace.
+
+## Transaction Payload (type="transaction") {#pull-payload}
+
+The client signs the `hold()` transaction and submits it to the
+server for broadcast. This is the default mode.
+
+~~~json
+{
+  "type": "transaction",
+  "approveTx": "0x<RLP-encoded signed approve() tx>",
+  "holdTx": "0x<RLP-encoded signed hold() tx>"
+}
+~~~
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | MUST be `"transaction"` |
+| `approveTx` | string | Yes | Hex-encoded RLP-serialized signed ERC-20 `approve()` transaction granting the merchant contract an allowance equal to or greater than `amount` |
+| `holdTx` | string | Yes | Hex-encoded RLP-serialized signed `hold()` transaction on the MerchantBase contract |
+
+Both transactions MUST include EIP-155 {{EIP-155}} chain ID
+protection matching the `chainId` in `methodDetails`.
+
+The `approveTx` MUST call `approve(spender, value)` on the token
+contract where `spender` is the `merchantContract` address and
+`value` is greater than or equal to `amount`.
+
+The `holdTx` MUST call `hold(holdAmount, merchantWallet)` on the
+`merchantContract` address where `holdAmount` equals `amount` and
+`merchantWallet` equals `recipient`.
+
+## Hash Payload (type="hash") {#push-payload}
+
+The client broadcasts both transactions independently and presents
+the confirmed hold transaction hash for server-side verification.
+
+~~~json
+{
+  "type": "hash",
+  "holdTxHash": "0x<transaction hash>"
+}
+~~~
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | MUST be `"hash"` |
+| `holdTxHash` | string | Yes | Hex-encoded transaction hash of the confirmed `hold()` call |
+
+The `approve()` transaction is not needed in the payload because
+the server verifies the hold state, not the approval.
+
+# Fee Payment
+
+## Server-Paid Fees
+
+When the server pays transaction fees on behalf of the client, the
+credential type MUST be `"transaction"`. The server adds its own
+signature as fee payer before broadcasting.
+
+Servers that offer fee sponsorship SHOULD:
+
+- Simulate both transactions before broadcast.
+- Rate-limit credential submissions per client.
+- Monitor the fee-payer account balance.
+
+## Client-Paid Fees
+
+When the client pays fees, either credential type MAY be used.
+For `"transaction"` payloads, both transactions MUST be fully
+signed by the client including fee payment. For `"hash"` payloads,
+the client broadcasts and pays fees independently.
+
+# Verification Procedure
+
+## Transaction Verification (type="transaction") {#tx-verification}
+
+Upon receiving a credential with `type="transaction"`, the server
+MUST:
+
+1. Decode the `approveTx` RLP payload and verify:
+   - The `to` address matches `currency`.
+   - The calldata encodes `approve(spender, value)` where `spender`
+     matches `merchantContract` and `value` >= `amount`.
+   - The chain ID matches `chainId`.
+   - The signer's address is recoverable from the signature.
+
+2. Decode the `holdTx` RLP payload and verify:
+   - The `to` address matches `merchantContract`.
+   - The calldata encodes `hold(holdAmount, merchantWallet)` where
+     `holdAmount` equals `amount` and `merchantWallet` equals
+     `recipient`.
+   - The chain ID matches `chainId`.
+   - The signer matches the `approveTx` signer.
+
+3. If the server is fee payer, add its signature to both
+   transactions. Simulate both via `eth_call` before broadcast.
+
+4. Broadcast `approveTx` via `eth_sendRawTransaction` and wait for
+   a receipt with `status == 1`.
+
+5. Broadcast `holdTx` via `eth_sendRawTransaction` and wait for a
+   receipt with `status == 1`.
+
+6. Extract `txId` from the `TransactionHeld` event in the hold
+   receipt:
+
+   ~~~
+   event TransactionHeld(
+     bytes32 indexed txId,
+     address indexed customer,
+     uint256 holdAmount,
+     uint256 maxSettleableAmount
+   )
+   ~~~
+
+7. Call `getHeldBalance(txId)` on PoBERC20Escrow and verify:
+   - `customer` matches the signer.
+   - `merchantContract` matches `merchantContract`.
+   - `merchantWallet` matches `recipient`.
+   - `amount` >= the requested `amount`.
+
+8. Record `txId` as consumed. Reject any future credential
+   referencing the same `txId`.
+
+9. Return 200 with the resource and a `Payment-Receipt` header.
+
+## Hash Verification (type="hash") {#hash-verification}
+
+Upon receiving a credential with `type="hash"`, the server MUST:
+
+1. Verify `holdTxHash` has not been previously consumed.
+
+2. Fetch the transaction receipt via `eth_getTransactionReceipt`.
+
+3. Verify `status == 1` (successful execution).
+
+4. Locate the `TransactionHeld` event and extract `txId`.
+
+5. Call `getHeldBalance(txId)` on PoBERC20Escrow and verify the
+   same fields as in step 7 of {{tx-verification}}.
+
+6. Record `txId` as consumed.
+
+7. Return 200 with the resource and a `Payment-Receipt` header.
+
+## Error Responses
+
+When verification fails, the server MUST respond with 402 and a
+fresh challenge. The response body SHOULD contain a Problem Details
+object {{RFC9457}} with one of the following `type` values:
+
+| type suffix | Condition |
+|-------------|-----------|
+| `malformed-credential` | Payload cannot be decoded or is missing required fields |
+| `invalid-challenge` | Challenge ID is unknown, expired, or already consumed |
+| `chain-mismatch` | Transaction chain ID does not match the challenge |
+| `verification-failed` | On-chain hold verification failed (wrong amount, recipient, or signer) |
+| `broadcast-failed` | Transaction broadcast or execution failed |
+
+## Receipt Generation
+
+The `Payment-Receipt` header contains a base64url-encoded JSON
+object:
+
+~~~json
+{
+  "method": "pob",
+  "intent": "escrow",
+  "challengeId": "kM9xPqWvT2nJrHsY4aDfEb",
+  "status": "success",
+  "timestamp": "2026-03-26T14:00:58Z",
+  "reference": "0xabc123...def456",
+  "txId": "0x<bytes32 hold transaction ID>",
+  "holdAmount": "5000000",
+  "merchantContract":
+    "0x1111111111111111111111111111111111111111"
+}
+~~~
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `"pob"` |
+| `intent` | string | `"escrow"` |
+| `challengeId` | string | The challenge `id` that was fulfilled |
+| `status` | string | `"success"` |
+| `timestamp` | string | RFC 3339 settlement timestamp |
+| `reference` | string | The `hold()` transaction hash |
+| `txId` | string | The `bytes32` hold transaction identifier for later settlement |
+| `holdAmount` | string | The amount actually held (in base units) |
+| `merchantContract` | string | The MerchantBase contract address |
+
+The `txId` and `merchantContract` fields are provided so the
+merchant backend can settle or release the hold without additional
+lookups.
+
+# Settlement Procedure
+
+Settlement occurs outside the HTTP 402 flow. The merchant backend
+calls the MerchantBase contract directly.
+
+## Settle
+
+The merchant wallet calls `settle(txId, finalAmount)` on the
+MerchantBase contract. The PoBERC20Escrow contract:
+
+1. Verifies `msg.sender` is the `merchantWallet` recorded in the
+   held balance.
+2. Verifies `finalAmount` <= held `amount`.
+3. Calculates and distributes:
+   - `rewardAmount` to `merchantOwner` based on the merchant's
+     configured reward percentage.
+   - `feeAmount` to the `feeWallet` based on the token-level
+     transaction fee percentage.
+   - `finalAmount - rewardAmount - feeAmount` to `merchantWallet`.
+   - `heldAmount - finalAmount` refunded to `customer`.
+4. Deletes the held balance record.
+5. Emits `TransactionSettled(txId, finalAmount)`.
+
+## Release
+
+The merchant owner calls `release(txId)` on the MerchantBase
+contract. The PoBERC20Escrow contract:
+
+1. Verifies `msg.sender` is the contract owner (the merchant
+   owner).
+2. Refunds the full held `amount` to `customer`.
+3. Deletes the held balance record.
+4. Emits `TransactionReleased(txId)`.
+
+## Idempotency
+
+Both `settle` and `release` delete the held balance record
+atomically. A second call with the same `txId` will revert because
+the held balance no longer exists. Callers SHOULD treat a revert
+on a previously settled or released `txId` as a success
+(idempotent).
+
+## Settlement and Release Are Mutually Exclusive
+
+The held balance is deleted upon either settle or release. It is
+not possible for both operations to succeed for the same `txId`.
+This satisfies the atomicity requirement of
+{{I-D.payment-intent-escrow}}.
+
+# Hold Expiry {#hold-expiry}
+
+The current MerchantBase contract does not enforce an on-chain
+hold expiration. The `holdExpiry` field in `methodDetails` is
+advisory: it communicates the server's expected service window.
+
+Implementations SHOULD add on-chain expiry enforcement so that
+customers can reclaim funds from stale holds without merchant
+cooperation. A future version of this specification will mandate
+on-chain expiry once the contract interface stabilizes.
+
+Until on-chain expiry is available, clients SHOULD set a local
+policy to reject holds where `holdExpiry` exceeds an acceptable
+duration (for example, 24 hours).
+
+# Security Considerations
+
+## Transaction Replay
+
+PoB transactions include EIP-155 {{EIP-155}} chain ID binding and
+nonce-based replay protection. Each `hold()` call produces a unique
+`txId` derived from the sender, block timestamp, and block number.
+Servers MUST track consumed `txId` values and reject duplicates.
+
+## Amount Verification
+
+Clients MUST parse the `request` payload and verify:
+
+- The `amount` is reasonable for the expected service.
+- The `currency` points to a known and trusted PoBERC20Escrow
+  token contract.
+- The `recipient` and `merchantContract` are expected addresses.
+- The `chainId` matches the intended network.
+
+Clients SHOULD reject challenges where the hold amount
+significantly exceeds the expected service cost.
+
+## Approval Scope
+
+The `approve()` transaction grants the merchant contract a spending
+allowance. Clients MUST set the allowance to exactly the hold
+`amount`, not an unlimited value. Unlimited approvals risk loss of
+all token balance if the merchant contract has a vulnerability.
+
+## Server-Paid Fee Exhaustion
+
+Servers that pay transaction fees on behalf of clients are exposed
+to fee exhaustion attacks. Malicious clients could submit
+syntactically valid but economically worthless credentials to drain
+the fee-payer account. Servers MUST:
+
+- Simulate transactions before broadcast.
+- Rate-limit submissions per authenticated client.
+- Monitor the fee-payer account balance.
+- Require client authentication before issuing challenges.
+
+## Settlement Authorization
+
+Only the `merchantWallet` recorded in the held balance can call
+`settle()`. Only the merchant owner can call `release()`. Servers
+MUST protect their merchant wallet private key. Compromise of this
+key allows unauthorized settlement of all active holds.
+
+## Hold Duration and Fund Locking
+
+An adversarial server could issue challenges with excessively long
+or missing `holdExpiry` to lock customer funds indefinitely.
+Clients MUST enforce a maximum acceptable hold duration. Agents
+acting on behalf of users SHOULD be configured with policy limits
+on per-hold amounts and aggregate exposure.
+
+## Contract Registry Trust
+
+The `merchantContract` is an arbitrary address provided by the
+server. Clients MUST verify that the contract at that address
+implements the expected MerchantBase interface and is associated
+with a trusted token. Clients SHOULD maintain an allowlist of
+known merchant contracts or validate against an on-chain registry
+such as UserIdRegistry.
+
+## Proof of Balance Privacy
+
+PoBERC20 transfers include zero-knowledge proofs that the sender
+has sufficient balance without revealing the actual balance. The
+hold operation itself does not leak the customer's total balance
+to the merchant. However, the hold `amount` is visible on-chain.
+Merchants can observe the maximum hold but not the customer's
+remaining balance after the hold.
+
+# IANA Considerations
+
+## Payment Method Registration
+
+This document registers the following payment method in the "HTTP
+Payment Methods" registry established by {{I-D.httpauth-payment}}:
+
+| Method Identifier | Description | Reference |
+|-------------------|-------------|-----------|
+| `pob` | Proof-of-Balance blockchain PoBERC20 token escrow | This document |
+
+Contact: Ryuji Ishiguro (<r2ishiguro@gmail.com>)
+
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP
+Payment Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|--------|-------------------|-------------|-----------|
+| `escrow` | `pob` | Hold-then-settle escrow payment | This document, {{I-D.payment-intent-escrow}} |
+
+--- back
+
+# ABNF Collected
+
+~~~abnf
+pob-escrow-challenge = "Payment" 1*SP
+  "id=" quoted-string ","
+  "realm=" quoted-string ","
+  "method=" DQUOTE "pob" DQUOTE ","
+  "intent=" DQUOTE "escrow" DQUOTE ","
+  "request=" base64url-nopad
+  [ "," "expires=" quoted-string ]
+  [ "," "digest=" quoted-string ]
+
+pob-escrow-credential = "Payment" 1*SP base64url-nopad
+
+; Credential payload (transaction mode)
+pob-escrow-tx-payload = "{" DQUOTE "type" DQUOTE ":"
+  DQUOTE "transaction" DQUOTE ","
+  DQUOTE "approveTx" DQUOTE ":" quoted-string ","
+  DQUOTE "holdTx" DQUOTE ":" quoted-string "}"
+
+; Credential payload (hash mode)
+pob-escrow-hash-payload = "{" DQUOTE "type" DQUOTE ":"
+  DQUOTE "hash" DQUOTE ","
+  DQUOTE "holdTxHash" DQUOTE ":" quoted-string "}"
+
+; Base64url encoding without padding per RFC 4648 Section 5
+base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
+
+; Ethereum hex-encoded values
+eth-address = "0x" 40HEXDIG
+eth-bytes32 = "0x" 64HEXDIG
+eth-tx-hash = "0x" 64HEXDIG
+~~~
+
+# Example
+
+## Challenge (Server to Client)
+
+~~~
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="kM9xPqWvT2nJrHsY4aDfEb",
+    realm="api.parkco.example.com",
+    method="pob",
+    intent="escrow",
+    expires="2026-03-26T14:05:00Z",
+    request="eyJhbW91bnQiOiI1MDAwMDAwIiwiY3VycmVuY3kiOiIwe
+    DIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw
+    MCIsInJlY2lwaWVudCI6IjB4NzQyZDM1Q2M2NjM0QzA1MzI5MjVhM
+    2I4NDRCYzllNzU5NWY4ZkUwMCIsImRlc2NyaXB0aW9uIjoiUGFya2
+    luZyBob2xkIOKAlCB1cCB0byAkNS4wMCIsIm1ldGhvZERldGFpbHM
+    iOnsiY2hhaW5JZCI6NDI0MzEsIm1lcmNoYW50Q29udHJhY3QiOiIw
+    eDExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE
+    iLCJtZXJjaGFudE93bmVyIjoiMHg1NTU1NTU1NTU1NTU1NTU1NTU1
+    NTU1NTU1NTU1NTU1NTU1NTU1NTU1IiwiZGVjaW1hbHMiOjYsInRva
+    2VuTmFtZSI6IlBvQlVTRCJ9fQ"
+Cache-Control: no-store
+Content-Type: application/problem+json
+
+{
+  "type": "about:blank",
+  "title": "Payment Required",
+  "status": 402
+}
+~~~
+
+## Credential (Client to Server)
+
+~~~
+POST /api/parking/book HTTP/1.1
+Host: api.parkco.example.com
+Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJrTTl4UHF
+    XdlQybkpySHNZNGFEZkViIiwicmVhbG0iOiJhcGkucGFya2NvLmV4
+    YW1wbGUuY29tIiwibWV0aG9kIjoicG9iIiwiaW50ZW50IjoiZXNjcm
+    93IiwicmVxdWVzdCI6ImV5SmhiVzkxYm5RaU9pSTFNREF3TURB... "
+    "}LCJzb3VyY2UiOiJkaWQ6cGtoOmVpcDE1NTo0MjQzMToweEFiQzEy
+    My4uLiIsInBheWxvYWQiOnsidHlwZSI6InRyYW5zYWN0aW9uIiwiYX
+    Bwcm92ZVR4IjoiMHhmODY1Li4uIiwiaG9sZFR4IjoiMHhmODY1Li4
+    uIn19
+Content-Type: application/json
+
+{"lotId": "A", "vehicleId": "ABC-1234", "durationMinutes": 120}
+~~~
+
+## Receipt (Server to Client)
+
+~~~
+HTTP/1.1 200 OK
+Payment-Receipt: eyJtZXRob2QiOiJwb2IiLCJpbnRlbnQiOiJlc2Ny
+    b3ciLCJjaGFsbGVuZ2VJZCI6ImtNOXhQcVd2VDJuSnJIc1k0YURmRW
+    IiLCJzdGF0dXMiOiJzdWNjZXNzIiwidGltZXN0YW1wIjoiMjAyNi0w
+    My0yNlQxNDowMDo1OFoiLCJyZWZlcmVuY2UiOiIweGFiYzEyMy4uL
+    mRlZjQ1NiIsInR4SWQiOiIweDAwMTEuLi4iLCJob2xkQW1vdW50Ijoi
+    NTAwMDAwMCIsIm1lcmNoYW50Q29udHJhY3QiOiIweDExMTEuLi4ifQ
+Cache-Control: private
+Content-Type: application/json
+
+{
+  "reservationId": "R-789",
+  "expiresAt": "2026-03-26T16:00:00Z",
+  "lot": "A",
+  "vehicle": "ABC-1234"
+}
+~~~
+
+# Contract Interface Reference
+
+The following Solidity interfaces are referenced by this
+specification. They are provided for implementer convenience and
+are not normative.
+
+## PoBERC20Escrow
+
+~~~solidity
+interface IPoBERC20Escrow {
+    struct HeldBalance {
+        address merchantContract;
+        address merchantWallet;
+        address feeWallet;
+        address merchantOwner;
+        address customer;
+        uint256 amount;
+        uint256 timestamp;
+    }
+
+    function hold(
+        address sender,
+        address merchantOwner,
+        address merchantWallet,
+        bytes32 txId,
+        uint256 amount
+    ) external;
+
+    function settle(
+        bytes32 txId,
+        uint256 finalAmount,
+        uint256 rewardAmount
+    ) external returns (bool);
+
+    function release(bytes32 txId) external;
+
+    function getHeldBalance(bytes32 txId)
+        external
+        view
+        returns (
+            address merchantContract,
+            address merchantWallet,
+            address feeWallet,
+            address merchantOwner,
+            address customer,
+            uint256 amount,
+            uint256 timestamp
+        );
+
+    event BalanceHeld(
+        bytes32 indexed txId,
+        address indexed merchant,
+        address indexed customer,
+        uint256 amount
+    );
+
+    event BalanceSettled(
+        bytes32 indexed txId,
+        address indexed merchantWallet,
+        address indexed merchantOwner,
+        uint256 totalDistributed
+    );
+
+    event BalanceReleased(
+        bytes32 indexed txId,
+        address indexed customer,
+        uint256 amount
+    );
+}
+~~~
+
+## MerchantBase
+
+~~~solidity
+interface IMerchantBase {
+    function hold(
+        uint256 holdAmount,
+        address merchantWallet
+    ) external returns (bytes32 txId);
+
+    function settle(
+        bytes32 txId,
+        uint256 finalAmount
+    ) external;
+
+    function release(bytes32 txId) external;
+
+    event TransactionHeld(
+        bytes32 indexed txId,
+        address indexed customer,
+        uint256 holdAmount,
+        uint256 maxSettleableAmount
+    );
+
+    event TransactionSettled(
+        bytes32 indexed txId,
+        uint256 finalAmount
+    );
+
+    event TransactionReleased(bytes32 indexed txId);
+}
+~~~
+
+# Acknowledgements
+
+The HTTP Payment Authentication Scheme and the intent-method
+layering model are defined by the MPP specifications at
+paymentauth.org. The escrow pattern draws from EMV
+preauthorization and capture semantics used in traditional payment
+card networks.

--- a/specs/methods/pob/draft-pob-escrow-00.md
+++ b/specs/methods/pob/draft-pob-escrow-00.md
@@ -64,8 +64,9 @@ method within the Payment HTTP Authentication Scheme
 behind escrow-based payments using PoBERC20 tokens on a
 Proof-of-Balance (PoB) blockchain.
 
-The client places a hold on funds through an on-chain escrow contract.
-The server verifies the hold and grants access. The merchant later
+The client places a hold on funds through an on-chain escrow contract
+and presents the confirmed transaction hash as proof. The server
+verifies the hold on-chain and grants access. The merchant later
 settles or releases the held funds when the final amount is known.
 This pattern maps to preauthorization and capture in traditional
 payment systems and is intended for autonomous machine-to-machine
@@ -231,11 +232,13 @@ network before signing any transaction.
 The Authorization header carries a base64url-encoded JSON object
 with the structure defined by {{I-D.httpauth-payment}}.
 
-~~~
+~~~json
 {
   "challenge": { ... },
   "source": "did:pkh:eip155:42431:0xAbC123...",
-  "payload": { ... }
+  "payload": {
+    "holdTxHash": "0x<transaction hash>"
+  }
 }
 ~~~
 
@@ -243,110 +246,33 @@ The `challenge` object echoes all challenge parameters from the
 server. The `source` field is RECOMMENDED and SHOULD use the
 `did:pkh` format with the PoB chain namespace.
 
-## Transaction Payload (type="transaction") {#pull-payload}
+## Payload
 
-The client signs the `hold()` transaction and submits it to the
-server for broadcast. This is the default mode.
-
-~~~json
-{
-  "type": "transaction",
-  "approveTx": "0x<RLP-encoded signed approve() tx>",
-  "holdTx": "0x<RLP-encoded signed hold() tx>"
-}
-~~~
+The client broadcasts `approve()` and `hold()` transactions
+independently and presents the confirmed hold transaction hash
+for server-side verification.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | Yes | MUST be `"transaction"` |
-| `approveTx` | string | Yes | Hex-encoded RLP-serialized signed ERC-20 `approve()` transaction granting the merchant contract an allowance equal to or greater than `amount` |
-| `holdTx` | string | Yes | Hex-encoded RLP-serialized signed `hold()` transaction on the MerchantBase contract |
-
-Both transactions MUST include EIP-155 {{EIP-155}} chain ID
-protection matching the `chainId` in `methodDetails`.
-
-The `approveTx` MUST call `approve(spender, value)` on the token
-contract where `spender` is the `merchantContract` address and
-`value` is greater than or equal to `amount`.
-
-The `holdTx` MUST call `hold(holdAmount, merchantWallet)` on the
-`merchantContract` address where `holdAmount` equals `amount` and
-`merchantWallet` equals `recipient`.
-
-## Hash Payload (type="hash") {#push-payload}
-
-The client broadcasts both transactions independently and presents
-the confirmed hold transaction hash for server-side verification.
-
-~~~json
-{
-  "type": "hash",
-  "holdTxHash": "0x<transaction hash>"
-}
-~~~
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | MUST be `"hash"` |
 | `holdTxHash` | string | Yes | Hex-encoded transaction hash of the confirmed `hold()` call |
 
-The `approve()` transaction is not needed in the payload because
-the server verifies the hold state, not the approval.
+The `approve()` transaction hash is not needed in the payload
+because the server verifies the hold state on-chain, not the
+approval. If the hold succeeded, the approval necessarily
+preceded it.
 
-# Fee Payment
+# Verification Procedure {#verification}
 
-## Server-Paid Fees
+Upon receiving a credential, the server MUST:
 
-When the server pays transaction fees on behalf of the client, the
-credential type MUST be `"transaction"`. The server adds its own
-signature as fee payer before broadcasting.
+1. Verify `holdTxHash` has not been previously consumed.
 
-Servers that offer fee sponsorship SHOULD:
+2. Fetch the transaction receipt via `eth_getTransactionReceipt`.
 
-- Simulate both transactions before broadcast.
-- Rate-limit credential submissions per client.
-- Monitor the fee-payer account balance.
+3. Verify `status == 1` (successful execution).
 
-## Client-Paid Fees
-
-When the client pays fees, either credential type MAY be used.
-For `"transaction"` payloads, both transactions MUST be fully
-signed by the client including fee payment. For `"hash"` payloads,
-the client broadcasts and pays fees independently.
-
-# Verification Procedure
-
-## Transaction Verification (type="transaction") {#tx-verification}
-
-Upon receiving a credential with `type="transaction"`, the server
-MUST:
-
-1. Decode the `approveTx` RLP payload and verify:
-   - The `to` address matches `currency`.
-   - The calldata encodes `approve(spender, value)` where `spender`
-     matches `merchantContract` and `value` >= `amount`.
-   - The chain ID matches `chainId`.
-   - The signer's address is recoverable from the signature.
-
-2. Decode the `holdTx` RLP payload and verify:
-   - The `to` address matches `merchantContract`.
-   - The calldata encodes `hold(holdAmount, merchantWallet)` where
-     `holdAmount` equals `amount` and `merchantWallet` equals
-     `recipient`.
-   - The chain ID matches `chainId`.
-   - The signer matches the `approveTx` signer.
-
-3. If the server is fee payer, add its signature to both
-   transactions. Simulate both via `eth_call` before broadcast.
-
-4. Broadcast `approveTx` via `eth_sendRawTransaction` and wait for
-   a receipt with `status == 1`.
-
-5. Broadcast `holdTx` via `eth_sendRawTransaction` and wait for a
-   receipt with `status == 1`.
-
-6. Extract `txId` from the `TransactionHeld` event in the hold
-   receipt:
+4. Locate the `TransactionHeld` event in the receipt and extract
+   `txId`:
 
    ~~~
    event TransactionHeld(
@@ -357,33 +283,14 @@ MUST:
    )
    ~~~
 
-7. Call `getHeldBalance(txId)` on PoBERC20Escrow and verify:
-   - `customer` matches the signer.
-   - `merchantContract` matches `merchantContract`.
-   - `merchantWallet` matches `recipient`.
-   - `amount` >= the requested `amount`.
+5. Call `getHeldBalance(txId)` on PoBERC20Escrow and verify:
+   - `customer` matches the `source` in the credential.
+   - `merchantContract` matches the challenge `merchantContract`.
+   - `merchantWallet` matches the challenge `recipient`.
+   - `amount` >= the challenge `amount`.
 
-8. Record `txId` as consumed. Reject any future credential
+6. Record `txId` as consumed. Reject any future credential
    referencing the same `txId`.
-
-9. Return 200 with the resource and a `Payment-Receipt` header.
-
-## Hash Verification (type="hash") {#hash-verification}
-
-Upon receiving a credential with `type="hash"`, the server MUST:
-
-1. Verify `holdTxHash` has not been previously consumed.
-
-2. Fetch the transaction receipt via `eth_getTransactionReceipt`.
-
-3. Verify `status == 1` (successful execution).
-
-4. Locate the `TransactionHeld` event and extract `txId`.
-
-5. Call `getHeldBalance(txId)` on PoBERC20Escrow and verify the
-   same fields as in step 7 of {{tx-verification}}.
-
-6. Record `txId` as consumed.
 
 7. Return 200 with the resource and a `Payment-Receipt` header.
 
@@ -397,9 +304,7 @@ object {{RFC9457}} with one of the following `type` values:
 |-------------|-----------|
 | `malformed-credential` | Payload cannot be decoded or is missing required fields |
 | `invalid-challenge` | Challenge ID is unknown, expired, or already consumed |
-| `chain-mismatch` | Transaction chain ID does not match the challenge |
-| `verification-failed` | On-chain hold verification failed (wrong amount, recipient, or signer) |
-| `broadcast-failed` | Transaction broadcast or execution failed |
+| `verification-failed` | On-chain hold verification failed (wrong amount, recipient, signer, or transaction not found) |
 
 ## Receipt Generation
 
@@ -525,22 +430,10 @@ significantly exceeds the expected service cost.
 
 ## Approval Scope
 
-The `approve()` transaction grants the merchant contract a spending
-allowance. Clients MUST set the allowance to exactly the hold
+The client calls `approve()` on the token contract before calling
+`hold()`. Clients MUST set the allowance to exactly the hold
 `amount`, not an unlimited value. Unlimited approvals risk loss of
 all token balance if the merchant contract has a vulnerability.
-
-## Server-Paid Fee Exhaustion
-
-Servers that pay transaction fees on behalf of clients are exposed
-to fee exhaustion attacks. Malicious clients could submit
-syntactically valid but economically worthless credentials to drain
-the fee-payer account. Servers MUST:
-
-- Simulate transactions before broadcast.
-- Rate-limit submissions per authenticated client.
-- Monitor the fee-payer account balance.
-- Require client authentication before issuing challenges.
 
 ## Settlement Authorization
 
@@ -613,16 +506,9 @@ pob-escrow-challenge = "Payment" 1*SP
 
 pob-escrow-credential = "Payment" 1*SP base64url-nopad
 
-; Credential payload (transaction mode)
-pob-escrow-tx-payload = "{" DQUOTE "type" DQUOTE ":"
-  DQUOTE "transaction" DQUOTE ","
-  DQUOTE "approveTx" DQUOTE ":" quoted-string ","
-  DQUOTE "holdTx" DQUOTE ":" quoted-string "}"
-
-; Credential payload (hash mode)
-pob-escrow-hash-payload = "{" DQUOTE "type" DQUOTE ":"
-  DQUOTE "hash" DQUOTE ","
-  DQUOTE "holdTxHash" DQUOTE ":" quoted-string "}"
+; Credential payload
+pob-escrow-payload = "{" DQUOTE "holdTxHash" DQUOTE ":"
+  DQUOTE eth-tx-hash DQUOTE "}"
 
 ; Base64url encoding without padding per RFC 4648 Section 5
 base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
@@ -666,17 +552,18 @@ Content-Type: application/problem+json
 
 ## Credential (Client to Server)
 
+The client has already broadcast `approve()` and `hold()`
+transactions on-chain and received a confirmed hold receipt.
+
 ~~~
 POST /api/parking/book HTTP/1.1
 Host: api.parkco.example.com
 Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJrTTl4UHF
     XdlQybkpySHNZNGFEZkViIiwicmVhbG0iOiJhcGkucGFya2NvLmV4
     YW1wbGUuY29tIiwibWV0aG9kIjoicG9iIiwiaW50ZW50IjoiZXNjcm
-    93IiwicmVxdWVzdCI6ImV5SmhiVzkxYm5RaU9pSTFNREF3TURB... "
-    "}LCJzb3VyY2UiOiJkaWQ6cGtoOmVpcDE1NTo0MjQzMToweEFiQzEy
-    My4uLiIsInBheWxvYWQiOnsidHlwZSI6InRyYW5zYWN0aW9uIiwiYX
-    Bwcm92ZVR4IjoiMHhmODY1Li4uIiwiaG9sZFR4IjoiMHhmODY1Li4
-    uIn19
+    93In0sInNvdXJjZSI6ImRpZDpwa2g6ZWlwMTU1OjQyNDMxOjB4QWJ
+    DMTIzLi4uIiwicGF5bG9hZCI6eyJob2xkVHhIYXNoIjoiMHhhYmMxM
+    jMuLi5kZWY0NTYifX0
 Content-Type: application/json
 
 {"lotId": "A", "vehicleId": "ABC-1234", "durationMinutes": 120}


### PR DESCRIPTION
## Summary

- Adds the **"escrow" intent** (`specs/intents/draft-payment-intent-escrow-00.md`) — a new payment intent for two-phase hold-then-settle payments where the final amount is not known at authorization time
- Adds **PoB escrow method** (`specs/methods/pob/draft-pob-escrow-00.md`) — implements escrow using PoBERC20Escrow smart contracts with on-chain hold/settle/release
- Adds **card escrow method** (`specs/methods/card/draft-card-escrow-00.md`) — implements escrow using standard card network preauthorization/capture/void

The escrow pattern is the standard preauth-and-capture model used in traditional payments (EMV, card networks) brought to MPP. Use cases include parking, fueling, metered compute, and hotel/rental reservations — anywhere the final charge depends on actual usage.

## Design decisions

- **`recipient` is REQUIRED** in the escrow intent, unlike the charge intent where some methods make it optional. For escrow, the client must know who will receive settled funds before authorizing a hold.
- **Settlement is out-of-band.** The 402 exchange only covers the hold. Settle/release happen later between the merchant backend and the payment network, not through HTTP Payment headers.
- **Hold expiry is a method concern.** The intent spec mandates that methods define expiry semantics but does not prescribe a mechanism (card networks use 7-day windows; smart contracts can enforce on-chain deadlines).

## Validation

- `lint_frontmatter.py` passes for all three specs
- `kramdown-rfc` → XML → `xml2rfc` HTML/TXT artifacts generated successfully (same benign warnings as existing specs)

## AI disclosure

Significant AI assistance (Claude) was used in drafting these specifications. All content has been reviewed for RFC compliance and technical accuracy.

## Test plan

- [ ] `make lint` passes
- [ ] `make check` passes (Docker build)
- [ ] Generated HTML/TXT artifacts render correctly
- [ ] Cross-references (`{{I-D.httpauth-payment}}`, `{{I-D.payment-intent-escrow}}`, `{{I-D.card-charge}}`) resolve
