### PR TITLE
[intent] authorize intent (auth and capture)

### DIFF
--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -47,35 +47,40 @@ normative:
 
 This document defines the "authorize" payment intent for use with the
 Payment HTTP Authentication Scheme. The "authorize" intent represents a
-pre-authorization where the payer grants the server permission to charge
-up to a specified amount within a time window, without immediate payment.
+payment authorization where the payer approves a maximum amount that a
+server can later capture before an expiry time.
 
 --- middle
 
 # Introduction
 
-The "authorize" intent enables pre-authorized payments where the payer
-grants the server permission to charge up to a specified amount at a
-later time. This is useful for:
+The "authorize" intent enables delayed payment capture. The payer
+authorizes a maximum amount, and the payment method creates a hold,
+escrow, or equivalent authorization. The server can later capture one or
+more amounts against that authorization, subject to the authorized maximum
+and expiry.
 
-Metered billing:
-: Pay-per-use APIs where total cost is unknown upfront
+This is useful for:
 
 Delayed fulfillment:
-: Services where delivery occurs after authorization
+: Services where delivery or shipment occurs after payment authorization.
+
+Metered billing:
+: Services where final cost is unknown when the payer authorizes payment.
 
 Spending caps:
-: User-controlled limits on automated spending
+: User-controlled limits on future server-initiated captures.
 
-Unlike the "charge" intent which requires immediate payment, "authorize"
-creates a payment capability that the server can exercise later.
+Unlike the "charge" intent, successful authorization is not itself a
+payment capture. A successful authorization response MUST NOT imply that
+the recipient has received funds.
 
 ## Relationship to Payment Methods
 
-Payment methods implement "authorize" using method-specific
-authorization mechanisms. This document defines the abstract semantics
-and shared request fields; payment method specifications define how
-those semantics are enforced.
+This document defines the abstract authorize semantics and shared request
+fields. Payment method specifications define how an authorization is
+created, how captures are executed, how unused authorizations are voided,
+and which method-specific policy applies to refund requests.
 
 # Requirements Language
 
@@ -84,77 +89,120 @@ those semantics are enforced.
 # Terminology
 
 Authorization
-: A grant of permission for a server to initiate payments up to a
-  specified limit within a specified time window, without requiring
-  immediate payment.
+: A method-enforced hold, escrow, or equivalent capability allowing a
+  server or operator to capture up to a maximum amount before an expiry.
 
-Spending Limit
-: The maximum amount that can be charged against an authorization
-  before it is exhausted.
+Capture
+: A method-specific operation that consumes part or all of an
+  authorization and transfers captured value to the recipient.
 
-Revocation
-: The act of canceling an authorization before its natural expiry,
-  preventing further charges.
+Void
+: A method-specific operation that closes an authorization and releases
+  any uncaptured value.
+
+Recipient
+: The method-native destination that receives captured value.
+
+Operator
+: A method-specific entity authorized to drive the payment lifecycle,
+  such as registering the authorization, capturing value, or voiding
+  unused value. Some methods use the server as the operator; others use a
+  payment processor, contract, or facilitator.
 
 # Intent Semantics
 
 ## Definition
 
-The "authorize" intent represents a request for the payer to grant
-permission for the server to initiate payments up to a specified limit,
-within a specified time window.
+The "authorize" intent requests the payer to authorize a maximum amount
+for future capture. The client does not need to know whether the payment
+method implements capture as a single capture, multiple captures, escrow
+release, card network capture, or another method-specific mechanism.
 
 ## Properties
 
 | Property | Value |
 |----------|-------|
-| **Intent Identifier** | `authorize` |
-| **Payment Timing** | Deferred (server-initiated later) |
-| **Idempotency** | Credential single-use; authorization reusable within limits |
-| **Reversibility** | Revocable before use |
+| Intent Identifier | `authorize` |
+| Payment Timing | Deferred capture |
+| Capture Count | Method-specific; one or more captures MAY occur |
+| Idempotency | Credential single-use; authorization lifecycle method-specific |
+| Reversibility | Uncaptured value can be voided; captured value refund is method/policy-specific |
 
-## Flow
+## Authorization Flow
 
 ~~~
-   Client                           Server                    Payment Network
-      │                                │                              │
-      │  (1) GET /resource             │                              │
-      ├───────────────────────────────>│                              │
-      │                                │                              │
-      │  (2) 402 Payment Required      │                              │
-      │      intent="authorize"        │                              │
-      │<───────────────────────────────┤                              │
-      │                                │                              │
-      │  (3) Sign authorization        │                              │
-      │                                │                              │
-      │  (4) Authorization: Payment    │                              │
-      ├───────────────────────────────>│                              │
-      │                                │                              │
-      │                                │  (5) Register authorization  │
-      │                                ├─────────────────────────────>│
-      │                                │                              │
-      │  (6) 200 OK (authorized)       │                              │
-      │<───────────────────────────────┤                              │
-      │                                │                              │
-      │        ... later ...           │                              │
-      │                                │                              │
-      │  (7) GET /resource             │                              │
-      ├───────────────────────────────>│                              │
-      │                                │  (8) Charge via auth         │
-      │                                ├─────────────────────────────>│
-      │                                │                              │
-      │  (9) 200 OK + Receipt          │                              │
-      │<───────────────────────────────┤                              │
-      │                                │                              │
+   Client                      Server / Operator             Payment Method
+      |                              |                              |
+      |  (1) GET /resource           |                              |
+      |----------------------------->|                              |
+      |                              |                              |
+      |  (2) 402 Payment Required    |                              |
+      |      intent="authorize"      |                              |
+      |<-----------------------------|                              |
+      |                              |                              |
+      |  (3) Create method-specific  |                              |
+      |      authorization credential|                              |
+      |                              |                              |
+      |  (4) Authorization: Payment  |                              |
+      |----------------------------->|                              |
+      |                              |  (5) Create hold/escrow/auth  |
+      |                              |----------------------------->|
+      |                              |                              |
+      |  (6) 200 OK                  |  (authorization active)       |
+      |      authorization handle    |<-----------------------------|
+      |<-----------------------------|                              |
+      |                              |                              |
 ~~~
 
-## Non-Atomicity
+## Capture Flow
 
-Unlike "charge", the "authorize" intent is non-atomic:
+Captures are method-specific operations. They can occur synchronously with
+resource delivery, after resource delivery, or as part of a separate
+fulfillment workflow.
 
-- Authorization registration is separate from payment collection
-- Multiple charges may occur against a single authorization
-- Total charges MUST NOT exceed the authorized limit
+~~~
+   Client                      Server / Operator             Payment Method
+      |                              |                              |
+      |  (1) Request fulfillment     |                              |
+      |----------------------------->|                              |
+      |                              |                              |
+      |                              |  (2) capture(amount)          |
+      |                              |----------------------------->|
+      |                              |                              |
+      |  (3) 200 OK                  |  (capture confirmed)          |
+      |      Payment-Receipt         |<-----------------------------|
+      |<-----------------------------|                              |
+      |                              |                              |
+~~~
+
+The core intent deliberately does not expose payment method capture
+capabilities, such as whether the method performs one capture or multiple
+captures. The payer authorizes a maximum amount; the payment method and
+server enforce the capture lifecycle.
+
+## Void Flow
+
+~~~
+   Server / Operator             Payment Method
+          |                            |
+          |  void(authorization)       |
+          |--------------------------->|
+          |                            |
+          |  uncaptured value released |
+          |<---------------------------|
+          |                            |
+~~~
+
+Void closes the authorization and releases any uncaptured value according
+to method-specific rules. Void does not refund captured value.
+
+## Refund Requests
+
+Refunds are out of scope for the core authorize lifecycle. Clients MAY
+request a refund through method-defined or merchant-defined channels.
+Servers MAY honor refund requests depending on payment method capability,
+merchant policy, and applicable rules. The "authorize" intent does not
+require partial refunds or on-protocol refund execution.
 
 # Request Schema
 
@@ -167,9 +215,8 @@ base64url-encoded without padding per {{I-D.httpauth-payment}}.
 ## Shared Fields
 
 All payment methods implementing the "authorize" intent MUST support these
-shared fields, enabling clients to parse and display authorization requests
-consistently across methods. Payment methods MAY elevate OPTIONAL fields
-to REQUIRED in their method specification.
+shared fields. Payment methods MAY elevate OPTIONAL fields to REQUIRED in
+their method specification.
 
 ### Required Fields
 
@@ -180,17 +227,16 @@ to REQUIRED in their method specification.
 | `authorizationExpires` | string | Authorization expiry timestamp in {{RFC3339}} format |
 
 The `amount` value MUST be a string representation of a non-negative
-integer in base 10 with no sign, decimal point, exponent, or
-surrounding whitespace. Leading zeros MUST NOT be used except for the
-value `"0"`.
+integer in base 10 with no sign, decimal point, exponent, or surrounding
+whitespace. Leading zeros MUST NOT be used except for the value `"0"`.
 
 ### Optional Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `recipient` | string | Payment recipient in method-native format |
+| `recipient` | string | Captured-value destination in method-native format |
 | `description` | string | Human-readable authorization description |
-| `externalId` | string | Merchant's reference (order ID, etc.) |
+| `externalId` | string | Merchant reference, order ID, or cart ID |
 | `methodDetails` | object | Method-specific extension data |
 
 Challenge expiry is conveyed by the `expires` auth-param in
@@ -217,83 +263,93 @@ payment networks:
 Payment method specifications MUST document which currency formats they
 support and how to interpret amounts for each format.
 
-## Method Extensions
-
-Payment methods MAY define additional fields in the `methodDetails` object.
-These fields are method-specific and MUST be documented in the payment
-method specification.
-
 ## Examples
 
-### Traditional Payment Processor (Stripe)
+### Stripe
 
-~~~ json
+~~~json
 {
   "amount": "100000",
   "currency": "usd",
-  "authorizationExpires": "2025-01-22T12:00:00Z",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
+  "recipient": "acct_merchant",
   "description": "Pre-authorization for metered API usage",
   "methodDetails": {
-    "captureMethod": "manual"
+    "networkId": "profile_1MqDcVKA5fEO2tZvKQm9g8Yj"
   }
 }
 ~~~
 
-### Blockchain Payment (Tempo)
+### Tempo
 
-~~~ json
+~~~json
 {
   "amount": "50000000",
   "currency": "0x20c0000000000000000000000000000000000001",
-  "authorizationExpires": "2025-02-05T12:00:00Z",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
+  "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
   "methodDetails": {
-    "chainId": 42431
+    "chainId": 42431,
+    "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
+    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"
   }
 }
 ~~~
 
 # Credential Requirements
 
-## Payload
+The credential `payload` for an "authorize" intent contains
+method-specific authorization material. Each credential MUST be usable
+only once for a challenge. Servers MUST reject replayed credentials.
 
-The credential `payload` for an "authorize" intent contains the
-authorization grant. The format is method-specific:
-
-| Authorization Type | Description | Example Methods |
-|-------------------|-------------|-----------------|
-| Signed Key Auth | Delegated signing key | Tempo Access Keys |
-| Token Approval | On-chain approval | EVM ERC-20 approve |
-| Saved Payment Method | Stored card/account | Stripe SetupIntent |
-
-## Reusability
-
-Each "authorize" credential MUST be usable only once per challenge.
-Servers MUST reject replayed credentials.
-
-A successfully registered authorization may enable multiple subsequent
-charges. The authorization persists until:
+Successful credential processing creates an authorization. The
+authorization persists until:
 
 - The `authorizationExpires` timestamp is reached
-- The spending limit is exhausted
-- The payer explicitly revokes it
+- The authorized amount is fully captured
+- The authorization is voided
+- A method-specific terminal state occurs
 
 # Authorization Lifecycle
 
 ## Registration
 
-When the server receives an "authorize" credential:
+When the server receives an "authorize" credential, it MUST:
 
-1. Verify the authorization signature/proof
-2. Store the authorization for future use
-3. Initialize durable state for the authorization, including its
-   remaining authorized amount
-4. Return success (200) to indicate authorization accepted
-5. Return success response; session reuse mechanisms are out of scope
-   for this specification
+1. Verify the challenge ID and challenge expiry.
+2. Verify the method-specific authorization credential.
+3. Create or confirm the method-specific hold, escrow, or authorization.
+4. Store durable state sufficient to correlate later captures and voids.
+5. Return success only after the authorization is active.
 
 Registration responses for `intent="authorize"` MUST NOT include a
-`Payment-Receipt` header. `Payment-Receipt` is reserved for later
-successful responses that actually consume authorized value.
+`Payment-Receipt` header. `Payment-Receipt` is reserved for successful
+responses that actually consume or capture authorized value.
+
+## Authorization Metadata
+
+Payment methods MAY return method-specific authorization metadata in a
+successful registration response body. Such metadata can include an
+authorization identifier, status, expiry, captured amount, remaining
+amount, or method reference. The core authorize intent does not define a
+mandatory authorization metadata schema, and clients MUST NOT rely on a
+method returning a core-defined authorization handle.
+
+## Captures
+
+Servers MUST enforce the following invariants across all captures for an
+authorization:
+
+- The cumulative captured amount MUST NOT exceed `amount`.
+- Captures MUST NOT occur after `authorizationExpires`.
+- Capture execution MUST be idempotent with respect to method-specific
+  retry behavior.
+- Captured value MUST be directed to the `recipient` or the
+  method-specific destination bound by the original authorization.
+
+Payment methods MAY use cumulative capture semantics, per-capture
+idempotency keys, processor idempotency keys, or other mechanisms to
+prevent duplicate capture.
 
 ## Server Accounting and Idempotency
 
@@ -303,43 +359,218 @@ remaining limits across concurrent requests and retries.
 At minimum, servers MUST track:
 
 - Authorization identifier
-- Remaining authorized amount
+- Authorized amount
+- Cumulative captured amount
 - Authorization expiry
-- Revocation status
+- Terminal state, if any
 
-When charging against an authorization, servers MUST perform the limit
-check and decrement atomically before, or atomically with, delivering the
-corresponding service.
+For retried HTTP requests, clients SHOULD send an `Idempotency-Key`
+header per {{I-D.ietf-httpapi-idempotency-key-header}}. Servers MUST NOT
+capture or consume authorized amount more than once for a duplicate
+idempotent request.
 
-For retried requests, clients SHOULD send an `Idempotency-Key` header per {{I-D.ietf-httpapi-idempotency-key-header}}.
-Servers MUST NOT decrement the remaining authorized amount more than once
-for a duplicate idempotent request.
+## Void
 
-## Charging
+Servers SHOULD provide a way to void an unused or partially used
+authorization. Void closes the authorization and releases uncaptured value
+according to method-specific rules. Void MUST NOT alter captured value.
 
-When charging against an authorization:
+## Refund Requests
 
-1. Verify the authorization is still valid (not expired, not revoked)
-2. Verify sufficient limit remains
-3. Execute the charge via method-specific mechanism
-4. Decrement the remaining limit atomically with service delivery
-5. Return `Payment-Receipt` with charge details
+Clients MAY request a refund through method-defined or merchant-defined
+channels. A successful refund request is not guaranteed by this intent and
+does not change the core authorization lifecycle.
 
-## Revocation
+## Non-Normative Protocol Examples
 
-Payers SHOULD be able to revoke authorizations before expiry. Revocation
-mechanisms are method-specific:
+The following non-normative examples illustrate possible wire shapes.
+Method specifications define the exact payload fields, response bodies,
+and any void or refund-request interfaces.
 
-| Method | Revocation Mechanism |
-|--------|---------------------|
-| Tempo | Remove Access Key from account |
-| EVM | Set approval to zero |
-| Stripe | Detach PaymentMethod from Customer |
+### Authorization Challenge
 
-## Expiry
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="auth_1a2b3c4d5e",
+  realm="api.example.com",
+  method="example",
+  intent="authorize",
+  expires="2026-05-13T12:05:00Z",
+  request="<base64url-encoded request>"
+Cache-Control: no-store
+Content-Type: application/json
 
-Servers MUST NOT charge against expired authorizations. Servers SHOULD
-provide a mechanism for payers to query authorization status.
+{
+  "type": "https://paymentauth.org/problems/payment-required",
+  "title": "Payment Required",
+  "status": 402,
+  "detail": "This resource requires payment authorization"
+}
+~~~
+
+Decoded request:
+
+~~~json
+{
+  "amount": "100000",
+  "currency": "usd",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
+  "recipient": "merchant_123"
+}
+~~~
+
+### Authorization Credential
+
+~~~http
+GET /resource HTTP/1.1
+Host: api.example.com
+Authorization: Payment <base64url-encoded credential>
+~~~
+
+Decoded credential:
+
+~~~json
+{
+  "challenge": {
+    "id": "auth_1a2b3c4d5e",
+    "realm": "api.example.com",
+    "method": "example",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2026-05-13T12:05:00Z"
+  },
+  "payload": {
+    "type": "method-specific"
+  }
+}
+~~~
+
+### Authorization Active
+
+Registration responses MUST NOT include `Payment-Receipt`. The response
+body below is illustrative metadata, not a required core schema.
+
+~~~http
+HTTP/1.1 200 OK
+Cache-Control: no-store
+Content-Type: application/json
+
+{
+  "authorization": {
+    "id": "pauth_123",
+    "status": "authorized",
+    "amount": "100000",
+    "capturedAmount": "0",
+    "remainingAmount": "100000",
+    "currency": "usd",
+    "recipient": "merchant_123",
+    "authorizationExpires": "2026-05-14T12:00:00Z"
+  }
+}
+~~~
+
+### Capture Receipt
+
+When a response consumes or captures authorized value, the server returns a
+`Payment-Receipt` header. The decoded receipt shape is method-specific.
+
+~~~http
+HTTP/1.1 200 OK
+Payment-Receipt: eyJtZXRob2QiOiJleGFtcGxlIiwiaW50ZW50IjoiYXV0aG9yaXplIiwic3RhdHVzIjoic3VjY2VzcyJ9
+Cache-Control: no-store
+Content-Type: application/json
+
+{
+  "result": "resource response"
+}
+~~~
+
+Decoded receipt:
+
+~~~json
+{
+  "method": "example",
+  "intent": "authorize",
+  "reference": "cap_456",
+  "authorizationId": "pauth_123",
+  "capturedAmount": "25000",
+  "delta": "25000",
+  "status": "success",
+  "timestamp": "2026-05-13T12:10:00Z"
+}
+~~~
+
+### Authorization Exhausted or Closed
+
+When an authorization cannot cover the request, the server returns a fresh
+challenge.
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="auth_6f7g8h9i0j",
+  realm="api.example.com",
+  method="example",
+  intent="authorize",
+  expires="2026-05-13T12:20:00Z",
+  request="eyJ..."
+Cache-Control: no-store
+Content-Type: application/problem+json
+
+{
+  "type": "https://paymentauth.org/problems/authorization-exhausted",
+  "title": "Authorization Exhausted",
+  "status": 402,
+  "detail": "The previous authorization cannot cover this request"
+}
+~~~
+
+### Method-Defined Void
+
+Void is a method-specific or server-operator operation. A method that
+exposes void over HTTP might use a shape like this:
+
+~~~http
+POST /payments/authorizations/pauth_123/void HTTP/1.1
+Host: api.example.com
+Idempotency-Key: void_123
+~~~
+
+~~~http
+HTTP/1.1 200 OK
+Cache-Control: no-store
+Content-Type: application/json
+
+{
+  "authorizationId": "pauth_123",
+  "status": "voided",
+  "releasedAmount": "75000"
+}
+~~~
+
+### Out-of-Band Refund Request
+
+Refund requests are merchant-defined or method-defined and do not change
+the core authorization semantics:
+
+~~~http
+POST /payments/authorizations/pauth_123/refund-requests HTTP/1.1
+Host: api.example.com
+Content-Type: application/json
+
+{
+  "reason": "requested_by_customer"
+}
+~~~
+
+~~~http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+  "refundRequestId": "rr_123",
+  "status": "pending_review"
+}
+~~~
 
 ## Error Responses
 
@@ -349,30 +580,45 @@ MUST return an appropriate HTTP status code:
 | Condition | Status Code | Behavior |
 |-----------|-------------|----------|
 | Authorization expired | 402 Payment Required | Issue new challenge |
-| Spending limit exhausted | 402 Payment Required | Issue new challenge |
-| Authorization revoked | 402 Payment Required | Issue new challenge |
+| Authorized amount exhausted | 402 Payment Required | Issue new challenge |
+| Authorization voided or closed | 402 Payment Required | Issue new challenge |
 | Invalid credential | 401 Unauthorized | Reject credential |
 
 For all 402 responses, the server MUST include a `WWW-Authenticate`
-header with a fresh challenge. Clients receiving a 402 after a
-previously valid authorization SHOULD treat the authorization as
-exhausted and initiate a new authorization flow.
+header with a fresh challenge. Clients receiving a 402 after a previously
+valid authorization SHOULD initiate a new authorization flow.
 
 # Security Considerations
 
 ## Limit Verification
 
-Clients MUST verify the requested limit is acceptable before signing.
-Authorizations grant future spending capability without further user
-interaction.
+Clients MUST verify the requested limit is acceptable before authorizing.
+Authorizations allow future captures without further user interaction.
 
-Clients MUST verify `authorizationExpires` is not unreasonably far in the
-future.
+Clients MUST verify:
+
+- The `amount` and `currency`
+- The `recipient`, when exposed by the method
+- The authorization expiry
+- Method-specific lifecycle authority, processor, or escrow identifiers
+  when present
+
+## Destination and Lifecycle Authority
+
+Some methods distinguish between the destination that receives captured
+funds and an authority that can drive authorization, capture, or void
+operations. For example, an on-chain method might use a recipient address
+for settlement and a separate operator address for lifecycle operations.
+Where a method exposes separate roles, clients SHOULD display them when
+they differ. Method specifications MUST define which role fields are bound
+by the payer's authorization and MUST ensure lifecycle authority cannot
+redirect captured value to a different destination.
 
 ## Expiry Windows
 
 Clients SHOULD prefer short authorization windows. Long-lived
-authorizations increase risk if credentials are compromised.
+authorizations increase risk if credentials are compromised or merchant
+systems behave incorrectly.
 
 Recommended maximum windows:
 
@@ -385,35 +631,18 @@ Recommended maximum windows:
 These values are informational guidance. Deployments SHOULD evaluate
 their own risk tolerance and adjust authorization windows accordingly.
 
-## Revocation Capability
+## Refund Expectations
 
-Payment methods implementing "authorize" SHOULD provide revocation
-mechanisms. Payers MUST be able to revoke authorizations if they suspect
-compromise.
-
-## Authorization Scope
-
-Authorizations SHOULD be scoped as narrowly as possible:
-
-- Specific recipient address (not "any address")
-- Specific asset/currency
-- Reasonable limits and expiry
-
-## Server Accountability
-
-Servers holding authorizations are responsible for:
-
-- Secure storage of authorization data
-- Not exceeding authorized limits
-- Providing transaction records to payers
-- Honoring revocation requests
+Clients MUST NOT assume that captured value can be refunded through the
+Payment Authentication protocol. Refund rights and procedures are
+method-specific and policy-specific.
 
 ## Caching
 
-Responses to authorization challenges (402 Payment Required) and
-responses that consume authorized value SHOULD include
-`Cache-Control: no-store` to prevent sensitive payment data from being
-cached by intermediaries.
+Responses to authorization challenges (402 Payment Required), responses
+that establish authorizations, and responses that consume authorized value
+SHOULD include `Cache-Control: no-store` to prevent sensitive payment data
+from being cached by intermediaries.
 
 # IANA Considerations
 
@@ -424,7 +653,7 @@ Intents" registry established by {{I-D.httpauth-payment}}:
 
 | Intent | Description | Reference |
 |--------|-------------|-----------|
-| `authorize` | Pre-authorization for future charges | This document |
+| `authorize` | Authorization for deferred capture | This document |
 
 --- back
 
@@ -432,5 +661,3 @@ Intents" registry established by {{I-D.httpauth-payment}}:
 
 The authors thank the MPP community for their feedback on this
 specification.
-
-

--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -624,17 +624,6 @@ Clients SHOULD prefer short authorization windows. Long-lived
 authorizations increase risk if credentials are compromised or merchant
 systems behave incorrectly.
 
-Recommended maximum windows:
-
-| Use Case | Recommended Max |
-|----------|-----------------|
-| Single session | 1 hour |
-| Daily usage | 24 hours |
-| Monthly billing | 30 days |
-
-These values are informational guidance. Deployments SHOULD evaluate
-their own risk tolerance and adjust authorization windows accordingly.
-
 ## Refund Expectations
 
 Clients MUST NOT assume that captured value can be refunded through the

--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -4,7 +4,7 @@ abbrev: Payment Intent Authorize
 docname: draft-payment-intent-authorize-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 
@@ -35,15 +35,20 @@ normative:
     author:
       - name: Jake Moxey
     date: 2026-01
+  I-D.ietf-httpapi-idempotency-key-header:
+    title: "The Idempotency-Key HTTP Header Field"
+    target: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/
+    author:
+      - name: Jayadeba Jena
+    date: 2024-06
 ---
 
 --- abstract
 
 This document defines the "authorize" payment intent for use with the
-Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. The "authorize"
-intent represents a pre-authorization where the payer grants the server
-permission to charge up to a specified amount within a time window,
-without immediate payment.
+Payment HTTP Authentication Scheme. The "authorize" intent represents a
+pre-authorization where the payer grants the server permission to charge
+up to a specified amount within a time window, without immediate payment.
 
 --- middle
 
@@ -53,9 +58,14 @@ The "authorize" intent enables pre-authorized payments where the payer
 grants the server permission to charge up to a specified amount at a
 later time. This is useful for:
 
-- **Metered billing**: Pay-per-use APIs where total cost is unknown upfront
-- **Delayed fulfillment**: Services where delivery occurs after authorization
-- **Spending caps**: User-controlled limits on automated spending
+Metered billing:
+: Pay-per-use APIs where total cost is unknown upfront
+
+Delayed fulfillment:
+: Services where delivery occurs after authorization
+
+Spending caps:
+: User-controlled limits on automated spending
 
 Unlike the "charge" intent which requires immediate payment, "authorize"
 creates a payment capability that the server can exercise later.
@@ -165,9 +175,14 @@ to REQUIRED in their method specification.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `amount` | string | Maximum authorization amount in base units |
+| `amount` | string | Maximum authorization amount in base units (stringified non-negative integer, no leading zeros) |
 | `currency` | string | Currency or asset identifier (see {{currency-formats}}) |
 | `authorizationExpires` | string | Authorization expiry timestamp in {{RFC3339}} format |
+
+The `amount` value MUST be a string representation of a non-negative
+integer in base 10 with no sign, decimal point, exponent, or
+surrounding whitespace. Leading zeros MUST NOT be used except for the
+value `"0"`.
 
 ### Optional Fields
 
@@ -183,6 +198,10 @@ Challenge expiry is conveyed by the `expires` auth-param in
 format. Request objects MUST NOT duplicate the challenge expiry value.
 The `authorizationExpires` field instead defines when the authorization
 itself expires.
+
+The `authorizationExpires` value MUST be strictly later than the
+challenge `expires` timestamp. Servers MUST reject credentials where
+`authorizationExpires` is at or before the challenge `expires`.
 
 ## Currency Formats {#currency-formats}
 
@@ -269,7 +288,8 @@ When the server receives an "authorize" credential:
 3. Initialize durable state for the authorization, including its
    remaining authorized amount
 4. Return success (200) to indicate authorization accepted
-5. Optionally return `Payment-Authorization` for session reuse
+5. Return success response; session reuse mechanisms are out of scope
+   for this specification
 
 Registration responses for `intent="authorize"` MUST NOT include a
 `Payment-Receipt` header. `Payment-Receipt` is reserved for later
@@ -291,7 +311,7 @@ When charging against an authorization, servers MUST perform the limit
 check and decrement atomically before, or atomically with, delivering the
 corresponding service.
 
-For retried requests, clients SHOULD send an `Idempotency-Key` header.
+For retried requests, clients SHOULD send an `Idempotency-Key` header per {{I-D.ietf-httpapi-idempotency-key-header}}.
 Servers MUST NOT decrement the remaining authorized amount more than once
 for a duplicate idempotent request.
 
@@ -321,6 +341,23 @@ mechanisms are method-specific:
 Servers MUST NOT charge against expired authorizations. Servers SHOULD
 provide a mechanism for payers to query authorization status.
 
+## Error Responses
+
+When an authorization cannot be used to fulfill a request, the server
+MUST return an appropriate HTTP status code:
+
+| Condition | Status Code | Behavior |
+|-----------|-------------|----------|
+| Authorization expired | 402 Payment Required | Issue new challenge |
+| Spending limit exhausted | 402 Payment Required | Issue new challenge |
+| Authorization revoked | 402 Payment Required | Issue new challenge |
+| Invalid credential | 401 Unauthorized | Reject credential |
+
+For all 402 responses, the server MUST include a `WWW-Authenticate`
+header with a fresh challenge. Clients receiving a 402 after a
+previously valid authorization SHOULD treat the authorization as
+exhausted and initiate a new authorization flow.
+
 # Security Considerations
 
 ## Limit Verification
@@ -345,6 +382,9 @@ Recommended maximum windows:
 | Daily usage | 24 hours |
 | Monthly billing | 30 days |
 
+These values are informational guidance. Deployments SHOULD evaluate
+their own risk tolerance and adjust authorization windows accordingly.
+
 ## Revocation Capability
 
 Payment methods implementing "authorize" SHOULD provide revocation
@@ -368,6 +408,13 @@ Servers holding authorizations are responsible for:
 - Providing transaction records to payers
 - Honoring revocation requests
 
+## Caching
+
+Responses to authorization challenges (402 Payment Required) and
+responses that consume authorized value SHOULD include
+`Cache-Control: no-store` to prevent sensitive payment data from being
+cached by intermediaries.
+
 # IANA Considerations
 
 ## Payment Intent Registration
@@ -386,4 +433,4 @@ Intents" registry established by {{I-D.httpauth-payment}}:
 The authors thank the MPP community for their feedback on this
 specification.
 
-TK: add other contributors.
+

--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -1,0 +1,389 @@
+---
+title: Authorize Intent for HTTP Payment Authentication
+abbrev: Payment Intent Authorize
+docname: draft-payment-intent-authorize-00
+version: 00
+category: info
+ipr: trust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Jake Moxey
+    ins: J. Moxey
+    email: jake@tempo.xyz
+    org: Tempo Labs
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    org: Tempo Labs
+  - name: Tom Meagher
+    ins: T. Meagher
+    email: thomas@tempo.xyz
+    org: Tempo Labs
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC4648:
+  RFC8174:
+  RFC8259:
+  RFC8785:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+---
+
+--- abstract
+
+This document defines the "authorize" payment intent for use with the
+Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. The "authorize"
+intent represents a pre-authorization where the payer grants the server
+permission to charge up to a specified amount within a time window,
+without immediate payment.
+
+--- middle
+
+# Introduction
+
+The "authorize" intent enables pre-authorized payments where the payer
+grants the server permission to charge up to a specified amount at a
+later time. This is useful for:
+
+- **Metered billing**: Pay-per-use APIs where total cost is unknown upfront
+- **Delayed fulfillment**: Services where delivery occurs after authorization
+- **Spending caps**: User-controlled limits on automated spending
+
+Unlike the "charge" intent which requires immediate payment, "authorize"
+creates a payment capability that the server can exercise later.
+
+## Relationship to Payment Methods
+
+Payment methods implement "authorize" using method-specific
+authorization mechanisms. This document defines the abstract semantics
+and shared request fields; payment method specifications define how
+those semantics are enforced.
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+Authorization
+: A grant of permission for a server to initiate payments up to a
+  specified limit within a specified time window, without requiring
+  immediate payment.
+
+Spending Limit
+: The maximum amount that can be charged against an authorization
+  before it is exhausted.
+
+Revocation
+: The act of canceling an authorization before its natural expiry,
+  preventing further charges.
+
+# Intent Semantics
+
+## Definition
+
+The "authorize" intent represents a request for the payer to grant
+permission for the server to initiate payments up to a specified limit,
+within a specified time window.
+
+## Properties
+
+| Property | Value |
+|----------|-------|
+| **Intent Identifier** | `authorize` |
+| **Payment Timing** | Deferred (server-initiated later) |
+| **Idempotency** | Credential single-use; authorization reusable within limits |
+| **Reversibility** | Revocable before use |
+
+## Flow
+
+~~~
+   Client                           Server                    Payment Network
+      │                                │                              │
+      │  (1) GET /resource             │                              │
+      ├───────────────────────────────>│                              │
+      │                                │                              │
+      │  (2) 402 Payment Required      │                              │
+      │      intent="authorize"        │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+      │  (3) Sign authorization        │                              │
+      │                                │                              │
+      │  (4) Authorization: Payment    │                              │
+      ├───────────────────────────────>│                              │
+      │                                │                              │
+      │                                │  (5) Register authorization  │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+      │  (6) 200 OK (authorized)       │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+      │        ... later ...           │                              │
+      │                                │                              │
+      │  (7) GET /resource             │                              │
+      ├───────────────────────────────>│                              │
+      │                                │  (8) Charge via auth         │
+      │                                ├─────────────────────────────>│
+      │                                │                              │
+      │  (9) 200 OK + Receipt          │                              │
+      │<───────────────────────────────┤                              │
+      │                                │                              │
+~~~
+
+## Non-Atomicity
+
+Unlike "charge", the "authorize" intent is non-atomic:
+
+- Authorization registration is separate from payment collection
+- Multiple charges may occur against a single authorization
+- Total charges MUST NOT exceed the authorized limit
+
+# Request Schema
+
+The `request` parameter for an "authorize" intent is a JSON object with
+shared fields defined by this specification and optional method-specific
+extensions in the `methodDetails` field. The `request` JSON MUST be
+serialized using JSON Canonicalization Scheme (JCS) {{RFC8785}} and
+base64url-encoded without padding per {{I-D.httpauth-payment}}.
+
+## Shared Fields
+
+All payment methods implementing the "authorize" intent MUST support these
+shared fields, enabling clients to parse and display authorization requests
+consistently across methods. Payment methods MAY elevate OPTIONAL fields
+to REQUIRED in their method specification.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `amount` | string | Maximum authorization amount in base units |
+| `currency` | string | Currency or asset identifier (see {{currency-formats}}) |
+| `authorizationExpires` | string | Authorization expiry timestamp in {{RFC3339}} format |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recipient` | string | Payment recipient in method-native format |
+| `description` | string | Human-readable authorization description |
+| `externalId` | string | Merchant's reference (order ID, etc.) |
+| `methodDetails` | object | Method-specific extension data |
+
+Challenge expiry is conveyed by the `expires` auth-param in
+`WWW-Authenticate` per {{I-D.httpauth-payment}}, using {{RFC3339}}
+format. Request objects MUST NOT duplicate the challenge expiry value.
+The `authorizationExpires` field instead defines when the authorization
+itself expires.
+
+## Currency Formats {#currency-formats}
+
+The `currency` field supports multiple formats to accommodate different
+payment networks:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| ISO 4217 | `"usd"`, `"eur"` | Fiat currencies (lowercase) |
+| Token address | `"0x20c0..."` | ERC-20, TIP-20, or similar token contracts |
+| Method-defined | (varies) | Payment method-specific currency identifiers |
+
+Payment method specifications MUST document which currency formats they
+support and how to interpret amounts for each format.
+
+## Method Extensions
+
+Payment methods MAY define additional fields in the `methodDetails` object.
+These fields are method-specific and MUST be documented in the payment
+method specification.
+
+## Examples
+
+### Traditional Payment Processor (Stripe)
+
+~~~ json
+{
+  "amount": "100000",
+  "currency": "usd",
+  "authorizationExpires": "2025-01-22T12:00:00Z",
+  "description": "Pre-authorization for metered API usage",
+  "methodDetails": {
+    "captureMethod": "manual"
+  }
+}
+~~~
+
+### Blockchain Payment (Tempo)
+
+~~~ json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "authorizationExpires": "2025-02-05T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431
+  }
+}
+~~~
+
+# Credential Requirements
+
+## Payload
+
+The credential `payload` for an "authorize" intent contains the
+authorization grant. The format is method-specific:
+
+| Authorization Type | Description | Example Methods |
+|-------------------|-------------|-----------------|
+| Signed Key Auth | Delegated signing key | Tempo Access Keys |
+| Token Approval | On-chain approval | EVM ERC-20 approve |
+| Saved Payment Method | Stored card/account | Stripe SetupIntent |
+
+## Reusability
+
+Each "authorize" credential MUST be usable only once per challenge.
+Servers MUST reject replayed credentials.
+
+A successfully registered authorization may enable multiple subsequent
+charges. The authorization persists until:
+
+- The `authorizationExpires` timestamp is reached
+- The spending limit is exhausted
+- The payer explicitly revokes it
+
+# Authorization Lifecycle
+
+## Registration
+
+When the server receives an "authorize" credential:
+
+1. Verify the authorization signature/proof
+2. Store the authorization for future use
+3. Initialize durable state for the authorization, including its
+   remaining authorized amount
+4. Return success (200) to indicate authorization accepted
+5. Optionally return `Payment-Authorization` for session reuse
+
+Registration responses for `intent="authorize"` MUST NOT include a
+`Payment-Receipt` header. `Payment-Receipt` is reserved for later
+successful responses that actually consume authorized value.
+
+## Server Accounting and Idempotency
+
+Servers MUST maintain durable authorization state sufficient to enforce
+remaining limits across concurrent requests and retries.
+
+At minimum, servers MUST track:
+
+- Authorization identifier
+- Remaining authorized amount
+- Authorization expiry
+- Revocation status
+
+When charging against an authorization, servers MUST perform the limit
+check and decrement atomically before, or atomically with, delivering the
+corresponding service.
+
+For retried requests, clients SHOULD send an `Idempotency-Key` header.
+Servers MUST NOT decrement the remaining authorized amount more than once
+for a duplicate idempotent request.
+
+## Charging
+
+When charging against an authorization:
+
+1. Verify the authorization is still valid (not expired, not revoked)
+2. Verify sufficient limit remains
+3. Execute the charge via method-specific mechanism
+4. Decrement the remaining limit atomically with service delivery
+5. Return `Payment-Receipt` with charge details
+
+## Revocation
+
+Payers SHOULD be able to revoke authorizations before expiry. Revocation
+mechanisms are method-specific:
+
+| Method | Revocation Mechanism |
+|--------|---------------------|
+| Tempo | Remove Access Key from account |
+| EVM | Set approval to zero |
+| Stripe | Detach PaymentMethod from Customer |
+
+## Expiry
+
+Servers MUST NOT charge against expired authorizations. Servers SHOULD
+provide a mechanism for payers to query authorization status.
+
+# Security Considerations
+
+## Limit Verification
+
+Clients MUST verify the requested limit is acceptable before signing.
+Authorizations grant future spending capability without further user
+interaction.
+
+Clients MUST verify `authorizationExpires` is not unreasonably far in the
+future.
+
+## Expiry Windows
+
+Clients SHOULD prefer short authorization windows. Long-lived
+authorizations increase risk if credentials are compromised.
+
+Recommended maximum windows:
+
+| Use Case | Recommended Max |
+|----------|-----------------|
+| Single session | 1 hour |
+| Daily usage | 24 hours |
+| Monthly billing | 30 days |
+
+## Revocation Capability
+
+Payment methods implementing "authorize" SHOULD provide revocation
+mechanisms. Payers MUST be able to revoke authorizations if they suspect
+compromise.
+
+## Authorization Scope
+
+Authorizations SHOULD be scoped as narrowly as possible:
+
+- Specific recipient address (not "any address")
+- Specific asset/currency
+- Reasonable limits and expiry
+
+## Server Accountability
+
+Servers holding authorizations are responsible for:
+
+- Secure storage of authorization data
+- Not exceeding authorized limits
+- Providing transaction records to payers
+- Honoring revocation requests
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the "authorize" intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Description | Reference |
+|--------|-------------|-----------|
+| `authorize` | Pre-authorization for future charges | This document |
+
+--- back
+
+# Acknowledgements
+
+The authors thank the MPP community for their feedback on this
+specification.
+
+TK: add other contributors.

--- a/specs/intents/draft-payment-intent-authorize-00.md
+++ b/specs/intents/draft-payment-intent-authorize-00.md
@@ -149,7 +149,7 @@ release, card network capture, or another method-specific mechanism.
       |                              |----------------------------->|
       |                              |                              |
       |  (6) 200 OK                  |  (authorization active)       |
-      |      authorization handle    |<-----------------------------|
+      |      optional metadata       |<-----------------------------|
       |<-----------------------------|                              |
       |                              |                              |
 ~~~
@@ -245,6 +245,9 @@ format. Request objects MUST NOT duplicate the challenge expiry value.
 The `authorizationExpires` field instead defines when the authorization
 itself expires.
 
+Servers issuing an "authorize" challenge MUST include the `expires`
+auth-param.
+
 The `authorizationExpires` value MUST be strictly later than the
 challenge `expires` timestamp. Servers MUST reject credentials where
 `authorizationExpires` is at or before the challenge `expires`.
@@ -275,7 +278,8 @@ support and how to interpret amounts for each format.
   "recipient": "acct_merchant",
   "description": "Pre-authorization for metered API usage",
   "methodDetails": {
-    "networkId": "profile_1MqDcVKA5fEO2tZvKQm9g8Yj"
+    "networkId": "profile_1MqDcVKA5fEO2tZvKQm9g8Yj",
+    "paymentMethodTypes": ["card", "link"]
   }
 }
 ~~~
@@ -582,7 +586,7 @@ MUST return an appropriate HTTP status code:
 | Authorization expired | 402 Payment Required | Issue new challenge |
 | Authorized amount exhausted | 402 Payment Required | Issue new challenge |
 | Authorization voided or closed | 402 Payment Required | Issue new challenge |
-| Invalid credential | 401 Unauthorized | Reject credential |
+| Invalid credential | 402 Payment Required | Issue new challenge |
 
 For all 402 responses, the server MUST include a `WWW-Authenticate`
 header with a fresh challenge. Clients receiving a 402 after a previously
@@ -654,6 +658,8 @@ Intents" registry established by {{I-D.httpauth-payment}}:
 | Intent | Description | Reference |
 |--------|-------------|-----------|
 | `authorize` | Authorization for deferred capture | This document |
+
+Contact: Tempo Labs (<contact@tempo.xyz>)
 
 --- back
 

--- a/specs/methods/stripe/draft-stripe-authorize-00.md
+++ b/specs/methods/stripe/draft-stripe-authorize-00.md
@@ -1,0 +1,661 @@
+---
+title: Stripe authorize Intent for HTTP Payment Authentication
+abbrev: Stripe Authorize
+docname: draft-stripe-authorize-00
+version: 00
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    org: Tempo Labs
+  - name: Steve Kaliski
+    ins: S. Kaliski
+    email: stevekaliski@stripe.com
+    org: Stripe
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC8174:
+  RFC8785:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+  I-D.payment-intent-authorize:
+    title: "Authorize Intent for HTTP Payment Authentication"
+    target: https://datatracker.ietf.org/doc/draft-payment-intent-authorize/
+    author:
+      - name: Jake Moxey
+    date: 2026-03
+  STRIPE-API:
+    target: https://stripe.com/docs/api
+    title: Stripe API Reference
+    author:
+      - org: Stripe, Inc.
+  STRIPE-SPT:
+    target: https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens
+    title: Shared payment tokens
+    author:
+      - org: Stripe, Inc.
+---
+
+--- abstract
+
+This document defines the "authorize" intent for the Stripe payment method
+within the Payment HTTP Authentication Scheme. It specifies how clients
+grant payment authority using Shared Payment Tokens and how servers
+create Stripe PaymentIntents with manual capture.
+
+--- middle
+
+# Introduction
+
+The `authorize` intent for Stripe uses a Shared Payment Token (SPT) and a
+Stripe PaymentIntent with manual capture. The client creates an SPT for
+the maximum authorized amount using Stripe client-side flows. The server
+then creates and confirms a PaymentIntent with `capture_method=manual`
+and `payment_method_data[shared_payment_granted_token]` set to the SPT.
+The authorization is active when the PaymentIntent reaches
+`requires_capture`.
+
+The server later captures against that PaymentIntent. Stripe may support
+multiple captures for eligible card payments. If multicapture is not
+available, the implementation can still satisfy the authorize intent with
+a single final capture or by issuing fresh authorizations where additional
+captures are required.
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+PaymentIntent
+: A Stripe API object that tracks the lifecycle of a customer payment,
+  from confirmation through capture, cancellation, and refund. Not to be
+  confused with the HTTP Payment Auth `intent` parameter.
+
+Shared Payment Token (SPT)
+: A single-use token (prefixed with `spt_`) that represents authorization
+  to charge a payment method. SPTs are created by clients using Stripe
+  client-side flows and consumed by servers when creating PaymentIntents.
+  In the Stripe API, SPTs are provided as
+  `payment_method_data[shared_payment_granted_token]` on PaymentIntent
+  creation. See {{STRIPE-SPT}}.
+
+Manual Capture
+: A Stripe PaymentIntent configuration where confirmation authorizes the
+  payment method and a later server-side capture operation captures
+  funds.
+
+# Intent Identifier
+
+This specification defines the following intent for the `stripe` payment
+method:
+
+~~~
+authorize
+~~~
+
+The intent identifier is case-sensitive and MUST be lowercase.
+
+# Intent: "authorize"
+
+An authorization of up to the specified amount. The server creates a
+manual-capture PaymentIntent after receiving the SPT and may later
+capture against that PaymentIntent.
+
+**Fulfillment mechanism:**
+
+1. **Shared Payment Token (SPT)**: The payer creates an SPT using Stripe
+   client-side flows, which the server uses to create a PaymentIntent via
+   Stripe.
+
+## Stripe Authorize Flow
+
+~~~
+   Client                      Server                         Stripe
+      |                           |                              |
+      |  (1) GET /resource        |                              |
+      |-------------------------->|                              |
+      |                           |                              |
+      |  (2) 402 Payment Required |                              |
+      |<--------------------------|                              |
+      |                           |                              |
+      |  (3) Create SPT using Stripe client-side flows            |
+      |--------------------------------------------------------->|
+      |                           |                              |
+      |  (4) Authorization:       |                              |
+      |      Payment <credential> |  (payload contains SPT)       |
+      |-------------------------->|                              |
+      |                           |  (5) Create PaymentIntent     |
+      |                           |      capture_method=manual    |
+      |                           |      confirm=true, SPT        |
+      |                           |----------------------------->|
+      |                           |                              |
+      |  (6) 200 OK               |                              |
+      |      authorization active |                              |
+      |<--------------------------|                              |
+      |                           |                              |
+      |         ... later ...     |                              |
+      |                           |                              |
+      |                           |  (7) Capture PaymentIntent    |
+      |                           |----------------------------->|
+      |                           |                              |
+      |  (8) 200 OK + receipt     |                              |
+      |<--------------------------|                              |
+      |                           |                              |
+~~~
+
+## Relationship to the Payment Scheme
+
+This document is a payment method intent specification as defined in
+{{I-D.httpauth-payment}}. It defines the `request` and `payload`
+structures for the `authorize` intent of the `stripe` payment method,
+along with verification, authorization, capture, and void procedures.
+
+# Request Schema
+
+The `request` parameter in the `WWW-Authenticate` challenge contains a
+base64url-encoded JSON object with the following fields. The JSON MUST be
+serialized using JSON Canonicalization Scheme (JCS) {{RFC8785}} before
+base64url encoding, per {{I-D.httpauth-payment}}.
+
+## Shared Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | string | REQUIRED | Maximum authorization amount in the smallest currency unit |
+| `currency` | string | REQUIRED | Three-letter ISO currency code, lowercase |
+| `authorizationExpires` | string | REQUIRED | Latest intended capture time in {{RFC3339}} format |
+| `recipient` | string | OPTIONAL | Stripe business or merchant identifier |
+| `description` | string | OPTIONAL | Human-readable authorization description |
+| `externalId` | string | OPTIONAL | Merchant reference, order ID, or cart ID |
+
+## Method Details
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `methodDetails.networkId` | string | REQUIRED | Stripe Business Network Profile ID |
+| `methodDetails.paymentMethodTypes` | []string | REQUIRED | Seller-supported payment method types |
+
+The challenge request does not contain a PaymentIntent ID or a
+PaymentIntent client secret. The client fulfills the challenge by creating
+an SPT scoped to the challenged amount, currency, expiry, and seller
+details. The server consumes that SPT when creating the manual-capture
+PaymentIntent.
+
+**Example:**
+
+~~~json
+{
+  "amount": "100000",
+  "currency": "usd",
+  "recipient": "acct_merchant",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
+  "description": "Pre-authorization for metered API usage",
+  "externalId": "order_12345",
+  "methodDetails": {
+    "networkId": "profile_1MqDcVKA5fEO2tZvKQm9g8Yj",
+    "paymentMethodTypes": ["card", "link"]
+  }
+}
+~~~
+
+# Credential Schema
+
+The Payment credential is a base64url-encoded JSON object containing
+`challenge` and `payload` fields per {{I-D.httpauth-payment}}. For Stripe
+authorize, the `payload` object contains the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spt` | string | REQUIRED | Shared Payment Token ID |
+| `externalId` | string | OPTIONAL | Client reference ID |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "auth_1a2b3c4d5e",
+    "realm": "api.example.com",
+    "method": "stripe",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2026-05-13T12:05:00Z"
+  },
+  "payload": {
+    "spt": "spt_1N4Zv32eZvKYlo2CPhVPkJlW"
+  }
+}
+~~~
+
+# Verification Procedure
+
+Servers MUST verify Stripe authorize credentials as follows:
+
+1. Verify the challenge ID matches an outstanding challenge.
+2. Verify the challenge has not expired.
+3. Extract the `spt` from the credential payload.
+4. Verify the SPT has not been previously used for this challenge.
+5. Verify the SPT is usable. If Stripe indicates that the SPT is
+   revoked, expired, requires additional action, or is otherwise
+   unusable, reject the credential.
+6. Create and confirm a PaymentIntent using the SPT, with `amount`,
+   `currency`, `capture_method`, merchant context, and metadata matching
+   the challenge.
+7. Verify the PaymentIntent has `capture_method=manual`.
+8. Verify the PaymentIntent status is `requires_capture`.
+9. Store durable authorization state for later capture or cancellation.
+
+Servers MUST complete challenge validation before acting on Stripe
+credential material.
+
+# Authorization Lifecycle
+
+## Creating the SPT
+
+The client creates an SPT using Stripe client-side flows. This step can
+use Stripe's standard card collection and authentication flow. The SPT
+MUST be scoped to the challenged currency, maximum amount, expiry, and
+seller details.
+
+If creating or preparing the SPT requires additional customer action, the
+client MUST complete that action before submitting the Payment credential
+to the server. Clients MUST NOT submit an SPT that is not usable for
+PaymentIntent creation.
+
+~~~javascript
+const spt = await stripe.sharedPayment.issuedTokens.create({
+  payment_method: "pm_123",
+  usage_limits: {
+    currency: request.currency,
+    max_amount: Number(request.amount),
+    expires_at: expiresAt
+  },
+  seller_details: {
+    network_business_profile: request.methodDetails.networkId
+  }
+});
+~~~
+
+## Creating the PaymentIntent
+
+After receiving the Payment credential, the server creates and confirms a
+PaymentIntent with manual capture. For example:
+
+~~~javascript
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: Number(request.amount),
+  currency: request.currency,
+  capture_method: "manual",
+  payment_method_data: {
+    shared_payment_granted_token: credential.spt
+  },
+  confirm: true,
+  automatic_payment_methods: {
+    enabled: true,
+    allow_redirects: "never"
+  },
+  metadata: {
+    challenge_id: challenge.id,
+    external_id: request.externalId
+  }
+}, {
+  idempotencyKey: `${challenge.id}_${credential.spt}`
+});
+~~~
+
+The server MUST verify that the resulting PaymentIntent status is
+`requires_capture` before accepting the authorization. If Stripe returns a
+state that requires additional client action or otherwise cannot be
+authorized synchronously, the server MUST reject the credential and issue
+a fresh challenge.
+
+## Capture
+
+Captures are server-side Stripe API calls. The client does not need to
+know whether the Stripe implementation performs one capture or multiple
+captures.
+
+If Stripe multicapture is available for the PaymentIntent, the server MAY
+perform multiple partial captures using Stripe's supported capture
+parameters and leave the PaymentIntent capturable until the final capture.
+
+If multicapture is not available, the server MUST use a fallback that
+still respects the core authorize semantics:
+
+Single capture:
+: The server delays capture until the final amount is known, then captures
+  once and cancels or releases any uncaptured remainder according to
+  Stripe behavior.
+
+Fresh authorization:
+: The server issues a fresh authorize challenge and creates a new
+  PaymentIntent for a later fulfillment unit that cannot be captured under
+  the original PaymentIntent.
+
+Stored credential:
+: Where the payer has separately consented to stored credential or
+  off-session use, the server MAY create additional PaymentIntents under
+  the applicable Stripe rules. This is distinct from the original
+  authorize credential and MUST comply with Stripe and payment network
+  requirements.
+
+## Void
+
+Void maps to canceling an uncaptured PaymentIntent. Servers SHOULD cancel
+manual-capture PaymentIntents when no further capture is expected. Stripe
+releases uncaptured funds according to payment method and network rules.
+
+## Refund Requests
+
+Refunds are out of band for this intent. Clients MAY request refunds
+through merchant-defined channels. Servers MAY honor those requests by
+creating Stripe Refunds or through other merchant policy. This
+specification does not require client-side Stripe refund capability.
+
+# Receipt Generation
+
+Registration responses for `intent="authorize"` MUST NOT include a
+`Payment-Receipt` header. Servers MUST return a `Payment-Receipt` header
+only on successful responses that actually consume or capture authorized
+value, per {{I-D.httpauth-payment}}.
+
+The receipt payload for Stripe authorize:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `"stripe"` |
+| `intent` | string | `"authorize"` |
+| `reference` | string | Stripe PaymentIntent ID |
+| `capturedAmount` | string | Cumulative captured amount after this capture |
+| `delta` | string | Amount captured by this receipt |
+| `status` | string | `"success"` |
+| `timestamp` | string | {{RFC3339}} capture time |
+| `externalId` | string | OPTIONAL. Echoed from the challenge request or credential |
+
+# Security Considerations
+
+## Authorization Amount
+
+Clients MUST verify the maximum authorization amount, currency, expiry,
+and seller details before creating the SPT. A consumed SPT can produce a
+manual-capture PaymentIntent that allows later server-side capture without
+further client interaction, subject to Stripe and payment network rules.
+
+## SPT Single-Use Constraint
+
+SPTs are single-use tokens. Stripe automatically prevents SPT reuse at the
+API level, and idempotency keys prevent duplicate PaymentIntent creation.
+Servers MUST enforce single-use challenge IDs per
+{{I-D.httpauth-payment}} and SHOULD use Stripe idempotency keys derived
+from the challenge ID and SPT.
+
+## PaymentIntent Binding
+
+Servers MUST bind created PaymentIntents to challenge IDs using metadata
+or equivalent durable state and verify the binding before later capture.
+The authorize challenge does not require a PaymentIntent client secret,
+and implementations MUST NOT include PaymentIntent client secrets in
+`WWW-Authenticate` parameters or in the base64url-encoded challenge
+`request`.
+
+## Capture Windows
+
+Payment method and card network rules constrain how long a Stripe
+authorization can remain capturable. Servers MUST NOT advertise an
+`authorizationExpires` value that they cannot honor for the selected
+PaymentIntent and payment method.
+
+## Refund Expectations
+
+Clients MUST NOT assume refunds can be initiated directly by the client.
+Refunds require merchant or platform action and are subject to Stripe,
+payment network, and merchant policy.
+
+# IANA Considerations
+
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|--------|-------------------|-------------|-----------|
+| `authorize` | `stripe` | Manual-capture Stripe PaymentIntent authorization | This document |
+
+--- back
+
+# ABNF Collected
+
+~~~abnf
+stripe-authorize-challenge = "Payment" 1*SP
+  "id=" quoted-string ","
+  "realm=" quoted-string ","
+  "method=" DQUOTE "stripe" DQUOTE ","
+  "intent=" DQUOTE "authorize" DQUOTE ","
+  "request=" base64url-nopad
+
+stripe-authorize-credential = "Payment" 1*SP base64url-nopad
+
+; Base64url encoding without padding per RFC 4648 Section 5
+base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
+~~~
+
+# Example
+
+**Challenge:**
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="auth_1a2b3c4d5e",
+  realm="api.example.com",
+  method="stripe",
+  intent="authorize",
+  expires="2026-05-13T12:05:00Z",
+  request="<base64url-encoded JSON below>"
+Cache-Control: no-store
+~~~
+
+Decoded request:
+
+~~~json
+{
+  "amount": "100000",
+  "currency": "usd",
+  "recipient": "acct_merchant",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
+  "description": "Pre-authorization for metered API usage",
+  "externalId": "order_12345",
+  "methodDetails": {
+    "networkId": "profile_1MqDcVKA5fEO2tZvKQm9g8Yj",
+    "paymentMethodTypes": ["card", "link"]
+  }
+}
+~~~
+
+**Client creates SPT:**
+
+~~~javascript
+const spt = await stripe.sharedPayment.issuedTokens.create({
+  payment_method: "pm_123",
+  usage_limits: {
+    currency: "usd",
+    max_amount: 100000,
+    expires_at: 1778760000
+  },
+  seller_details: {
+    network_business_profile: "profile_1MqDcVKA5fEO2tZvKQm9g8Yj"
+  }
+});
+~~~
+
+**Credential:**
+
+~~~json
+{
+  "challenge": {
+    "id": "auth_1a2b3c4d5e",
+    "realm": "api.example.com",
+    "method": "stripe",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2026-05-13T12:05:00Z"
+  },
+  "payload": {
+    "spt": "spt_1N4Zv32eZvKYlo2CPhVPkJlW"
+  }
+}
+~~~
+
+**Authorization active response:**
+
+~~~http
+HTTP/1.1 200 OK
+Cache-Control: no-store
+Content-Type: application/json
+
+{
+  "authorization": {
+    "id": "pi_1N4Zv32eZvKYlo2CPhVPkJlW",
+    "method": "stripe",
+    "status": "authorized",
+    "amount": "100000",
+    "capturedAmount": "0",
+    "remainingAmount": "100000",
+    "currency": "usd",
+    "recipient": "acct_merchant",
+    "authorizationExpires": "2026-05-14T12:00:00Z"
+  }
+}
+~~~
+
+## Capture Examples
+
+### Multicapture Implementation
+
+If Stripe multicapture is available, the server can capture less than the
+full authorized amount while leaving the PaymentIntent capturable for
+later captures.
+
+Decoded first capture receipt:
+
+~~~json
+{
+  "method": "stripe",
+  "intent": "authorize",
+  "reference": "pi_1N4Zv32eZvKYlo2CPhVPkJlW",
+  "capturedAmount": "25000",
+  "delta": "25000",
+  "status": "success",
+  "timestamp": "2026-05-13T12:10:00Z",
+  "externalId": "order_12345"
+}
+~~~
+
+Decoded later capture receipt:
+
+~~~json
+{
+  "method": "stripe",
+  "intent": "authorize",
+  "reference": "pi_1N4Zv32eZvKYlo2CPhVPkJlW",
+  "capturedAmount": "60000",
+  "delta": "35000",
+  "status": "success",
+  "timestamp": "2026-05-13T12:30:00Z",
+  "externalId": "order_12345"
+}
+~~~
+
+### Single-Capture Fallback
+
+If Stripe multicapture is not available, the server can delay capture
+until the final amount is known and then perform one capture. In this
+example, the server captures 60.00 USD from a 100.00 USD authorization;
+Stripe releases uncaptured value according to PaymentIntent and network
+rules.
+
+~~~json
+{
+  "method": "stripe",
+  "intent": "authorize",
+  "reference": "pi_1N4Zv32eZvKYlo2CPhVPkJlW",
+  "capturedAmount": "60000",
+  "delta": "60000",
+  "status": "success",
+  "timestamp": "2026-05-13T12:30:00Z",
+  "externalId": "order_12345"
+}
+~~~
+
+### Fresh-Authorization Fallback
+
+If a later fulfillment unit cannot be captured under the original
+PaymentIntent, the server issues a fresh 402 challenge and creates a new
+PaymentIntent.
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="auth_next_1",
+  realm="api.example.com",
+  method="stripe",
+  intent="authorize",
+  expires="2026-05-13T13:05:00Z",
+  request="<base64url-encoded request for the next authorization>"
+Cache-Control: no-store
+~~~
+
+## Void Example
+
+If no capture is needed, or no additional capture is expected, the server
+cancels the uncaptured PaymentIntent.
+
+~~~json
+{
+  "authorizationId": "pi_1N4Zv32eZvKYlo2CPhVPkJlW",
+  "status": "voided",
+  "releasedAmount": "40000"
+}
+~~~
+
+## Out-of-Band Refund Request Example
+
+After capture, the client MAY request a refund through a merchant-defined
+interface. The merchant can honor the request by creating a Stripe Refund,
+but this is outside the core authorize lifecycle.
+
+~~~http
+POST /payments/stripe/authorizations/pi_1N4Zv32eZvKYlo2CPhVPkJlW/refund-requests HTTP/1.1
+Host: api.example.com
+Content-Type: application/json
+
+{
+  "reason": "requested_by_customer"
+}
+~~~
+
+~~~http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+  "refundRequestId": "rr_456",
+  "status": "pending_review"
+}
+~~~
+
+# Acknowledgements
+
+The authors thank the Tempo and Stripe communities for their feedback on
+this specification.

--- a/specs/methods/stripe/draft-stripe-authorize-00.md
+++ b/specs/methods/stripe/draft-stripe-authorize-00.md
@@ -25,7 +25,7 @@ normative:
   RFC8785:
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
     author:
       - name: Jake Moxey
     date: 2026-01
@@ -189,9 +189,17 @@ base64url encoding, per {{I-D.httpauth-payment}}.
 
 The challenge request does not contain a PaymentIntent ID or a
 PaymentIntent client secret. The client fulfills the challenge by creating
-an SPT scoped to the challenged amount, currency, expiry, and seller
-details. The server consumes that SPT when creating the manual-capture
-PaymentIntent.
+an SPT scoped to the challenged amount, currency, expiry, seller details,
+and one of the listed `methodDetails.paymentMethodTypes` values. The
+server consumes that SPT when creating the manual-capture PaymentIntent.
+
+The `amount` value MUST fit the Stripe API integer amount range for the
+selected currency and payment method. Implementations MUST reject values
+that cannot be converted to an exact Stripe integer amount.
+
+Servers issuing a Stripe authorize challenge MUST include the `expires`
+auth-param. The `authorizationExpires` value MUST be strictly later than
+the challenge `expires` timestamp.
 
 **Example:**
 
@@ -275,11 +283,17 @@ to the server. Clients MUST NOT submit an SPT that is not usable for
 PaymentIntent creation.
 
 ~~~javascript
+const amount = BigInt(request.amount);
+if (amount > BigInt(Number.MAX_SAFE_INTEGER)) {
+  throw new Error("amount exceeds exact JavaScript integer range");
+}
+const stripeAmount = Number(amount);
+
 const spt = await stripe.sharedPayment.issuedTokens.create({
   payment_method: "pm_123",
   usage_limits: {
     currency: request.currency,
-    max_amount: Number(request.amount),
+    max_amount: stripeAmount,
     expires_at: expiresAt
   },
   seller_details: {
@@ -294,18 +308,21 @@ After receiving the Payment credential, the server creates and confirms a
 PaymentIntent with manual capture. For example:
 
 ~~~javascript
+const amount = BigInt(request.amount);
+if (amount > BigInt(Number.MAX_SAFE_INTEGER)) {
+  throw new Error("amount exceeds exact JavaScript integer range");
+}
+const stripeAmount = Number(amount);
+
 const paymentIntent = await stripe.paymentIntents.create({
-  amount: Number(request.amount),
+  amount: stripeAmount,
   currency: request.currency,
   capture_method: "manual",
+  payment_method_types: request.methodDetails.paymentMethodTypes,
   payment_method_data: {
     shared_payment_granted_token: credential.spt
   },
   confirm: true,
-  automatic_payment_methods: {
-    enabled: true,
-    allow_redirects: "never"
-  },
   metadata: {
     challenge_id: challenge.id,
     external_id: request.externalId
@@ -425,14 +442,7 @@ payment network, and merchant policy.
 
 # IANA Considerations
 
-## Payment Intent Registration
-
-This document registers the following payment intent in the "HTTP Payment
-Intents" registry established by {{I-D.httpauth-payment}}:
-
-| Intent | Applicable Methods | Description | Reference |
-|--------|-------------------|-------------|-----------|
-| `authorize` | `stripe` | Manual-capture Stripe PaymentIntent authorization | This document |
+This document has no IANA actions.
 
 --- back
 
@@ -444,6 +454,7 @@ stripe-authorize-challenge = "Payment" 1*SP
   "realm=" quoted-string ","
   "method=" DQUOTE "stripe" DQUOTE ","
   "intent=" DQUOTE "authorize" DQUOTE ","
+  "expires=" quoted-string ","
   "request=" base64url-nopad
 
 stripe-authorize-credential = "Payment" 1*SP base64url-nopad

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -4,7 +4,7 @@ abbrev: Tempo Authorize
 docname: draft-tempo-authorize-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 
@@ -12,15 +12,15 @@ author:
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Brendan Ryan
     ins: B. Ryan
     email: brendan@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
   - name: Tom Meagher
     ins: T. Meagher
     email: thomas@tempo.xyz
-    organization: Tempo Labs
+    org: Tempo Labs
 
 normative:
   RFC2119:
@@ -55,6 +55,13 @@ informative:
     author:
       - name: Vitalik Buterin
     date: 2016-01
+  EIP-20:
+    title: "ERC-20 Token Standard"
+    target: https://eips.ethereum.org/EIPS/eip-20
+    author:
+      - name: Fabian Vogelsteller
+      - name: Vitalik Buterin
+    date: 2015-11
   TEMPO-TX-SPEC:
     title: "Tempo Transaction Specification"
     target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
@@ -70,9 +77,8 @@ informative:
 --- abstract
 
 This document defines the "authorize" intent for the "tempo" payment method
-in the Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. It
-specifies how clients grant servers spending limits with expiry on the
-Tempo blockchain.
+in the Payment HTTP Authentication Scheme. It specifies how clients grant
+servers spending limits with expiry on the Tempo blockchain.
 
 --- middle
 
@@ -162,10 +168,10 @@ base64url-encoded without padding per {{I-D.httpauth-payment}}.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Maximum spend amount in base units |
+| `amount` | string | REQUIRED | Amount in base units (stringified non-negative integer, no leading zeros) |
 | `currency` | string | REQUIRED | TIP-20 token address |
 | `authorizationExpires` | string | REQUIRED | Authorization expiry timestamp in {{RFC3339}} format |
-| `recipient` | string | OPTIONAL | Authorized spender address (required for transaction fulfillment) |
+| `recipient` | string | OPTIONAL | Authorized spender address; REQUIRED for `type="transaction"` fulfillment, OPTIONAL for `type="keyAuthorization"` |
 | `description` | string | OPTIONAL | Human-readable authorization description |
 | `externalId` | string | OPTIONAL | Merchant's reference (order ID, etc.) |
 
@@ -173,7 +179,7 @@ base64url-encoded without padding per {{I-D.httpauth-payment}}.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID (default: 42431) |
+| `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID. If omitted, the default value is 42431 (Tempo mainnet). |
 | `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees (default: `false`) |
 | `methodDetails.validFrom` | string | OPTIONAL | Start timestamp in {{RFC3339}} format |
 
@@ -182,6 +188,10 @@ Challenge expiry is conveyed by the `expires` auth-param in
 format. Request objects MUST NOT duplicate the challenge expiry value.
 The `authorizationExpires` field instead defines when the authorization
 itself expires.
+
+The `authorizationExpires` value MUST be strictly later than the
+challenge `expires` timestamp. Servers MUST reject credentials where
+`authorizationExpires` is at or before the challenge `expires`.
 
 **Example:**
 
@@ -231,6 +241,10 @@ JSON object per {{I-D.httpauth-payment}}.
 | `challenge` | object | REQUIRED | Echo of the challenge from the server |
 | `payload` | object | REQUIRED | Tempo-specific payload object |
 | `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
+
+The `source` field, if present, SHOULD use the `did:pkh` method with
+the chain ID applicable to the challenge and the payer's Ethereum
+address.
 
 ## Transaction Payload (type="transaction")
 
@@ -502,11 +516,23 @@ Servers MUST verify the payer identity by:
 - For `type="hash"`: Retrieving the `from` address from the transaction
   receipt onchain
 
+## Caching
+
+Responses to authorization challenges (402 Payment Required) and
+responses that consume authorized value SHOULD include
+`Cache-Control: no-store` to prevent sensitive payment data from being
+cached by intermediaries.
+
 # IANA Considerations
 
-This document does not require any IANA actions. The `tempo` payment
-method is already registered, and the `authorize` intent is registered by
-{{I-D.payment-intent-authorize}}.
+## Payment Intent Registration
+
+This document registers the following payment intent in the "HTTP Payment
+Intents" registry established by {{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|--------|-------------------|-------------|-----------|
+| `authorize` | `tempo` | Pre-authorization for future TIP-20 charges | This document |
 
 --- back
 
@@ -560,9 +586,25 @@ This requests approval for up to 50.00 alphaUSD (50000000 base units).
 }
 ~~~
 
+# ABNF Collected
+
+~~~ abnf
+tempo-authorize-challenge = "Payment" 1*SP
+  "id=" quoted-string ","
+  "realm=" quoted-string ","
+  "method=" DQUOTE "tempo" DQUOTE ","
+  "intent=" DQUOTE "authorize" DQUOTE ","
+  "request=" base64url-nopad
+
+tempo-authorize-credential = "Payment" 1*SP base64url-nopad
+
+; Base64url encoding without padding per RFC 4648 Section 5
+base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
+~~~
+
 # Acknowledgements
 
 The authors thank the MPP community for their feedback on this
 specification.
 
-TK: add other contributors.
+

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -47,6 +47,19 @@ normative:
     author:
       - name: Micah Zoltu
     date: 2020-10
+  EIP-712:
+    title: "Typed structured data hashing and signing"
+    target: https://eips.ethereum.org/EIPS/eip-712
+    author:
+      - name: Remco Bloemen
+    date: 2017-09
+  TIP-1034:
+    title: "TIP-20 Channel Escrow Precompile"
+    target: https://tips.sh/1034-1
+    author:
+      - name: Tanishk Goyal
+      - name: Brendan Ryan
+    date: 2026-04
   TEMPO-TX-SPEC:
     title: "Tempo Transaction Specification"
     target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
@@ -59,36 +72,45 @@ informative:
     target: https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md
     author:
       - org: W3C Credentials Community Group
-  SOLIDITY-ABI:
-    title: "Contract ABI Specification"
-    target: https://docs.soliditylang.org/en/latest/abi-spec.html
-    author:
-      - org: Solidity
 ---
 
 --- abstract
 
 This document defines the "authorize" intent for the "tempo" payment
-method in the Payment HTTP Authentication Scheme. It specifies an
-escrow-backed authorization flow where a client signs a Tempo transaction
-that funds an escrow, and an operator later captures value up to the
-authorized amount.
+method in the Payment HTTP Authentication Scheme. It profiles the
+TIP-1034 TIP-20 channel escrow precompile for authorization-and-capture
+flows. The payer opens a channel funded up to a maximum amount, and the
+operator later captures value through TIP-1034 cumulative voucher
+settlement.
 
 --- middle
 
 # Introduction
 
-The `authorize` intent for Tempo creates an on-chain escrow authorization.
-The payer signs a Tempo transaction that calls an escrow contract's
-`authorize` function and transfers the maximum authorized amount into
-escrow. The server broadcasts that transaction, optionally sponsoring
-fees. After the authorization is active, an operator can capture value to
-the recipient, using cumulative capture semantics. The operator can also
-void remaining uncaptured value.
+The `authorize` intent for Tempo creates an authorization by opening a
+TIP-1034 channel. The payer signs a Tempo transaction that calls the
+canonical TIP-20 channel escrow precompile's `open` function. That call
+escrows the maximum authorized amount. After the authorization is active,
+an operator captures value by submitting TIP-1034 vouchers signed by the
+channel's `authorizedSigner`.
 
-This flow provides a true authorization-and-capture model: funds are
-reserved at authorization time, captured value cannot exceed the escrowed
-amount, and unused value can be returned to the payer.
+This document does not define a separate Tempo authorization escrow
+contract. Instead, it maps the HTTP Payment Authentication authorize
+lifecycle onto TIP-1034:
+
+| Authorize lifecycle | TIP-1034 operation |
+|---------------------|--------------------|
+| Create authorization | `open(payee, operator, token, deposit, salt, authorizedSigner)` |
+| Authorization identifier | `channelId` |
+| Partial capture | `settle(descriptor, cumulativeAmount, signature)` |
+| Final capture and release | `close(descriptor, cumulativeAmount, captureAmount, signature)` |
+| Void unused value | `close(descriptor, settled, settled, emptySignature)` |
+| Payer-initiated reclaim | `requestClose(descriptor)` followed by `withdraw(descriptor)` after the close grace period |
+
+TIP-1034 channels do not carry an on-chain `authorizationExpires` field.
+For this profile, `authorizationExpires` is enforced by the server and
+operator. Implementations that require on-chain expiry enforcement need a
+future TIP-1034 extension or a separate adapter.
 
 ## Flow
 
@@ -100,26 +122,29 @@ amount, and unused value can be returned to the payer.
       |                              |                              |
       |  (2) 402 Payment Required    |                              |
       |      intent="authorize"      |                              |
+      |      amount, recipient,      |                              |
+      |      operator, signer        |                              |
       |<-----------------------------|                              |
       |                              |                              |
       |  (3) Sign tx calling         |                              |
-      |      escrow.authorize(info)  |                              |
+      |      TIP-1034.open(...)      |                              |
       |                              |                              |
       |  (4) Authorization: Payment  |                              |
-      |      signed transaction      |                              |
+      |      signed open tx          |                              |
       |----------------------------->|                              |
       |                              |  (5) Add fee-payer signature  |
       |                              |      if requested             |
-      |                              |  (6) Broadcast transaction    |
+      |                              |  (6) Broadcast open tx        |
       |                              |----------------------------->|
       |                              |                              |
-      |  (7) 200 OK                  |  (escrow funded)              |
+      |  (7) 200 OK                  |  (channel funded)             |
       |      authorization active    |<-----------------------------|
       |<-----------------------------|                              |
       |                              |                              |
       |         ... later ...        |                              |
       |                              |                              |
-      |                              |  (8) capture(cumulative)      |
+      |                              |  (8) settle(voucher)          |
+      |                              |      or close(voucher)        |
       |                              |----------------------------->|
       |                              |                              |
       |  (9) 200 OK + receipt        |  (delta paid to recipient)    |
@@ -134,26 +159,49 @@ amount, and unused value can be returned to the payer.
 # Terminology
 
 TIP-20
-: Tempo's enshrined token standard, implemented as precompiles rather
-  than smart contracts. TIP-20 tokens use 6 decimal places.
+: Tempo's enshrined token standard. TIP-20 tokens use 6 decimal places.
+
+TIP-1034 Channel Escrow
+: The canonical TIP-20 channel escrow precompile at
+  `0x4d50500000000000000000000000000000000000`.
 
 Tempo Transaction
 : An EIP-2718 transaction with type prefix `0x76`, supporting batched
   calls, multiple signature types, 2D nonces, and validity windows.
 
-Escrow Contract
-: A contract that holds authorized funds and enforces capture, void, and
-  reclaim semantics.
-
 Payer
-: The account that funds the escrow authorization.
+: The account that funds the authorization channel.
 
 Recipient
-: The address that receives captured funds.
+: The address that receives captured funds. This profile maps the
+  recipient to the TIP-1034 `payee`.
 
 Operator
-: The address authorized to register the authorization transaction,
-  capture cumulative amounts, and void remaining uncaptured funds.
+: The address authorized by TIP-1034 to call `settle` and `close` on the
+  recipient's behalf. The operator does not receive captured funds unless
+  it is also the recipient.
+
+Authorized Signer
+: The TIP-1034 `authorizedSigner` whose voucher signatures authorize
+  capture. For server-initiated capture without further payer
+  interaction, this address is expected to be controlled by the server,
+  operator, or another merchant-authorized signing service.
+
+Voucher
+: The TIP-1034 EIP-712 signed message
+  `Voucher(bytes32 channelId,uint96 cumulativeAmount)`.
+
+Channel Descriptor
+: The immutable TIP-1034 channel identity tuple supplied in post-open
+  calls. It contains payer, payee, operator, token, salt,
+  authorizedSigner, and expiringNonceHash.
+
+# Encoding Conventions
+
+Addresses and hashes use `0x`-prefixed hexadecimal encoding. Examples in
+this document use lowercase hexadecimal. Implementations MUST compare
+addresses and hashes by decoded byte value, not by case-sensitive string
+comparison.
 
 # Request Schema
 
@@ -168,7 +216,7 @@ without padding per {{I-D.httpauth-payment}}.
 |-------|------|----------|-------------|
 | `amount` | string | REQUIRED | Maximum authorization amount in base units (stringified non-negative integer, no leading zeros) |
 | `currency` | string | REQUIRED | TIP-20 token address |
-| `authorizationExpires` | string | REQUIRED | Last time the authorization can be captured, in {{RFC3339}} format |
+| `authorizationExpires` | string | REQUIRED | Last time the server or operator can capture, in {{RFC3339}} format |
 | `recipient` | string | REQUIRED | Destination address that receives captured funds |
 | `description` | string | OPTIONAL | Human-readable authorization description |
 | `externalId` | string | OPTIONAL | Merchant reference, order ID, or cart ID |
@@ -177,21 +225,24 @@ without padding per {{I-D.httpauth-payment}}.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `methodDetails.escrowContract` | string | REQUIRED | Tempo escrow contract address |
-| `methodDetails.operator` | string | REQUIRED | Address authorized to capture and void this authorization |
+| `methodDetails.escrowContract` | string | REQUIRED | TIP-1034 channel escrow precompile address. It MUST equal `0x4d50500000000000000000000000000000000000`. |
+| `methodDetails.operator` | string | REQUIRED | Address authorized to settle and close the channel |
+| `methodDetails.authorizedSigner` | string | REQUIRED | Address whose voucher signatures authorize capture |
 | `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID. If omitted, the default value is 42431 (Tempo mainnet). |
-| `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees for the client-signed authorization transaction (default: `false`) |
+| `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees for the client-signed open transaction (default: `false`) |
 
-The top-level `recipient` and `methodDetails.operator` are distinct
-roles. The recipient receives captured funds. The operator drives the
-authorization lifecycle. They MAY be the same address, but clients SHOULD
-display both values when they differ.
+The top-level `recipient`, `methodDetails.operator`, and
+`methodDetails.authorizedSigner` are distinct roles. The recipient
+receives captured funds. The operator submits channel lifecycle
+transactions. The authorized signer signs capture vouchers. Any two or
+all three addresses MAY be the same, but clients SHOULD display them when
+they differ.
 
 Challenge expiry is conveyed by the `expires` auth-param in
 `WWW-Authenticate` per {{I-D.httpauth-payment}}, using {{RFC3339}}
 format. Request objects MUST NOT duplicate the challenge expiry value.
-The `authorizationExpires` field instead defines when capture authority
-expires.
+The `authorizationExpires` field instead defines the HTTP Payment
+Authentication authorization expiry.
 
 Servers issuing a Tempo authorize challenge MUST include the `expires`
 auth-param.
@@ -200,10 +251,14 @@ The `authorizationExpires` value MUST be strictly later than the
 challenge `expires` timestamp. Servers MUST reject credentials where
 `authorizationExpires` is at or before the challenge `expires`.
 
-The `amount` value MUST fit the `uint120 maxAmount` field in
-`AuthorizationInfo`. Servers MUST reject requests with an `amount` greater
-than 2^120 - 1. The Unix-seconds representation of
-`authorizationExpires` MUST fit the `uint48 authorizationExpiry` field.
+The `amount` value MUST fit the TIP-1034 `uint96 deposit` and
+`uint96 cumulativeAmount` fields. Servers MUST reject requests with an
+`amount` greater than 2^96 - 1.
+
+`methodDetails.authorizedSigner` MUST NOT be the zero address for
+server-initiated authorize-and-capture flows. A zero authorized signer
+would make the payer the voucher signer under TIP-1034 and would require
+additional payer interaction for every capture.
 
 **Example:**
 
@@ -211,12 +266,13 @@ than 2^120 - 1. The Unix-seconds representation of
 {
   "amount": "50000000",
   "currency": "0x20c0000000000000000000000000000000000001",
-  "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+  "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
   "authorizationExpires": "2026-05-14T12:00:00Z",
   "methodDetails": {
     "chainId": 42431,
-    "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
-    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    "escrowContract": "0x4d50500000000000000000000000000000000000",
+    "operator": "0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "authorizedSigner": "0xb1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6b1b2",
     "feePayer": true
   }
 }
@@ -233,24 +289,28 @@ JSON object per {{I-D.httpauth-payment}}.
 |-------|------|----------|-------------|
 | `challenge` | object | REQUIRED | Echo of the challenge from the server |
 | `payload` | object | REQUIRED | Tempo-specific payload object |
-| `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
+| `source` | string | OPTIONAL | Payer identifier as a DID, for example `did:pkh:eip155:42431:0x...` |
 
 The `source` field, if present, SHOULD use the `did:pkh` method
 {{DID-PKH}} with the chain ID applicable to the challenge and the payer's
-Ethereum address.
-Servers MUST verify payer identity from the signed transaction and MUST
-NOT trust `source` without verification.
+Ethereum address. Servers MUST verify payer identity from the signed
+transaction and MUST NOT trust `source` without verification.
 
 ## Transaction Payload
 
 The `transaction` field contains the complete client-signed Tempo
 Transaction (type `0x76`) serialized as RLP and hex-encoded with `0x`
-prefix. The transaction MUST call `authorize(info)` on the escrow contract
-identified by `methodDetails.escrowContract`.
+prefix. The transaction MUST call `open` on the TIP-1034 channel escrow
+precompile identified by `methodDetails.escrowContract`.
+
+The `channelId` field is OPTIONAL and is only a client hint. Servers MUST
+derive the authoritative `channelId` from the signed transaction and
+TIP-1034 channel identity rules.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `transaction` | string | REQUIRED | Hex-encoded RLP-serialized signed Tempo Transaction |
+| `channelId` | string | OPTIONAL | Client-computed channel identifier hint |
 
 **Example:**
 
@@ -265,7 +325,8 @@ identified by `methodDetails.escrowContract`.
     "expires": "2026-05-13T12:05:00Z"
   },
   "payload": {
-    "transaction": "0x76f901...signed transaction bytes..."
+    "transaction": "0x76f901...signed open transaction bytes...",
+    "channelId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f"
   },
   "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
 }
@@ -273,178 +334,186 @@ identified by `methodDetails.escrowContract`.
 
 The signed transaction MUST:
 
-1. Call `authorize(info)` on `methodDetails.escrowContract`.
-2. Set `info.payer` to the transaction signer.
-3. Set `info.recipient` to the challenge `recipient`.
-4. Set `info.operator` to `methodDetails.operator`.
-5. Set `info.token` to the challenge `currency`.
-6. Set `info.maxAmount` to the challenge `amount`.
-7. Set `info.authorizationExpiry` to the Unix-seconds representation of
-   `authorizationExpires`.
-8. Include a payer-generated salt or nonce that makes the authorization
+1. Call `open(payee, operator, token, deposit, salt, authorizedSigner)` on
+   `methodDetails.escrowContract`.
+2. Set `payee` to the challenge `recipient`.
+3. Set `operator` to `methodDetails.operator`.
+4. Set `token` to the challenge `currency`.
+5. Set `deposit` to the challenge `amount`.
+6. Set `authorizedSigner` to `methodDetails.authorizedSigner`.
+7. Include a payer-generated `salt` that helps make the channel
    identifier unique.
-9. Use a transaction validity window no later than the challenge
+8. Use a transaction validity window no later than the challenge
    `expires` auth-param.
 
-If `methodDetails.feePayer` is `true`, the client signs with
-`fee_payer_signature` set to `0x00` and `fee_token` empty, allowing the
-server to add the fee-payer signature before broadcasting. If
-`feePayer` is `false` or omitted, the client MUST include valid fee
-payment fields so the transaction is executable without server
-sponsorship.
+The transaction signer is the TIP-1034 payer. If `methodDetails.feePayer`
+is `true`, the client signs with `fee_payer_signature` set to `0x00` and
+`fee_token` empty, allowing the server to add the fee-payer signature
+before broadcasting. If `feePayer` is `false` or omitted, the client MUST
+include valid fee payment fields so the transaction is executable without
+server sponsorship.
 
-# Escrow Contract Semantics {#escrow-contract-semantics}
+# TIP-1034 Channel Semantics {#tip1034-channel-semantics}
 
-Tempo authorize uses an escrow contract with the following abstract state
-and operations. Exact Solidity types MAY vary, but implementations MUST
-preserve these semantics.
+Tempo authorize uses the TIP-1034 channel escrow precompile. This section
+summarizes the TIP-1034 surface used by this profile. TIP-1034 remains
+authoritative if this summary and TIP-1034 conflict.
 
-## Authorization Info
+## Channel Data
 
 ~~~solidity
-struct AuthorizationInfo {
+struct ChannelDescriptor {
     address payer;
-    address recipient;
+    address payee;
     address operator;
     address token;
-    uint120 maxAmount;
-    uint48 authorizationExpiry;
     bytes32 salt;
+    address authorizedSigner;
+    bytes32 expiringNonceHash;
+}
+
+struct ChannelState {
+    uint96 settled;
+    uint96 deposit;
+    uint32 closeRequestedAt;
 }
 ~~~
 
-## Authorization State
+The `channelId` is computed by TIP-1034 from the channel descriptor, the
+canonical precompile address, and the chain ID. For `open`,
+`expiringNonceHash` is derived from the enclosing transaction's
+replay-protected signing context. For post-open operations, the complete
+descriptor is supplied in calldata.
+
+## Interface Subset
 
 ~~~solidity
-struct AuthorizationState {
-    bool initialized;
-    bool closed;
-    uint120 authorizedAmount;
-    uint120 capturedAmount;
-}
-~~~
+interface ITIP20ChannelEscrow {
+    function open(
+        address payee,
+        address operator,
+        address token,
+        uint96 deposit,
+        bytes32 salt,
+        address authorizedSigner
+    ) external returns (bytes32 channelId);
 
-The authorization identifier MUST be bound to the chain, escrow contract,
-and economic terms. A compliant implementation SHOULD compute it using
-Solidity ABI encoding and Keccak-256 {{SOLIDITY-ABI}} with a
-domain-separated hash equivalent to:
+    function settle(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        bytes calldata signature
+    ) external;
 
-~~~
-authorizationId = keccak256(abi.encode(
-    block.chainid,
-    address(this),
-    payer,
-    recipient,
-    operator,
-    token,
-    maxAmount,
-    authorizationExpiry,
-    salt
-))
-~~~
+    function close(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        uint96 captureAmount,
+        bytes calldata signature
+    ) external;
 
-## Interface Sketch
+    function requestClose(ChannelDescriptor calldata descriptor) external;
 
-~~~solidity
-interface ITempoAuthCaptureEscrow {
-    function authorize(AuthorizationInfo calldata info)
-        external
-        returns (bytes32 authorizationId);
+    function withdraw(ChannelDescriptor calldata descriptor) external;
 
-    function capture(AuthorizationInfo calldata info, uint120 cumulativeCaptured)
-        external
-        returns (uint120 delta);
-
-    function void(AuthorizationInfo calldata info) external;
-
-    function reclaim(AuthorizationInfo calldata info) external;
-
-    function getAuthorizationId(AuthorizationInfo calldata info)
+    function getChannel(ChannelDescriptor calldata descriptor)
         external
         view
-        returns (bytes32 authorizationId);
+        returns (Channel memory);
 }
 ~~~
 
-### authorize
+## Authorization Creation
 
-`authorize(info)` opens a new authorization and transfers
-`info.maxAmount` from `info.payer` into escrow. It MUST reject duplicate
-authorization identifiers. It MUST reject authorizations at or after
-`info.authorizationExpiry`.
+An authorization is active only after the TIP-1034 `open` transaction is
+confirmed and the server verifies that the channel exists with:
 
-The client-signed Tempo transaction is the payer authorization for this
-transfer. The account whose authorization causes the `authorize(info)`
-call to execute MUST equal `info.payer`. If the transaction has a
-separate fee payer, the fee payer MUST NOT be treated as the payer for
-authorization purposes. Implementations MUST reject `authorize(info)` if
-the effective transaction authorizer cannot be determined or does not
-match `info.payer`.
+1. `descriptor.payer` equal to the recovered transaction signer.
+2. `descriptor.payee` equal to `recipient`.
+3. `descriptor.operator` equal to `methodDetails.operator`.
+4. `descriptor.token` equal to `currency`.
+5. `descriptor.authorizedSigner` equal to
+   `methodDetails.authorizedSigner`.
+6. `state.deposit` equal to `amount`.
+7. `state.settled` equal to zero.
+8. `state.closeRequestedAt` equal to zero.
 
-### capture
+The channel's `channelId` is the Tempo authorize `authorizationId`.
 
-`capture(info, cumulativeCaptured)` transfers the delta between
-`cumulativeCaptured` and the previously recorded `capturedAmount` to
-`info.recipient`.
+## Capture
 
-Captures use cumulative semantics:
-
-~~~
-delta = cumulativeCaptured - capturedAmount
-~~~
-
-If `cumulativeCaptured` is less than or equal to `capturedAmount`, the
-call MUST be treated as idempotent and MUST NOT transfer additional
-funds. If `cumulativeCaptured` exceeds `info.maxAmount`, the call MUST
-fail. Only `info.operator` can call `capture`. Captures MUST fail at or
-after `info.authorizationExpiry`.
-
-This design avoids per-capture storage. The single `capturedAmount`
-watermark prevents replay from extracting additional funds.
-
-The escrow contract MUST apply the following terminal-state behavior:
-
-Active and before expiry:
-: If `cumulativeCaptured` is greater than `capturedAmount` and no greater
-  than `maxAmount`, advance the watermark and transfer the delta.
-
-Active retry:
-: If `cumulativeCaptured` is less than or equal to `capturedAmount`,
-  return success without transferring funds.
-
-Fully captured:
-: Exact or lower cumulative retries return success without transferring
-  funds. Higher values fail.
-
-Voided:
-: Capture fails.
-
-Reclaimed:
-: Capture fails.
-
-Expired:
-: Capture fails unless it is an exact or lower cumulative retry that
-  transfers no funds.
-
-### void
-
-`void(info)` closes the authorization and returns all
-uncaptured funds to `info.payer`:
+Captures use TIP-1034 cumulative vouchers. The operator obtains or
+creates a valid `Voucher(channelId,cumulativeAmount)` signature from the
+channel's `authorizedSigner` and calls:
 
 ~~~
-remaining = authorizedAmount - capturedAmount
+settle(descriptor, cumulativeAmount, signature)
 ~~~
 
-Only `info.operator` can void an authorization. Void MUST NOT alter or
-refund captured funds.
+The amount paid to `recipient` is:
 
-### reclaim
+~~~
+delta = cumulativeAmount - previousSettled
+~~~
 
-`reclaim(info)` allows `info.payer` to recover remaining uncaptured funds
-after `info.authorizationExpiry`. It closes the authorization and returns
-the same `remaining` value as `void`.
+For this authorize profile, `cumulativeAmount` MUST NOT exceed the
+original challenge `amount`, even if the channel is later topped up. The
+server and operator MUST NOT capture after `authorizationExpires`.
 
-Only `info.payer` can reclaim an authorization.
+TIP-1034 requires `settle` amounts to be strictly increasing. Therefore
+retried captures with the same or lower cumulative value are not
+submitted on-chain as no-op captures. Servers MUST provide HTTP
+idempotency from durable state by returning the previously recorded
+receipt for duplicate capture requests.
+
+## Final Capture and Close
+
+The operator SHOULD close the channel when no further captures will be
+made. A close that increases captured value uses:
+
+~~~
+close(descriptor, cumulativeAmount, captureAmount, signature)
+~~~
+
+For this profile, `captureAmount` is the final cumulative captured
+amount. `captureAmount` MUST NOT exceed the original challenge `amount`
+and MUST NOT exceed `cumulativeAmount`.
+
+The close operation transfers `captureAmount - previousSettled` to the
+recipient, refunds `deposit - captureAmount` to the payer, and deletes
+the channel state.
+
+## Void
+
+Void maps to a TIP-1034 close that does not increase captured value:
+
+~~~
+close(descriptor, settled, settled, "0x")
+~~~
+
+The operator SHOULD void authorizations when no further captures will be
+made. Void releases all uncaptured channel deposit to the payer and does
+not alter captured value.
+
+## Payer-Initiated Reclaim
+
+TIP-1034 does not have a single `reclaim` operation tied to
+`authorizationExpires`. The payer can initiate channel closure at any
+time by calling:
+
+~~~
+requestClose(descriptor)
+~~~
+
+After the TIP-1034 close grace period elapses, the payer can call:
+
+~~~
+withdraw(descriptor)
+~~~
+
+This returns the remaining channel deposit to the payer and deletes the
+channel state. Servers MUST stop accepting new captures for channels with
+`closeRequestedAt != 0`, unless the capture is part of a terminal close
+submitted before the grace period ends.
 
 # Verification Procedure
 
@@ -452,25 +521,34 @@ On receipt of a Tempo authorize credential, servers MUST:
 
 1. Verify the challenge ID and challenge expiry.
 2. Decode the transaction and verify it is a Tempo Transaction.
-3. Verify the transaction calls `authorize(info)` on
+3. Verify the transaction calls `open` on
    `methodDetails.escrowContract`.
-4. Recover or otherwise determine the payer from the transaction.
-5. Verify the `AuthorizationInfo` values match the challenge request:
-   - `payer` matches the recovered transaction signer
-   - `recipient` matches the challenge `recipient`
+4. Verify `methodDetails.escrowContract` equals the canonical TIP-1034
+   channel escrow precompile address.
+5. Recover or otherwise determine the payer from the transaction.
+6. Verify the `open` calldata values match the challenge request:
+   - `payee` matches `recipient`
    - `operator` matches `methodDetails.operator`
    - `token` matches `currency`
-   - `maxAmount` matches `amount`
-   - `authorizationExpiry` matches `authorizationExpires`
-6. Verify the transaction validity window expires no later than the
+   - `deposit` matches `amount`
+   - `authorizedSigner` matches `methodDetails.authorizedSigner`
+7. Derive the TIP-1034 `expiringNonceHash` from the transaction signing
+   context and compute the expected `channelId`.
+8. Verify any client-provided `payload.channelId` matches the computed
+   `channelId`.
+9. Verify the transaction validity window expires no later than the
    challenge `expires` auth-param.
-7. If `feePayer: true`, add the server's fee-payer signature using the
-   Tempo fee-payer signature domain.
-8. Broadcast the transaction.
-9. Verify onchain that the authorization exists, is not closed, and has
-   `authorizedAmount - capturedAmount` equal to the requested `amount`.
+10. If `feePayer: true`, add the server's fee-payer signature using the
+    Tempo fee-payer signature domain.
+11. Broadcast the transaction.
+12. Verify onchain that the channel exists with the expected descriptor,
+    `state.deposit == amount`, `state.settled == 0`, and
+    `state.closeRequestedAt == 0`.
+13. Store durable authorization state, including the challenge ID,
+    channel ID, full descriptor, authorized amount, captured amount,
+    authorization expiry, and terminal state.
 
-Servers MUST NOT return success until the escrow authorization is active
+Servers MUST NOT return success until the authorization channel is active
 onchain.
 
 # Capture, Void, and Refund
@@ -479,29 +557,56 @@ onchain.
 
 The server or operator MAY capture value after authorization succeeds.
 Capture operations are not carried in the client credential. They are
-method-side lifecycle operations driven by the operator.
+method-side lifecycle operations driven by the server or operator using
+TIP-1034 vouchers.
 
-The operator SHOULD use cumulative capture values. For example:
+The server MUST enforce the following before signing, requesting, or
+submitting a capture voucher:
 
-| Call | Prior `capturedAmount` | Delta paid | New `capturedAmount` |
-|------|------------------------|------------|----------------------|
-| `capture(info, 100)` | 0 | 100 | 100 |
-| `capture(info, 100)` retry | 100 | 0 | 100 |
-| `capture(info, 250)` | 100 | 150 | 250 |
+1. The channel is active.
+2. The latest observed Tempo block timestamp and server wall-clock time
+   are before `authorizationExpires`.
+3. The requested cumulative captured amount is greater than the stored
+   captured amount.
+4. The requested cumulative captured amount does not exceed the original
+   challenge `amount`.
+5. `closeRequestedAt == 0`, except for terminal close handling.
+6. The HTTP request is not a duplicate idempotency key that has already
+   consumed value.
+
+For example:
+
+| Operation | Prior captured | Submitted operation | Delta paid | New captured |
+|-----------|----------------|---------------------|------------|--------------|
+| First capture | 0 | `settle(..., 100, sig)` | 100 | 100 |
+| Duplicate HTTP retry | 100 | no on-chain call | 0 | 100 |
+| Later capture | 100 | `settle(..., 250, sig)` | 150 | 250 |
+| Final close | 250 | `close(..., 400, 400, sig)` | 150 | 400 |
 
 ## Void
 
 The operator SHOULD void authorizations when no further captures will be
-made. Void releases all uncaptured value to the payer and closes the
-authorization.
+made. Void is implemented with TIP-1034 `close` using the current settled
+amount as both `cumulativeAmount` and `captureAmount`. Void releases all
+uncaptured value to the payer and closes the channel.
+
+## Top-Up
+
+TIP-1034 supports `topUp`, but top-up is outside this authorize profile.
+Clients MUST NOT top up channels created for `intent="authorize"`.
+Servers and operators MUST NOT capture more than the original challenge
+`amount`, even if a channel's TIP-1034 `deposit` is later increased.
+
+Applications that need reusable or refillable channels SHOULD use the
+Tempo `session` intent instead of this authorize profile.
 
 ## Refund Requests
 
 Refunds are out of band for this version of the Tempo authorize method.
 Clients MAY request refunds through merchant-defined channels, and
 merchants MAY honor them by issuing a separate payment or other
-method-specific process. The escrow contract defined here does not require
-an onchain refund operation for captured funds.
+method-specific process. TIP-1034 does not define an on-chain refund
+operation for already captured funds.
 
 # Receipt Generation
 
@@ -516,8 +621,8 @@ The receipt payload for Tempo authorize:
 |-------|------|-------------|
 | `method` | string | `"tempo"` |
 | `intent` | string | `"authorize"` |
-| `reference` | string | Transaction hash of the capture transaction |
-| `authorizationId` | string | Escrow authorization identifier |
+| `reference` | string | Transaction hash of the `settle` or `close` transaction |
+| `authorizationId` | string | TIP-1034 `channelId` |
 | `capturedAmount` | string | Cumulative captured amount after this capture |
 | `delta` | string | Amount captured by this receipt |
 | `status` | string | `"success"` |
@@ -534,25 +639,58 @@ particular, clients MUST verify:
 2. `currency` is the expected TIP-20 token.
 3. `recipient` is controlled by the expected merchant or destination.
 4. `methodDetails.operator` is expected or acceptable.
-5. `methodDetails.escrowContract` is the expected escrow contract.
-6. `authorizationExpires` is acceptable.
+5. `methodDetails.authorizedSigner` is expected or acceptable.
+6. `methodDetails.escrowContract` is the canonical TIP-1034 channel
+   escrow precompile address.
+7. `authorizationExpires` is acceptable.
 
-If `recipient` and `operator` differ, clients SHOULD display both values.
+If `recipient`, `operator`, and `authorizedSigner` differ, clients SHOULD
+display each role.
 
-## Operator Power
+## Authorized Signer Power
 
-The operator can capture escrowed funds without additional payer
-interaction. This is intentional for delayed fulfillment and metered
-billing. The escrow contract MUST bind the recipient, token, amount,
-expiry, and operator into the authorization identifier so the operator
-cannot redirect funds or exceed the authorized maximum.
+The authorized signer can produce vouchers that allow the operator to
+settle or close the channel without further payer interaction. This is
+intentional for delayed fulfillment and metered billing. Clients MUST
+treat `authorizedSigner` as capture authority over the full challenge
+`amount`.
+
+## Expiry Enforcement
+
+TIP-1034 does not enforce `authorizationExpires` onchain. Servers and
+operators MUST enforce `authorizationExpires` before issuing or submitting
+capture vouchers. Clients MUST NOT assume that the precompile will reject
+late captures solely because the HTTP authorization has expired.
+
+For deployments that need on-chain expiry, implementers should use a
+future TIP-1034 extension or a separate adapter that validates expiry
+before voucher settlement.
+
+## Top-Up Risk
+
+TIP-1034 top-up increases the channel deposit, and the authorized signer
+can authorize settlement up to the resulting deposit. This authorize
+profile therefore forbids top-up use for authorization channels and
+requires server-side capture accounting against the original challenge
+`amount`. Clients SHOULD create a fresh channel for each authorization.
+
+## Payer-Initiated Close
+
+The payer can call `requestClose` before `authorizationExpires`. This is a
+TIP-1034 channel exit mechanism and is a method-specific terminal path
+for this profile. Servers SHOULD monitor channel state before capture and
+stop service delivery if `closeRequestedAt != 0`.
 
 ## Replay Prevention
 
 Tempo Transactions include chain ID, nonce, and optional `validBefore` /
-`validAfter` timestamps that prevent transaction replay. The escrow
-authorization identifier additionally binds the chain ID, escrow contract,
-payer, recipient, operator, token, amount, expiry, and salt.
+`validAfter` timestamps that prevent transaction replay. TIP-1034 channel
+identifiers additionally bind the channel descriptor, canonical precompile
+address, chain ID, and transaction-derived `expiringNonceHash`.
+
+TIP-1034 vouchers are bound to `channelId` and cumulative amount. The
+channel settlement watermark prevents a voucher from extracting funds
+more than once.
 
 ## Caching
 
@@ -605,12 +743,13 @@ Decoded request:
 {
   "amount": "50000000",
   "currency": "0x20c0000000000000000000000000000000000001",
-  "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+  "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
   "authorizationExpires": "2026-05-14T12:00:00Z",
   "methodDetails": {
     "chainId": 42431,
-    "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
-    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    "escrowContract": "0x4d50500000000000000000000000000000000000",
+    "operator": "0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "authorizedSigner": "0xb1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6b1b2",
     "feePayer": true
   }
 }
@@ -629,7 +768,8 @@ Decoded request:
     "expires": "2026-05-13T12:05:00Z"
   },
   "payload": {
-    "transaction": "0x76f901...signed transaction bytes..."
+    "transaction": "0x76f901...signed open transaction bytes...",
+    "channelId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f"
   },
   "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
 }
@@ -651,10 +791,11 @@ Content-Type: application/json
     "capturedAmount": "0",
     "remainingAmount": "50000000",
     "currency": "0x20c0000000000000000000000000000000000001",
-    "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    "recipient": "0x742d35cc6634c0532925a3b844bc9e7595f8fe00",
+    "operator": "0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "authorizedSigner": "0xb1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6b1b2",
     "authorizationExpires": "2026-05-14T12:00:00Z",
-    "reference": "0xauthorizeTxHash"
+    "reference": "0xopenTxHash"
   }
 }
 ~~~
@@ -663,9 +804,10 @@ Content-Type: application/json
 
 ### First Capture
 
-The operator calls `capture(info, 10000000)`. Since the prior
-`capturedAmount` is zero, the contract transfers 10.00 tokens to
-`recipient`.
+The operator obtains a voucher signature from `authorizedSigner` for
+`Voucher(channelId, 10000000)` and calls
+`settle(descriptor, 10000000, signature)`. Since the prior settled amount
+is zero, the precompile transfers 10.00 tokens to `recipient`.
 
 Decoded receipt:
 
@@ -673,7 +815,7 @@ Decoded receipt:
 {
   "method": "tempo",
   "intent": "authorize",
-  "reference": "0xcaptureTxHash1",
+  "reference": "0xsettleTxHash1",
   "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
   "capturedAmount": "10000000",
   "delta": "10000000",
@@ -684,10 +826,9 @@ Decoded receipt:
 
 ### Capture Retry
 
-If the operator retries `capture(info, 10000000)`, the contract observes
-that `cumulativeCaptured <= capturedAmount` and transfers no additional
-funds. Implementations MAY return the original receipt from durable
-server-side state.
+If the HTTP request that produced the first capture is retried with the
+same idempotency key, the server does not submit another TIP-1034
+`settle` call. It returns the durable receipt for the original capture.
 
 Decoded receipt:
 
@@ -695,7 +836,7 @@ Decoded receipt:
 {
   "method": "tempo",
   "intent": "authorize",
-  "reference": "0xcaptureTxHash1",
+  "reference": "0xsettleTxHash1",
   "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
   "capturedAmount": "10000000",
   "delta": "0",
@@ -706,9 +847,10 @@ Decoded receipt:
 
 ### Later Incremental Capture
 
-The operator calls `capture(info, 25000000)`. Since the prior
-`capturedAmount` is 10.00 tokens, the contract transfers only the 15.00
-token delta.
+The operator obtains a voucher signature for `Voucher(channelId,
+25000000)` and calls `settle(descriptor, 25000000, signature)`. Since the
+prior settled amount is 10.00 tokens, the precompile transfers only the
+15.00 token delta.
 
 Decoded receipt:
 
@@ -716,7 +858,7 @@ Decoded receipt:
 {
   "method": "tempo",
   "intent": "authorize",
-  "reference": "0xcaptureTxHash2",
+  "reference": "0xsettleTxHash2",
   "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
   "capturedAmount": "25000000",
   "delta": "15000000",
@@ -728,38 +870,39 @@ Decoded receipt:
 ## Void Example
 
 If the operator determines no further captures are needed, it calls
-`void(info)`. With 25.00 tokens captured from a 50.00 token
-authorization, the contract returns the remaining 25.00 tokens to the
-payer and closes the authorization.
+`close(descriptor, 25000000, 25000000, "0x")`. With 25.00 tokens captured
+from a 50.00 token authorization, the precompile returns the remaining
+25.00 tokens to the payer and deletes the channel state.
 
 ~~~json
 {
   "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
   "status": "voided",
   "releasedAmount": "25000000",
-  "reference": "0xvoidTxHash"
+  "reference": "0xcloseTxHash"
 }
 ~~~
 
-## Reclaim Example
+## Payer Reclaim Example
 
-If the operator does not void before `authorizationExpires`, the payer can
-call `reclaim(info)` after expiry. The contract returns all remaining
-uncaptured funds to the payer and closes the authorization.
+If the operator does not void, the payer can call
+`requestClose(descriptor)`. After the TIP-1034 close grace period, the
+payer calls `withdraw(descriptor)` to recover all remaining uncaptured
+funds.
 
 ~~~json
 {
   "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
   "status": "reclaimed",
   "releasedAmount": "25000000",
-  "reference": "0xreclaimTxHash"
+  "reference": "0xwithdrawTxHash"
 }
 ~~~
 
 ## Out-of-Band Refund Request Example
 
-Captured funds are not refunded by the escrow contract defined in this
-version. A merchant can expose a separate refund request interface:
+Captured funds are not refunded by TIP-1034. A merchant can expose a
+separate refund request interface:
 
 ~~~http
 POST /payments/tempo/authorizations/0x6d0f4fdf/refund-requests HTTP/1.1
@@ -781,214 +924,7 @@ Content-Type: application/json
 }
 ~~~
 
-# Reference Escrow Contract
-
-This non-normative appendix gives a complete Solidity reference
-implementation for the escrow semantics in this document. Implementations
-MAY use different source code or exact Solidity types, but compliant
-implementations MUST preserve the externally visible semantics described
-in {{escrow-contract-semantics}}.
-
-~~~solidity
-pragma solidity ^0.8.24;
-
-interface ITIP20 {
-    function transferFrom(address from, address to, uint256 amount)
-        external
-        returns (bool);
-
-    function transfer(address to, uint256 amount)
-        external
-        returns (bool);
-}
-
-contract TempoAuthCaptureEscrow {
-    struct AuthorizationInfo {
-        address payer;
-        address recipient;
-        address operator;
-        address token;
-        uint120 maxAmount;
-        uint48 authorizationExpiry;
-        bytes32 salt;
-    }
-
-    struct AuthorizationState {
-        bool initialized;
-        bool closed;
-        uint120 authorizedAmount;
-        uint120 capturedAmount;
-    }
-
-    mapping(bytes32 => AuthorizationState) public authorizations;
-
-    error UnknownAuthorization();
-    error DuplicateAuthorization();
-    error AuthorizationClosed();
-    error AuthorizationExpired();
-    error Unauthorized();
-    error CaptureExceedsMax();
-    error TransferFailed();
-
-    event Authorized(
-        bytes32 indexed authorizationId,
-        address indexed payer,
-        address indexed recipient,
-        address operator,
-        address token,
-        uint120 amount,
-        uint48 authorizationExpiry
-    );
-
-    event Captured(
-        bytes32 indexed authorizationId,
-        uint120 cumulativeCaptured,
-        uint120 delta
-    );
-
-    event Voided(bytes32 indexed authorizationId, uint120 releasedAmount);
-    event Reclaimed(bytes32 indexed authorizationId, uint120 releasedAmount);
-
-    function authorize(AuthorizationInfo calldata info)
-        external
-        returns (bytes32 authorizationId)
-    {
-        if (msg.sender != info.payer) revert Unauthorized();
-        if (block.timestamp >= info.authorizationExpiry) {
-            revert AuthorizationExpired();
-        }
-
-        authorizationId = getAuthorizationId(info);
-        AuthorizationState storage state = authorizations[authorizationId];
-        if (state.initialized) revert DuplicateAuthorization();
-
-        state.initialized = true;
-        state.authorizedAmount = info.maxAmount;
-
-        if (
-            !ITIP20(info.token).transferFrom(
-                info.payer,
-                address(this),
-                info.maxAmount
-            )
-        ) {
-            revert TransferFailed();
-        }
-
-        emit Authorized(
-            authorizationId,
-            info.payer,
-            info.recipient,
-            info.operator,
-            info.token,
-            info.maxAmount,
-            info.authorizationExpiry
-        );
-    }
-
-    function capture(
-        AuthorizationInfo calldata info,
-        uint120 cumulativeCaptured
-    ) external returns (uint120 delta) {
-        if (msg.sender != info.operator) revert Unauthorized();
-
-        bytes32 authorizationId = getAuthorizationId(info);
-        AuthorizationState storage state = authorizations[authorizationId];
-        if (!state.initialized) revert UnknownAuthorization();
-        if (state.closed) revert AuthorizationClosed();
-
-        if (cumulativeCaptured <= state.capturedAmount) {
-            emit Captured(authorizationId, cumulativeCaptured, 0);
-            return 0;
-        }
-
-        if (block.timestamp >= info.authorizationExpiry) {
-            revert AuthorizationExpired();
-        }
-        if (cumulativeCaptured > info.maxAmount) {
-            revert CaptureExceedsMax();
-        }
-
-        delta = cumulativeCaptured - state.capturedAmount;
-        state.capturedAmount = cumulativeCaptured;
-
-        if (!ITIP20(info.token).transfer(info.recipient, delta)) {
-            revert TransferFailed();
-        }
-
-        emit Captured(authorizationId, cumulativeCaptured, delta);
-    }
-
-    function void(AuthorizationInfo calldata info) external {
-        if (msg.sender != info.operator) revert Unauthorized();
-
-        bytes32 authorizationId = getAuthorizationId(info);
-        AuthorizationState storage state = authorizations[authorizationId];
-        if (!state.initialized) revert UnknownAuthorization();
-        if (state.closed) revert AuthorizationClosed();
-
-        uint120 releasedAmount =
-            state.authorizedAmount - state.capturedAmount;
-        state.closed = true;
-
-        if (
-            releasedAmount != 0
-                && !ITIP20(info.token).transfer(info.payer, releasedAmount)
-        ) {
-            revert TransferFailed();
-        }
-
-        emit Voided(authorizationId, releasedAmount);
-    }
-
-    function reclaim(AuthorizationInfo calldata info) external {
-        if (msg.sender != info.payer) revert Unauthorized();
-        if (block.timestamp < info.authorizationExpiry) {
-            revert AuthorizationExpired();
-        }
-
-        bytes32 authorizationId = getAuthorizationId(info);
-        AuthorizationState storage state = authorizations[authorizationId];
-        if (!state.initialized) revert UnknownAuthorization();
-        if (state.closed) revert AuthorizationClosed();
-
-        uint120 releasedAmount =
-            state.authorizedAmount - state.capturedAmount;
-        state.closed = true;
-
-        if (
-            releasedAmount != 0
-                && !ITIP20(info.token).transfer(info.payer, releasedAmount)
-        ) {
-            revert TransferFailed();
-        }
-
-        emit Reclaimed(authorizationId, releasedAmount);
-    }
-
-    function getAuthorizationId(AuthorizationInfo calldata info)
-        public
-        view
-        returns (bytes32 authorizationId)
-    {
-        return keccak256(
-            abi.encode(
-                block.chainid,
-                address(this),
-                info.payer,
-                info.recipient,
-                info.operator,
-                info.token,
-                info.maxAmount,
-                info.authorizationExpiry,
-                info.salt
-            )
-        );
-    }
-}
-~~~
-
 # Acknowledgements
 
-The authors thank the MPP community for their feedback on this
-specification.
+The authors thank the MPP community and the TIP-1034 contributors for
+their feedback on this specification.

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -1,0 +1,568 @@
+---
+title: Tempo authorize Intent for HTTP Payment Authentication
+abbrev: Tempo Authorize
+docname: draft-tempo-authorize-00
+version: 00
+category: info
+ipr: trust200902
+submissiontype: IETF
+consensus: true
+
+author:
+  - name: Jake Moxey
+    ins: J. Moxey
+    email: jake@tempo.xyz
+    organization: Tempo Labs
+  - name: Brendan Ryan
+    ins: B. Ryan
+    email: brendan@tempo.xyz
+    organization: Tempo Labs
+  - name: Tom Meagher
+    ins: T. Meagher
+    email: thomas@tempo.xyz
+    organization: Tempo Labs
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC4648:
+  RFC8174:
+  RFC8259:
+  RFC8785:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+  I-D.payment-intent-authorize:
+    title: "Authorize Intent for HTTP Payment Authentication"
+    target: https://datatracker.ietf.org/doc/draft-payment-intent-authorize/
+    author:
+      - name: Jake Moxey
+    date: 2026-03
+
+informative:
+  EIP-2718:
+    title: "Typed Transaction Envelope"
+    target: https://eips.ethereum.org/EIPS/eip-2718
+    author:
+      - name: Micah Zoltu
+    date: 2020-10
+  EIP-55:
+    title: "Mixed-case checksum address encoding"
+    target: https://eips.ethereum.org/EIPS/eip-55
+    author:
+      - name: Vitalik Buterin
+    date: 2016-01
+  TEMPO-TX-SPEC:
+    title: "Tempo Transaction Specification"
+    target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
+    author:
+      - org: Tempo Labs
+  TIP-1020:
+    title: "TIP-1020: Signature Verification Precompile"
+    target: https://docs.tempo.xyz/protocol/tips/tip-1020
+    author:
+      - org: Tempo Labs
+---
+
+--- abstract
+
+This document defines the "authorize" intent for the "tempo" payment method
+in the Payment HTTP Authentication Scheme {{I-D.httpauth-payment}}. It
+specifies how clients grant servers spending limits with expiry on the
+Tempo blockchain.
+
+--- middle
+
+# Introduction
+
+The `authorize` intent represents a payment authorization. The payer grants
+the server permission to charge up to the specified amount before the
+authorization expiry timestamp.
+
+This specification defines the request schema, credential formats, and
+settlement procedures for authorization on Tempo. It inherits the shared
+`authorize` intent semantics from {{I-D.payment-intent-authorize}} and
+defines Tempo-specific request fields, payloads, and settlement behavior.
+
+## Authorize Flow
+
+The following diagram illustrates the Tempo authorize flow:
+
+~~~
+   Client                        Server                     Tempo Network
+      |                             |                             |
+      |  (1) GET /api/resource      |                             |
+      |-------------------------->  |                             |
+      |                             |                             |
+      |  (2) 402 Payment Required   |                             |
+      |      intent="authorize"     |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |  (3) Sign keyAuthorization  |                             |
+      |      or approve tx          |                             |
+      |                             |                             |
+      |  (4) Authorization: Payment |                             |
+      |-------------------------->  |                             |
+      |                             |  (5) Store keyAuth or       |
+      |                             |      broadcast approve      |
+      |  (6) 200 OK (approved)      |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |         ... later ...       |                             |
+      |                             |  (7) Charge with keyAuth    |
+      |                             |      or transferFrom        |
+      |                             |-------------------------->  |
+      |                             |  (8) Transfer complete      |
+      |                             |<--------------------------  |
+      |                             |                             |
+~~~
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+TIP-20
+: Tempo's enshrined token standard, implemented as precompiles rather
+  than smart contracts. TIP-20 tokens use 6 decimal places and provide
+  `transfer`, `transferFrom`, and `approve` operations.
+
+Tempo Transaction
+: An EIP-2718 transaction with type prefix `0x76`, supporting batched
+  calls, multiple signature types (secp256k1, P256, WebAuthn), 2D nonces,
+  and validity windows.
+
+Access Key
+: A delegated signing key. Access keys may have an expiry timestamp and
+  a per-token spending limit. The server holds the access key and can
+  sign transactions on behalf of the payer within the authorized limits.
+
+2D Nonce
+: Tempo's nonce system where each account has multiple independent nonce
+  lanes (`nonce_key`), enabling parallel transaction submission.
+
+Fee Payer
+: An account that pays transaction fees on behalf of another account.
+  Tempo Transactions support fee payment via a separate signature
+  domain (`0x78`), allowing the server to pay for fees while the client
+  only signs the payment authorization.
+
+# Request Schema
+
+The `request` parameter in the `WWW-Authenticate` challenge contains a
+base64url-encoded JSON object. The `request` JSON MUST be serialized
+using JSON Canonicalization Scheme (JCS) {{RFC8785}} and
+base64url-encoded without padding per {{I-D.httpauth-payment}}.
+
+## Shared Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | string | REQUIRED | Maximum spend amount in base units |
+| `currency` | string | REQUIRED | TIP-20 token address |
+| `authorizationExpires` | string | REQUIRED | Authorization expiry timestamp in {{RFC3339}} format |
+| `recipient` | string | OPTIONAL | Authorized spender address (required for transaction fulfillment) |
+| `description` | string | OPTIONAL | Human-readable authorization description |
+| `externalId` | string | OPTIONAL | Merchant's reference (order ID, etc.) |
+
+## Method Details
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID (default: 42431) |
+| `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees (default: `false`) |
+| `methodDetails.validFrom` | string | OPTIONAL | Start timestamp in {{RFC3339}} format |
+
+Challenge expiry is conveyed by the `expires` auth-param in
+`WWW-Authenticate` per {{I-D.httpauth-payment}}, using {{RFC3339}}
+format. Request objects MUST NOT duplicate the challenge expiry value.
+The `authorizationExpires` field instead defines when the authorization
+itself expires.
+
+**Example:**
+
+~~~json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "authorizationExpires": "2025-02-05T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431,
+    "feePayer": true,
+    "validFrom": "2025-01-06T00:00:00Z"
+  }
+}
+~~~
+
+The client fulfills this by either:
+
+1. Signing a Tempo Transaction with `approve(recipient, amount)` on the
+   specified `currency` (token address), with `validBefore` set to no later
+   than the challenge `expires` auth-param and optionally `validAfter` set to
+   `methodDetails.validFrom`. The `recipient` field MUST be present in the
+   request when using transaction fulfillment.
+
+2. Signing a Key Authorization with expiry = `authorizationExpires` and a
+   spending limit = `amount` for the specified token.
+
+If `methodDetails.feePayer` is `true`, the client signs with
+`fee_payer_signature` set to `0x00` and `fee_token` empty. If `feePayer`
+is `false` or omitted, the client MUST NOT sign a key authorization; the
+client MUST sign a transaction with `fee_token` set to pay fees themselves.
+
+For transaction-based fulfillment, Tempo's `approve` operation does not
+natively expire after registration. Servers MUST NOT charge via an approval
+after `authorizationExpires`, and payers SHOULD revoke unused approvals when
+stronger onchain enforcement is desired.
+
+# Credential Schema
+
+The credential in the `Authorization` header contains a base64url-encoded
+JSON object per {{I-D.httpauth-payment}}.
+
+## Credential Structure
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `challenge` | object | REQUIRED | Echo of the challenge from the server |
+| `payload` | object | REQUIRED | Tempo-specific payload object |
+| `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
+
+## Transaction Payload (type="transaction")
+
+When `type` is `"transaction"`, `signature` contains the complete signed
+Tempo Transaction (type 0x76) serialized as RLP and hex-encoded with
+`0x` prefix. The transaction MUST contain an `approve(spender, amount)`
+call on the TIP-20 token.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed transaction |
+| `type` | string | REQUIRED | `"transaction"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0x76f901...signed transaction bytes...",
+    "type": "transaction"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+The transaction contains `approve(recipient, amount)` on the TIP-20 token.
+The server broadcasts this transaction to register the allowance onchain,
+then later calls `transferFrom` to collect payment.
+
+## Key Authorization Payload (type="keyAuthorization")
+
+When `type` is `"keyAuthorization"`, `signature` contains the complete signed
+Key Authorization serialized as RLP and hex-encoded with `0x` prefix. The
+authorization is signed by the root account and grants the access key
+permission to sign transactions on its behalf. The encoded value MUST be a
+signed key authorization containing `chainId`, `keyType`, `keyId`,
+`expiry`, and token spending limits. The embedded signature MUST use a
+primitive signature type supported by {{TIP-1020}}. Keychain wrapper
+signatures MUST NOT be used for this field.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed key authorization |
+| `type` | string | REQUIRED | `"keyAuthorization"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0xf8b2...signed authorization bytes...",
+    "type": "keyAuthorization"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+## Hash Payload (type="hash")
+
+When `type` is `"hash"`, the client has already broadcast an `approve`
+transaction to the Tempo network. The `hash` field contains the transaction
+hash for the server to verify onchain.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `hash` | string | REQUIRED | Transaction hash with `0x` prefix |
+| `type` | string | REQUIRED | `"hash"` |
+
+**Example:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "hash": "0x9f8e7d6c5b4a3210fedcba0987654321fedcba0987654321fedcba0987654321",
+    "type": "hash"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+The client constructs and broadcasts an `approve(recipient, amount)` transaction
+to Tempo, then submits the hash. The server verifies the approval was registered
+onchain before granting access.
+
+# Settlement Procedure
+
+## Settlement via Allowance (Transaction)
+
+For `intent="authorize"` fulfilled via transaction, the client signs an
+`approve` transaction granting the server a spending allowance. If
+`feePayer: true`, the server adds its fee payer signature before broadcasting:
+
+~~~
+   Client                           Server                        Tempo Network
+      |                                |                                |
+      |  (1) Authorization:            |                                |
+      |      Payment <credential>      |                                |
+      |------------------------------->|                                |
+      |                                |                                |
+      |                                |  (2) If feePayer: true,        |
+      |                                |      add fee payment signature |
+      |                                |                                |
+      |                                |  (3) eth_sendRawTxSync         |
+      |                                |------------------------------->|
+      |                                |                                |
+      |                                |  (4) Approval granted          |
+      |                                |<-------------------------------|
+      |                                |                                |
+      |  (5) 200 OK                    |                                |
+      |      (authorization active)    |                                |
+      |<-------------------------------|                                |
+      |                                |                                |
+      |         ... later, when service is consumed ...                 |
+      |                                |                                |
+      |                                |  (6) transferFrom(client,      |
+      |                                |      server, amount)           |
+      |                                |------------------------------->|
+      |                                |                                |
+      |                                |  (7) Transfer executed         |
+      |                                |<-------------------------------|
+      |                                |                                |
+~~~
+
+1. Client submits credential containing signed `approve` transaction
+2. If `feePayer: true`, server adds fee sponsorship (signs with `0x78` domain)
+3. Server broadcasts transaction; approval registered onchain
+4. Server returns success (approval is now active)
+5. Later, when the server needs to charge, it calls `transferFrom`
+6. Charges can occur up to the approved limit before expiry
+
+## Settlement via Key Authorization
+
+For `intent="authorize"` fulfilled via key authorization, the client signs
+an authorization granting the server permission to charge up to a limit:
+
+~~~
+   Client                        Server                     Tempo Network
+      |                             |                             |
+      |  (1) Authorization:         |                             |
+      |      Payment <credential>   |                             |
+      |      (signed keyAuth)       |                             |
+      |-------------------------->  |                             |
+      |                             |                             |
+      |                             |  (2) Store keyAuth          |
+      |                             |                             |
+      |  (3) 200 OK                 |                             |
+      |      (approval active)      |                             |
+      |<--------------------------  |                             |
+      |                             |                             |
+      |         ... later, when service is consumed ...           |
+      |                             |                             |
+      |                             |  (4) Construct tx with:     |
+      |                             |      - keyAuthorization     |
+      |                             |      - transfer(amt) call   |
+      |                             |                             |
+      |                             |  (5) eth_sendRawTxSync      |
+      |                             |-------------------------->  |
+      |                             |                             |
+      |                             |  (6) Key registered +       |
+      |                             |      transfer executed      |
+      |                             |<--------------------------  |
+      |                             |                             |
+~~~
+
+1. Client submits credential containing signed key authorization
+2. Server stores the authorization for future use
+3. Server grants access (approval is now active)
+4. Later, when the server needs to charge, it constructs a transaction
+   with the `keyAuthorization` and `transfer` call
+5. Charges can occur up to the authorized limit before expiry
+
+## Authorization State Management
+
+On-chain approvals and access-key limits do not by themselves make HTTP
+service delivery idempotent. Servers MUST maintain durable local state for
+each registered authorization, including the remaining amount the server is
+willing to consume for HTTP resource delivery.
+
+When consuming authorized value, servers MUST:
+
+- Verify the authorization has not expired or been revoked
+- Verify the local remaining amount is sufficient
+- Verify the on-chain approval or access-key limit is still sufficient
+- Atomically decrement local remaining amount before, or atomically with,
+  delivering the corresponding service
+
+For duplicate idempotent requests, servers MUST NOT decrement local state
+more than once.
+
+## Receipt Generation
+
+Registration responses for `intent="authorize"` MUST NOT include a
+`Payment-Receipt` header. Servers MUST return a `Payment-Receipt` header
+only on later successful responses that actually consume authorized value,
+per {{I-D.httpauth-payment}}.
+
+The receipt payload for Tempo authorize:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `"tempo"` |
+| `reference` | string | Transaction hash of the settlement transaction that consumed authorized value |
+| `status` | string | `"success"` |
+| `timestamp` | string | {{RFC3339}} settlement time |
+
+# Security Considerations
+
+## Access Key Security
+
+Access keys present additional security considerations:
+
+**Destination Scoping**: For `authorize` intent, clients SHOULD include
+destination restrictions to limit the addresses the key can transfer to.
+This prevents key compromise from enabling transfers to attacker-controlled
+addresses.
+
+**Spending Limits**: Access key spending limits are enforced by the
+AccountKeychain precompile onchain. Servers cannot exceed the authorized
+limits even if compromised.
+
+**Key Revocation**: Users can revoke access keys at any time via the
+AccountKeychain precompile. Servers SHOULD handle revocation gracefully
+by requesting new authorization.
+
+## Amount Verification
+
+Clients MUST parse and verify the `request` payload before signing:
+
+1. Verify `amount` is reasonable for the service
+2. Verify `currency` is the expected token address
+3. Verify `authorizationExpires` is not unreasonably far in the future
+
+## Source Verification
+
+If a credential includes the optional `source` field (a DID identifying the
+payer), servers MUST NOT trust this value without verification.
+
+Servers MUST verify the payer identity by:
+
+- For `type="transaction"`: Recovering the signer address from the
+  transaction signature using standard ECDSA recovery
+- For `type="keyAuthorization"`: Recovering the root signer address from the
+  signed key authorization using {{TIP-1020}}-compatible verification
+  semantics over the encoded key authorization payload
+- For `type="hash"`: Retrieving the `from` address from the transaction
+  receipt onchain
+
+# IANA Considerations
+
+This document does not require any IANA actions. The `tempo` payment
+method is already registered, and the `authorize` intent is registered by
+{{I-D.payment-intent-authorize}}.
+
+--- back
+
+# Example
+
+**Challenge:**
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="nR5tYuLpS8mWvXzQ1eCgHj",
+  realm="api.example.com",
+  method="tempo",
+  intent="authorize",
+  expires="2025-02-05T12:05:00Z",
+  request="<base64url-encoded JSON below>"
+~~~
+
+The `request` decodes to:
+
+~~~json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "authorizationExpires": "2025-02-05T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431,
+    "feePayer": true
+  }
+}
+~~~
+
+This requests approval for up to 50.00 alphaUSD (50000000 base units).
+
+**Credential (via Key Authorization):**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2025-02-05T12:05:00Z"
+  },
+  "payload": {
+    "signature": "0xf8b2...signed authorization bytes...",
+    "type": "keyAuthorization"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+# Acknowledgements
+
+The authors thank the MPP community for their feedback on this
+specification.
+
+TK: add other contributors.

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -52,6 +52,18 @@ normative:
     target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
     author:
       - org: Tempo Labs
+
+informative:
+  DID-PKH:
+    title: "The did:pkh Method"
+    target: https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md
+    author:
+      - org: W3C Credentials Community Group
+  SOLIDITY-ABI:
+    title: "Contract ABI Specification"
+    target: https://docs.soliditylang.org/en/latest/abi-spec.html
+    author:
+      - org: Solidity
 ---
 
 --- abstract
@@ -181,9 +193,17 @@ format. Request objects MUST NOT duplicate the challenge expiry value.
 The `authorizationExpires` field instead defines when capture authority
 expires.
 
+Servers issuing a Tempo authorize challenge MUST include the `expires`
+auth-param.
+
 The `authorizationExpires` value MUST be strictly later than the
 challenge `expires` timestamp. Servers MUST reject credentials where
 `authorizationExpires` is at or before the challenge `expires`.
+
+The `amount` value MUST fit the `uint120 maxAmount` field in
+`AuthorizationInfo`. Servers MUST reject requests with an `amount` greater
+than 2^120 - 1. The Unix-seconds representation of
+`authorizationExpires` MUST fit the `uint48 authorizationExpiry` field.
 
 **Example:**
 
@@ -215,8 +235,9 @@ JSON object per {{I-D.httpauth-payment}}.
 | `payload` | object | REQUIRED | Tempo-specific payload object |
 | `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
 
-The `source` field, if present, SHOULD use the `did:pkh` method with the
-chain ID applicable to the challenge and the payer's Ethereum address.
+The `source` field, if present, SHOULD use the `did:pkh` method
+{{DID-PKH}} with the chain ID applicable to the challenge and the payer's
+Ethereum address.
 Servers MUST verify payer identity from the signed transaction and MUST
 NOT trust `source` without verification.
 
@@ -306,7 +327,8 @@ struct AuthorizationState {
 ~~~
 
 The authorization identifier MUST be bound to the chain, escrow contract,
-and economic terms. A compliant implementation SHOULD compute it using a
+and economic terms. A compliant implementation SHOULD compute it using
+Solidity ABI encoding and Keccak-256 {{SOLIDITY-ABI}} with a
 domain-separated hash equivalent to:
 
 ~~~
@@ -423,6 +445,8 @@ refund captured funds.
 `reclaim(info)` allows `info.payer` to recover remaining uncaptured funds
 after `info.authorizationExpiry`. It closes the authorization and returns
 the same `remaining` value as `voidAuthorization`.
+
+Only `info.payer` can reclaim an authorization.
 
 # Verification Procedure
 
@@ -541,14 +565,7 @@ from being cached by intermediaries.
 
 # IANA Considerations
 
-## Payment Intent Registration
-
-This document registers the following payment intent in the "HTTP Payment
-Intents" registry established by {{I-D.httpauth-payment}}:
-
-| Intent | Applicable Methods | Description | Reference |
-|--------|-------------------|-------------|-----------|
-| `authorize` | `tempo` | Escrow-backed authorization for future TIP-20 captures | This document |
+This document has no IANA actions.
 
 --- back
 
@@ -560,6 +577,7 @@ tempo-authorize-challenge = "Payment" 1*SP
   "realm=" quoted-string ","
   "method=" DQUOTE "tempo" DQUOTE ","
   "intent=" DQUOTE "authorize" DQUOTE ","
+  "expires=" quoted-string ","
   "request=" base64url-nopad
 
 tempo-authorize-credential = "Payment" 1*SP base64url-nopad

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -241,17 +241,16 @@ Ethereum address.
 Servers MUST verify payer identity from the signed transaction and MUST
 NOT trust `source` without verification.
 
-## Transaction Payload (type="transaction")
+## Transaction Payload
 
-When `type` is `"transaction"`, `transaction` contains the complete
-client-signed Tempo Transaction (type `0x76`) serialized as RLP and
-hex-encoded with `0x` prefix. The transaction MUST call `authorize(info)`
-on the escrow contract identified by `methodDetails.escrowContract`.
+The `transaction` field contains the complete client-signed Tempo
+Transaction (type `0x76`) serialized as RLP and hex-encoded with `0x`
+prefix. The transaction MUST call `authorize(info)` on the escrow contract
+identified by `methodDetails.escrowContract`.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `transaction` | string | REQUIRED | Hex-encoded RLP-serialized signed Tempo Transaction |
-| `type` | string | REQUIRED | `"transaction"` |
 
 **Example:**
 
@@ -266,8 +265,7 @@ on the escrow contract identified by `methodDetails.escrowContract`.
     "expires": "2026-05-13T12:05:00Z"
   },
   "payload": {
-    "transaction": "0x76f901...signed transaction bytes...",
-    "type": "transaction"
+    "transaction": "0x76f901...signed transaction bytes..."
   },
   "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
 }
@@ -295,7 +293,7 @@ server to add the fee-payer signature before broadcasting. If
 payment fields so the transaction is executable without server
 sponsorship.
 
-# Escrow Contract Semantics
+# Escrow Contract Semantics {#escrow-contract-semantics}
 
 Tempo authorize uses an escrow contract with the following abstract state
 and operations. Exact Solidity types MAY vary, but implementations MUST
@@ -357,7 +355,7 @@ interface ITempoAuthCaptureEscrow {
         external
         returns (uint120 delta);
 
-    function voidAuthorization(AuthorizationInfo calldata info) external;
+    function void(AuthorizationInfo calldata info) external;
 
     function reclaim(AuthorizationInfo calldata info) external;
 
@@ -428,9 +426,9 @@ Expired:
 : Capture fails unless it is an exact or lower cumulative retry that
   transfers no funds.
 
-### voidAuthorization
+### void
 
-`voidAuthorization(info)` closes the authorization and returns all
+`void(info)` closes the authorization and returns all
 uncaptured funds to `info.payer`:
 
 ~~~
@@ -444,13 +442,13 @@ refund captured funds.
 
 `reclaim(info)` allows `info.payer` to recover remaining uncaptured funds
 after `info.authorizationExpiry`. It closes the authorization and returns
-the same `remaining` value as `voidAuthorization`.
+the same `remaining` value as `void`.
 
 Only `info.payer` can reclaim an authorization.
 
 # Verification Procedure
 
-On receipt of a `type="transaction"` credential, servers MUST:
+On receipt of a Tempo authorize credential, servers MUST:
 
 1. Verify the challenge ID and challenge expiry.
 2. Decode the transaction and verify it is a Tempo Transaction.
@@ -631,8 +629,7 @@ Decoded request:
     "expires": "2026-05-13T12:05:00Z"
   },
   "payload": {
-    "transaction": "0x76f901...signed transaction bytes...",
-    "type": "transaction"
+    "transaction": "0x76f901...signed transaction bytes..."
   },
   "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
 }
@@ -731,7 +728,7 @@ Decoded receipt:
 ## Void Example
 
 If the operator determines no further captures are needed, it calls
-`voidAuthorization(info)`. With 25.00 tokens captured from a 50.00 token
+`void(info)`. With 25.00 tokens captured from a 50.00 token
 authorization, the contract returns the remaining 25.00 tokens to the
 payer and closes the authorization.
 
@@ -781,6 +778,213 @@ Content-Type: application/json
 {
   "refundRequestId": "rr_789",
   "status": "pending_review"
+}
+~~~
+
+# Reference Escrow Contract
+
+This non-normative appendix gives a complete Solidity reference
+implementation for the escrow semantics in this document. Implementations
+MAY use different source code or exact Solidity types, but compliant
+implementations MUST preserve the externally visible semantics described
+in {{escrow-contract-semantics}}.
+
+~~~solidity
+pragma solidity ^0.8.24;
+
+interface ITIP20 {
+    function transferFrom(address from, address to, uint256 amount)
+        external
+        returns (bool);
+
+    function transfer(address to, uint256 amount)
+        external
+        returns (bool);
+}
+
+contract TempoAuthCaptureEscrow {
+    struct AuthorizationInfo {
+        address payer;
+        address recipient;
+        address operator;
+        address token;
+        uint120 maxAmount;
+        uint48 authorizationExpiry;
+        bytes32 salt;
+    }
+
+    struct AuthorizationState {
+        bool initialized;
+        bool closed;
+        uint120 authorizedAmount;
+        uint120 capturedAmount;
+    }
+
+    mapping(bytes32 => AuthorizationState) public authorizations;
+
+    error UnknownAuthorization();
+    error DuplicateAuthorization();
+    error AuthorizationClosed();
+    error AuthorizationExpired();
+    error Unauthorized();
+    error CaptureExceedsMax();
+    error TransferFailed();
+
+    event Authorized(
+        bytes32 indexed authorizationId,
+        address indexed payer,
+        address indexed recipient,
+        address operator,
+        address token,
+        uint120 amount,
+        uint48 authorizationExpiry
+    );
+
+    event Captured(
+        bytes32 indexed authorizationId,
+        uint120 cumulativeCaptured,
+        uint120 delta
+    );
+
+    event Voided(bytes32 indexed authorizationId, uint120 releasedAmount);
+    event Reclaimed(bytes32 indexed authorizationId, uint120 releasedAmount);
+
+    function authorize(AuthorizationInfo calldata info)
+        external
+        returns (bytes32 authorizationId)
+    {
+        if (msg.sender != info.payer) revert Unauthorized();
+        if (block.timestamp >= info.authorizationExpiry) {
+            revert AuthorizationExpired();
+        }
+
+        authorizationId = getAuthorizationId(info);
+        AuthorizationState storage state = authorizations[authorizationId];
+        if (state.initialized) revert DuplicateAuthorization();
+
+        state.initialized = true;
+        state.authorizedAmount = info.maxAmount;
+
+        if (
+            !ITIP20(info.token).transferFrom(
+                info.payer,
+                address(this),
+                info.maxAmount
+            )
+        ) {
+            revert TransferFailed();
+        }
+
+        emit Authorized(
+            authorizationId,
+            info.payer,
+            info.recipient,
+            info.operator,
+            info.token,
+            info.maxAmount,
+            info.authorizationExpiry
+        );
+    }
+
+    function capture(
+        AuthorizationInfo calldata info,
+        uint120 cumulativeCaptured
+    ) external returns (uint120 delta) {
+        if (msg.sender != info.operator) revert Unauthorized();
+
+        bytes32 authorizationId = getAuthorizationId(info);
+        AuthorizationState storage state = authorizations[authorizationId];
+        if (!state.initialized) revert UnknownAuthorization();
+        if (state.closed) revert AuthorizationClosed();
+
+        if (cumulativeCaptured <= state.capturedAmount) {
+            emit Captured(authorizationId, cumulativeCaptured, 0);
+            return 0;
+        }
+
+        if (block.timestamp >= info.authorizationExpiry) {
+            revert AuthorizationExpired();
+        }
+        if (cumulativeCaptured > info.maxAmount) {
+            revert CaptureExceedsMax();
+        }
+
+        delta = cumulativeCaptured - state.capturedAmount;
+        state.capturedAmount = cumulativeCaptured;
+
+        if (!ITIP20(info.token).transfer(info.recipient, delta)) {
+            revert TransferFailed();
+        }
+
+        emit Captured(authorizationId, cumulativeCaptured, delta);
+    }
+
+    function void(AuthorizationInfo calldata info) external {
+        if (msg.sender != info.operator) revert Unauthorized();
+
+        bytes32 authorizationId = getAuthorizationId(info);
+        AuthorizationState storage state = authorizations[authorizationId];
+        if (!state.initialized) revert UnknownAuthorization();
+        if (state.closed) revert AuthorizationClosed();
+
+        uint120 releasedAmount =
+            state.authorizedAmount - state.capturedAmount;
+        state.closed = true;
+
+        if (
+            releasedAmount != 0
+                && !ITIP20(info.token).transfer(info.payer, releasedAmount)
+        ) {
+            revert TransferFailed();
+        }
+
+        emit Voided(authorizationId, releasedAmount);
+    }
+
+    function reclaim(AuthorizationInfo calldata info) external {
+        if (msg.sender != info.payer) revert Unauthorized();
+        if (block.timestamp < info.authorizationExpiry) {
+            revert AuthorizationExpired();
+        }
+
+        bytes32 authorizationId = getAuthorizationId(info);
+        AuthorizationState storage state = authorizations[authorizationId];
+        if (!state.initialized) revert UnknownAuthorization();
+        if (state.closed) revert AuthorizationClosed();
+
+        uint120 releasedAmount =
+            state.authorizedAmount - state.capturedAmount;
+        state.closed = true;
+
+        if (
+            releasedAmount != 0
+                && !ITIP20(info.token).transfer(info.payer, releasedAmount)
+        ) {
+            revert TransferFailed();
+        }
+
+        emit Reclaimed(authorizationId, releasedAmount);
+    }
+
+    function getAuthorizationId(AuthorizationInfo calldata info)
+        public
+        view
+        returns (bytes32 authorizationId)
+    {
+        return keccak256(
+            abi.encode(
+                block.chainid,
+                address(this),
+                info.payer,
+                info.recipient,
+                info.operator,
+                info.token,
+                info.maxAmount,
+                info.authorizationExpiry,
+                info.salt
+            )
+        );
+    }
 }
 ~~~
 

--- a/specs/methods/tempo/draft-tempo-authorize-00.md
+++ b/specs/methods/tempo/draft-tempo-authorize-00.md
@@ -41,89 +41,78 @@ normative:
     author:
       - name: Jake Moxey
     date: 2026-03
-
-informative:
   EIP-2718:
     title: "Typed Transaction Envelope"
     target: https://eips.ethereum.org/EIPS/eip-2718
     author:
       - name: Micah Zoltu
     date: 2020-10
-  EIP-55:
-    title: "Mixed-case checksum address encoding"
-    target: https://eips.ethereum.org/EIPS/eip-55
-    author:
-      - name: Vitalik Buterin
-    date: 2016-01
-  EIP-20:
-    title: "ERC-20 Token Standard"
-    target: https://eips.ethereum.org/EIPS/eip-20
-    author:
-      - name: Fabian Vogelsteller
-      - name: Vitalik Buterin
-    date: 2015-11
   TEMPO-TX-SPEC:
     title: "Tempo Transaction Specification"
     target: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction
-    author:
-      - org: Tempo Labs
-  TIP-1020:
-    title: "TIP-1020: Signature Verification Precompile"
-    target: https://docs.tempo.xyz/protocol/tips/tip-1020
     author:
       - org: Tempo Labs
 ---
 
 --- abstract
 
-This document defines the "authorize" intent for the "tempo" payment method
-in the Payment HTTP Authentication Scheme. It specifies how clients grant
-servers spending limits with expiry on the Tempo blockchain.
+This document defines the "authorize" intent for the "tempo" payment
+method in the Payment HTTP Authentication Scheme. It specifies an
+escrow-backed authorization flow where a client signs a Tempo transaction
+that funds an escrow, and an operator later captures value up to the
+authorized amount.
 
 --- middle
 
 # Introduction
 
-The `authorize` intent represents a payment authorization. The payer grants
-the server permission to charge up to the specified amount before the
-authorization expiry timestamp.
+The `authorize` intent for Tempo creates an on-chain escrow authorization.
+The payer signs a Tempo transaction that calls an escrow contract's
+`authorize` function and transfers the maximum authorized amount into
+escrow. The server broadcasts that transaction, optionally sponsoring
+fees. After the authorization is active, an operator can capture value to
+the recipient, using cumulative capture semantics. The operator can also
+void remaining uncaptured value.
 
-This specification defines the request schema, credential formats, and
-settlement procedures for authorization on Tempo. It inherits the shared
-`authorize` intent semantics from {{I-D.payment-intent-authorize}} and
-defines Tempo-specific request fields, payloads, and settlement behavior.
+This flow provides a true authorization-and-capture model: funds are
+reserved at authorization time, captured value cannot exceed the escrowed
+amount, and unused value can be returned to the payer.
 
-## Authorize Flow
-
-The following diagram illustrates the Tempo authorize flow:
+## Flow
 
 ~~~
-   Client                        Server                     Tempo Network
-      |                             |                             |
-      |  (1) GET /api/resource      |                             |
-      |-------------------------->  |                             |
-      |                             |                             |
-      |  (2) 402 Payment Required   |                             |
-      |      intent="authorize"     |                             |
-      |<--------------------------  |                             |
-      |                             |                             |
-      |  (3) Sign keyAuthorization  |                             |
-      |      or approve tx          |                             |
-      |                             |                             |
-      |  (4) Authorization: Payment |                             |
-      |-------------------------->  |                             |
-      |                             |  (5) Store keyAuth or       |
-      |                             |      broadcast approve      |
-      |  (6) 200 OK (approved)      |                             |
-      |<--------------------------  |                             |
-      |                             |                             |
-      |         ... later ...       |                             |
-      |                             |  (7) Charge with keyAuth    |
-      |                             |      or transferFrom        |
-      |                             |-------------------------->  |
-      |                             |  (8) Transfer complete      |
-      |                             |<--------------------------  |
-      |                             |                             |
+   Client                      Server / Operator              Tempo Network
+      |                              |                              |
+      |  (1) GET /api/resource       |                              |
+      |----------------------------->|                              |
+      |                              |                              |
+      |  (2) 402 Payment Required    |                              |
+      |      intent="authorize"      |                              |
+      |<-----------------------------|                              |
+      |                              |                              |
+      |  (3) Sign tx calling         |                              |
+      |      escrow.authorize(info)  |                              |
+      |                              |                              |
+      |  (4) Authorization: Payment  |                              |
+      |      signed transaction      |                              |
+      |----------------------------->|                              |
+      |                              |  (5) Add fee-payer signature  |
+      |                              |      if requested             |
+      |                              |  (6) Broadcast transaction    |
+      |                              |----------------------------->|
+      |                              |                              |
+      |  (7) 200 OK                  |  (escrow funded)              |
+      |      authorization active    |<-----------------------------|
+      |<-----------------------------|                              |
+      |                              |                              |
+      |         ... later ...        |                              |
+      |                              |                              |
+      |                              |  (8) capture(cumulative)      |
+      |                              |----------------------------->|
+      |                              |                              |
+      |  (9) 200 OK + receipt        |  (delta paid to recipient)    |
+      |<-----------------------------|<-----------------------------|
+      |                              |                              |
 ~~~
 
 # Requirements Language
@@ -134,60 +123,63 @@ The following diagram illustrates the Tempo authorize flow:
 
 TIP-20
 : Tempo's enshrined token standard, implemented as precompiles rather
-  than smart contracts. TIP-20 tokens use 6 decimal places and provide
-  `transfer`, `transferFrom`, and `approve` operations.
+  than smart contracts. TIP-20 tokens use 6 decimal places.
 
 Tempo Transaction
 : An EIP-2718 transaction with type prefix `0x76`, supporting batched
-  calls, multiple signature types (secp256k1, P256, WebAuthn), 2D nonces,
-  and validity windows.
+  calls, multiple signature types, 2D nonces, and validity windows.
 
-Access Key
-: A delegated signing key. Access keys may have an expiry timestamp and
-  a per-token spending limit. The server holds the access key and can
-  sign transactions on behalf of the payer within the authorized limits.
+Escrow Contract
+: A contract that holds authorized funds and enforces capture, void, and
+  reclaim semantics.
 
-2D Nonce
-: Tempo's nonce system where each account has multiple independent nonce
-  lanes (`nonce_key`), enabling parallel transaction submission.
+Payer
+: The account that funds the escrow authorization.
 
-Fee Payer
-: An account that pays transaction fees on behalf of another account.
-  Tempo Transactions support fee payment via a separate signature
-  domain (`0x78`), allowing the server to pay for fees while the client
-  only signs the payment authorization.
+Recipient
+: The address that receives captured funds.
+
+Operator
+: The address authorized to register the authorization transaction,
+  capture cumulative amounts, and void remaining uncaptured funds.
 
 # Request Schema
 
 The `request` parameter in the `WWW-Authenticate` challenge contains a
 base64url-encoded JSON object. The `request` JSON MUST be serialized
-using JSON Canonicalization Scheme (JCS) {{RFC8785}} and
-base64url-encoded without padding per {{I-D.httpauth-payment}}.
+using JSON Canonicalization Scheme (JCS) {{RFC8785}} and base64url-encoded
+without padding per {{I-D.httpauth-payment}}.
 
 ## Shared Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `amount` | string | REQUIRED | Amount in base units (stringified non-negative integer, no leading zeros) |
+| `amount` | string | REQUIRED | Maximum authorization amount in base units (stringified non-negative integer, no leading zeros) |
 | `currency` | string | REQUIRED | TIP-20 token address |
-| `authorizationExpires` | string | REQUIRED | Authorization expiry timestamp in {{RFC3339}} format |
-| `recipient` | string | OPTIONAL | Authorized spender address; REQUIRED for `type="transaction"` fulfillment, OPTIONAL for `type="keyAuthorization"` |
+| `authorizationExpires` | string | REQUIRED | Last time the authorization can be captured, in {{RFC3339}} format |
+| `recipient` | string | REQUIRED | Destination address that receives captured funds |
 | `description` | string | OPTIONAL | Human-readable authorization description |
-| `externalId` | string | OPTIONAL | Merchant's reference (order ID, etc.) |
+| `externalId` | string | OPTIONAL | Merchant reference, order ID, or cart ID |
 
 ## Method Details
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `methodDetails.escrowContract` | string | REQUIRED | Tempo escrow contract address |
+| `methodDetails.operator` | string | REQUIRED | Address authorized to capture and void this authorization |
 | `methodDetails.chainId` | number | OPTIONAL | Tempo chain ID. If omitted, the default value is 42431 (Tempo mainnet). |
-| `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees (default: `false`) |
-| `methodDetails.validFrom` | string | OPTIONAL | Start timestamp in {{RFC3339}} format |
+| `methodDetails.feePayer` | boolean | OPTIONAL | If `true`, server pays transaction fees for the client-signed authorization transaction (default: `false`) |
+
+The top-level `recipient` and `methodDetails.operator` are distinct
+roles. The recipient receives captured funds. The operator drives the
+authorization lifecycle. They MAY be the same address, but clients SHOULD
+display both values when they differ.
 
 Challenge expiry is conveyed by the `expires` auth-param in
 `WWW-Authenticate` per {{I-D.httpauth-payment}}, using {{RFC3339}}
 format. Request objects MUST NOT duplicate the challenge expiry value.
-The `authorizationExpires` field instead defines when the authorization
-itself expires.
+The `authorizationExpires` field instead defines when capture authority
+expires.
 
 The `authorizationExpires` value MUST be strictly later than the
 challenge `expires` timestamp. Servers MUST reject credentials where
@@ -199,35 +191,16 @@ challenge `expires` timestamp. Servers MUST reject credentials where
 {
   "amount": "50000000",
   "currency": "0x20c0000000000000000000000000000000000001",
-  "authorizationExpires": "2025-02-05T12:00:00Z",
+  "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
   "methodDetails": {
     "chainId": 42431,
-    "feePayer": true,
-    "validFrom": "2025-01-06T00:00:00Z"
+    "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
+    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    "feePayer": true
   }
 }
 ~~~
-
-The client fulfills this by either:
-
-1. Signing a Tempo Transaction with `approve(recipient, amount)` on the
-   specified `currency` (token address), with `validBefore` set to no later
-   than the challenge `expires` auth-param and optionally `validAfter` set to
-   `methodDetails.validFrom`. The `recipient` field MUST be present in the
-   request when using transaction fulfillment.
-
-2. Signing a Key Authorization with expiry = `authorizationExpires` and a
-   spending limit = `amount` for the specified token.
-
-If `methodDetails.feePayer` is `true`, the client signs with
-`fee_payer_signature` set to `0x00` and `fee_token` empty. If `feePayer`
-is `false` or omitted, the client MUST NOT sign a key authorization; the
-client MUST sign a transaction with `fee_token` set to pay fees themselves.
-
-For transaction-based fulfillment, Tempo's `approve` operation does not
-natively expire after registration. Servers MUST NOT charge via an approval
-after `authorizationExpires`, and payers SHOULD revoke unused approvals when
-stronger onchain enforcement is desired.
 
 # Credential Schema
 
@@ -242,20 +215,21 @@ JSON object per {{I-D.httpauth-payment}}.
 | `payload` | object | REQUIRED | Tempo-specific payload object |
 | `source` | string | OPTIONAL | Payer identifier as a DID (e.g., `did:pkh:eip155:42431:0x...`) |
 
-The `source` field, if present, SHOULD use the `did:pkh` method with
-the chain ID applicable to the challenge and the payer's Ethereum
-address.
+The `source` field, if present, SHOULD use the `did:pkh` method with the
+chain ID applicable to the challenge and the payer's Ethereum address.
+Servers MUST verify payer identity from the signed transaction and MUST
+NOT trust `source` without verification.
 
 ## Transaction Payload (type="transaction")
 
-When `type` is `"transaction"`, `signature` contains the complete signed
-Tempo Transaction (type 0x76) serialized as RLP and hex-encoded with
-`0x` prefix. The transaction MUST contain an `approve(spender, amount)`
-call on the TIP-20 token.
+When `type` is `"transaction"`, `transaction` contains the complete
+client-signed Tempo Transaction (type `0x76`) serialized as RLP and
+hex-encoded with `0x` prefix. The transaction MUST call `authorize(info)`
+on the escrow contract identified by `methodDetails.escrowContract`.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed transaction |
+| `transaction` | string | REQUIRED | Hex-encoded RLP-serialized signed Tempo Transaction |
 | `type` | string | REQUIRED | `"transaction"` |
 
 **Example:**
@@ -268,260 +242,302 @@ call on the TIP-20 token.
     "method": "tempo",
     "intent": "authorize",
     "request": "eyJ...",
-    "expires": "2025-02-05T12:05:00Z"
+    "expires": "2026-05-13T12:05:00Z"
   },
   "payload": {
-    "signature": "0x76f901...signed transaction bytes...",
+    "transaction": "0x76f901...signed transaction bytes...",
     "type": "transaction"
   },
   "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
 }
 ~~~
 
-The transaction contains `approve(recipient, amount)` on the TIP-20 token.
-The server broadcasts this transaction to register the allowance onchain,
-then later calls `transferFrom` to collect payment.
+The signed transaction MUST:
 
-## Key Authorization Payload (type="keyAuthorization")
+1. Call `authorize(info)` on `methodDetails.escrowContract`.
+2. Set `info.payer` to the transaction signer.
+3. Set `info.recipient` to the challenge `recipient`.
+4. Set `info.operator` to `methodDetails.operator`.
+5. Set `info.token` to the challenge `currency`.
+6. Set `info.maxAmount` to the challenge `amount`.
+7. Set `info.authorizationExpiry` to the Unix-seconds representation of
+   `authorizationExpires`.
+8. Include a payer-generated salt or nonce that makes the authorization
+   identifier unique.
+9. Use a transaction validity window no later than the challenge
+   `expires` auth-param.
 
-When `type` is `"keyAuthorization"`, `signature` contains the complete signed
-Key Authorization serialized as RLP and hex-encoded with `0x` prefix. The
-authorization is signed by the root account and grants the access key
-permission to sign transactions on its behalf. The encoded value MUST be a
-signed key authorization containing `chainId`, `keyType`, `keyId`,
-`expiry`, and token spending limits. The embedded signature MUST use a
-primitive signature type supported by {{TIP-1020}}. Keychain wrapper
-signatures MUST NOT be used for this field.
+If `methodDetails.feePayer` is `true`, the client signs with
+`fee_payer_signature` set to `0x00` and `fee_token` empty, allowing the
+server to add the fee-payer signature before broadcasting. If
+`feePayer` is `false` or omitted, the client MUST include valid fee
+payment fields so the transaction is executable without server
+sponsorship.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `signature` | string | REQUIRED | Hex-encoded RLP-serialized signed key authorization |
-| `type` | string | REQUIRED | `"keyAuthorization"` |
+# Escrow Contract Semantics
 
-**Example:**
+Tempo authorize uses an escrow contract with the following abstract state
+and operations. Exact Solidity types MAY vary, but implementations MUST
+preserve these semantics.
 
-~~~json
-{
-  "challenge": {
-    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
-    "realm": "api.example.com",
-    "method": "tempo",
-    "intent": "authorize",
-    "request": "eyJ...",
-    "expires": "2025-02-05T12:05:00Z"
-  },
-  "payload": {
-    "signature": "0xf8b2...signed authorization bytes...",
-    "type": "keyAuthorization"
-  },
-  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+## Authorization Info
+
+~~~solidity
+struct AuthorizationInfo {
+    address payer;
+    address recipient;
+    address operator;
+    address token;
+    uint120 maxAmount;
+    uint48 authorizationExpiry;
+    bytes32 salt;
 }
 ~~~
 
-## Hash Payload (type="hash")
+## Authorization State
 
-When `type` is `"hash"`, the client has already broadcast an `approve`
-transaction to the Tempo network. The `hash` field contains the transaction
-hash for the server to verify onchain.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `hash` | string | REQUIRED | Transaction hash with `0x` prefix |
-| `type` | string | REQUIRED | `"hash"` |
-
-**Example:**
-
-~~~json
-{
-  "challenge": {
-    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
-    "realm": "api.example.com",
-    "method": "tempo",
-    "intent": "authorize",
-    "request": "eyJ...",
-    "expires": "2025-02-05T12:05:00Z"
-  },
-  "payload": {
-    "hash": "0x9f8e7d6c5b4a3210fedcba0987654321fedcba0987654321fedcba0987654321",
-    "type": "hash"
-  },
-  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+~~~solidity
+struct AuthorizationState {
+    bool initialized;
+    bool closed;
+    uint120 authorizedAmount;
+    uint120 capturedAmount;
 }
 ~~~
 
-The client constructs and broadcasts an `approve(recipient, amount)` transaction
-to Tempo, then submits the hash. The server verifies the approval was registered
-onchain before granting access.
-
-# Settlement Procedure
-
-## Settlement via Allowance (Transaction)
-
-For `intent="authorize"` fulfilled via transaction, the client signs an
-`approve` transaction granting the server a spending allowance. If
-`feePayer: true`, the server adds its fee payer signature before broadcasting:
+The authorization identifier MUST be bound to the chain, escrow contract,
+and economic terms. A compliant implementation SHOULD compute it using a
+domain-separated hash equivalent to:
 
 ~~~
-   Client                           Server                        Tempo Network
-      |                                |                                |
-      |  (1) Authorization:            |                                |
-      |      Payment <credential>      |                                |
-      |------------------------------->|                                |
-      |                                |                                |
-      |                                |  (2) If feePayer: true,        |
-      |                                |      add fee payment signature |
-      |                                |                                |
-      |                                |  (3) eth_sendRawTxSync         |
-      |                                |------------------------------->|
-      |                                |                                |
-      |                                |  (4) Approval granted          |
-      |                                |<-------------------------------|
-      |                                |                                |
-      |  (5) 200 OK                    |                                |
-      |      (authorization active)    |                                |
-      |<-------------------------------|                                |
-      |                                |                                |
-      |         ... later, when service is consumed ...                 |
-      |                                |                                |
-      |                                |  (6) transferFrom(client,      |
-      |                                |      server, amount)           |
-      |                                |------------------------------->|
-      |                                |                                |
-      |                                |  (7) Transfer executed         |
-      |                                |<-------------------------------|
-      |                                |                                |
+authorizationId = keccak256(abi.encode(
+    block.chainid,
+    address(this),
+    payer,
+    recipient,
+    operator,
+    token,
+    maxAmount,
+    authorizationExpiry,
+    salt
+))
 ~~~
 
-1. Client submits credential containing signed `approve` transaction
-2. If `feePayer: true`, server adds fee sponsorship (signs with `0x78` domain)
-3. Server broadcasts transaction; approval registered onchain
-4. Server returns success (approval is now active)
-5. Later, when the server needs to charge, it calls `transferFrom`
-6. Charges can occur up to the approved limit before expiry
+## Interface Sketch
 
-## Settlement via Key Authorization
+~~~solidity
+interface ITempoAuthCaptureEscrow {
+    function authorize(AuthorizationInfo calldata info)
+        external
+        returns (bytes32 authorizationId);
 
-For `intent="authorize"` fulfilled via key authorization, the client signs
-an authorization granting the server permission to charge up to a limit:
+    function capture(AuthorizationInfo calldata info, uint120 cumulativeCaptured)
+        external
+        returns (uint120 delta);
 
-~~~
-   Client                        Server                     Tempo Network
-      |                             |                             |
-      |  (1) Authorization:         |                             |
-      |      Payment <credential>   |                             |
-      |      (signed keyAuth)       |                             |
-      |-------------------------->  |                             |
-      |                             |                             |
-      |                             |  (2) Store keyAuth          |
-      |                             |                             |
-      |  (3) 200 OK                 |                             |
-      |      (approval active)      |                             |
-      |<--------------------------  |                             |
-      |                             |                             |
-      |         ... later, when service is consumed ...           |
-      |                             |                             |
-      |                             |  (4) Construct tx with:     |
-      |                             |      - keyAuthorization     |
-      |                             |      - transfer(amt) call   |
-      |                             |                             |
-      |                             |  (5) eth_sendRawTxSync      |
-      |                             |-------------------------->  |
-      |                             |                             |
-      |                             |  (6) Key registered +       |
-      |                             |      transfer executed      |
-      |                             |<--------------------------  |
-      |                             |                             |
+    function voidAuthorization(AuthorizationInfo calldata info) external;
+
+    function reclaim(AuthorizationInfo calldata info) external;
+
+    function getAuthorizationId(AuthorizationInfo calldata info)
+        external
+        view
+        returns (bytes32 authorizationId);
+}
 ~~~
 
-1. Client submits credential containing signed key authorization
-2. Server stores the authorization for future use
-3. Server grants access (approval is now active)
-4. Later, when the server needs to charge, it constructs a transaction
-   with the `keyAuthorization` and `transfer` call
-5. Charges can occur up to the authorized limit before expiry
+### authorize
 
-## Authorization State Management
+`authorize(info)` opens a new authorization and transfers
+`info.maxAmount` from `info.payer` into escrow. It MUST reject duplicate
+authorization identifiers. It MUST reject authorizations at or after
+`info.authorizationExpiry`.
 
-On-chain approvals and access-key limits do not by themselves make HTTP
-service delivery idempotent. Servers MUST maintain durable local state for
-each registered authorization, including the remaining amount the server is
-willing to consume for HTTP resource delivery.
+The client-signed Tempo transaction is the payer authorization for this
+transfer. The account whose authorization causes the `authorize(info)`
+call to execute MUST equal `info.payer`. If the transaction has a
+separate fee payer, the fee payer MUST NOT be treated as the payer for
+authorization purposes. Implementations MUST reject `authorize(info)` if
+the effective transaction authorizer cannot be determined or does not
+match `info.payer`.
 
-When consuming authorized value, servers MUST:
+### capture
 
-- Verify the authorization has not expired or been revoked
-- Verify the local remaining amount is sufficient
-- Verify the on-chain approval or access-key limit is still sufficient
-- Atomically decrement local remaining amount before, or atomically with,
-  delivering the corresponding service
+`capture(info, cumulativeCaptured)` transfers the delta between
+`cumulativeCaptured` and the previously recorded `capturedAmount` to
+`info.recipient`.
 
-For duplicate idempotent requests, servers MUST NOT decrement local state
-more than once.
+Captures use cumulative semantics:
 
-## Receipt Generation
+~~~
+delta = cumulativeCaptured - capturedAmount
+~~~
+
+If `cumulativeCaptured` is less than or equal to `capturedAmount`, the
+call MUST be treated as idempotent and MUST NOT transfer additional
+funds. If `cumulativeCaptured` exceeds `info.maxAmount`, the call MUST
+fail. Only `info.operator` can call `capture`. Captures MUST fail at or
+after `info.authorizationExpiry`.
+
+This design avoids per-capture storage. The single `capturedAmount`
+watermark prevents replay from extracting additional funds.
+
+The escrow contract MUST apply the following terminal-state behavior:
+
+Active and before expiry:
+: If `cumulativeCaptured` is greater than `capturedAmount` and no greater
+  than `maxAmount`, advance the watermark and transfer the delta.
+
+Active retry:
+: If `cumulativeCaptured` is less than or equal to `capturedAmount`,
+  return success without transferring funds.
+
+Fully captured:
+: Exact or lower cumulative retries return success without transferring
+  funds. Higher values fail.
+
+Voided:
+: Capture fails.
+
+Reclaimed:
+: Capture fails.
+
+Expired:
+: Capture fails unless it is an exact or lower cumulative retry that
+  transfers no funds.
+
+### voidAuthorization
+
+`voidAuthorization(info)` closes the authorization and returns all
+uncaptured funds to `info.payer`:
+
+~~~
+remaining = authorizedAmount - capturedAmount
+~~~
+
+Only `info.operator` can void an authorization. Void MUST NOT alter or
+refund captured funds.
+
+### reclaim
+
+`reclaim(info)` allows `info.payer` to recover remaining uncaptured funds
+after `info.authorizationExpiry`. It closes the authorization and returns
+the same `remaining` value as `voidAuthorization`.
+
+# Verification Procedure
+
+On receipt of a `type="transaction"` credential, servers MUST:
+
+1. Verify the challenge ID and challenge expiry.
+2. Decode the transaction and verify it is a Tempo Transaction.
+3. Verify the transaction calls `authorize(info)` on
+   `methodDetails.escrowContract`.
+4. Recover or otherwise determine the payer from the transaction.
+5. Verify the `AuthorizationInfo` values match the challenge request:
+   - `payer` matches the recovered transaction signer
+   - `recipient` matches the challenge `recipient`
+   - `operator` matches `methodDetails.operator`
+   - `token` matches `currency`
+   - `maxAmount` matches `amount`
+   - `authorizationExpiry` matches `authorizationExpires`
+6. Verify the transaction validity window expires no later than the
+   challenge `expires` auth-param.
+7. If `feePayer: true`, add the server's fee-payer signature using the
+   Tempo fee-payer signature domain.
+8. Broadcast the transaction.
+9. Verify onchain that the authorization exists, is not closed, and has
+   `authorizedAmount - capturedAmount` equal to the requested `amount`.
+
+Servers MUST NOT return success until the escrow authorization is active
+onchain.
+
+# Capture, Void, and Refund
+
+## Capture
+
+The server or operator MAY capture value after authorization succeeds.
+Capture operations are not carried in the client credential. They are
+method-side lifecycle operations driven by the operator.
+
+The operator SHOULD use cumulative capture values. For example:
+
+| Call | Prior `capturedAmount` | Delta paid | New `capturedAmount` |
+|------|------------------------|------------|----------------------|
+| `capture(info, 100)` | 0 | 100 | 100 |
+| `capture(info, 100)` retry | 100 | 0 | 100 |
+| `capture(info, 250)` | 100 | 150 | 250 |
+
+## Void
+
+The operator SHOULD void authorizations when no further captures will be
+made. Void releases all uncaptured value to the payer and closes the
+authorization.
+
+## Refund Requests
+
+Refunds are out of band for this version of the Tempo authorize method.
+Clients MAY request refunds through merchant-defined channels, and
+merchants MAY honor them by issuing a separate payment or other
+method-specific process. The escrow contract defined here does not require
+an onchain refund operation for captured funds.
+
+# Receipt Generation
 
 Registration responses for `intent="authorize"` MUST NOT include a
 `Payment-Receipt` header. Servers MUST return a `Payment-Receipt` header
-only on later successful responses that actually consume authorized value,
-per {{I-D.httpauth-payment}}.
+only on successful responses that actually consume or capture authorized
+value, per {{I-D.httpauth-payment}}.
 
 The receipt payload for Tempo authorize:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `method` | string | `"tempo"` |
-| `reference` | string | Transaction hash of the settlement transaction that consumed authorized value |
+| `intent` | string | `"authorize"` |
+| `reference` | string | Transaction hash of the capture transaction |
+| `authorizationId` | string | Escrow authorization identifier |
+| `capturedAmount` | string | Cumulative captured amount after this capture |
+| `delta` | string | Amount captured by this receipt |
 | `status` | string | `"success"` |
 | `timestamp` | string | {{RFC3339}} settlement time |
 
 # Security Considerations
 
-## Access Key Security
+## Role Verification
 
-Access keys present additional security considerations:
+Clients MUST parse and verify the `request` payload before signing. In
+particular, clients MUST verify:
 
-**Destination Scoping**: For `authorize` intent, clients SHOULD include
-destination restrictions to limit the addresses the key can transfer to.
-This prevents key compromise from enabling transfers to attacker-controlled
-addresses.
+1. `amount` is reasonable for the service.
+2. `currency` is the expected TIP-20 token.
+3. `recipient` is controlled by the expected merchant or destination.
+4. `methodDetails.operator` is expected or acceptable.
+5. `methodDetails.escrowContract` is the expected escrow contract.
+6. `authorizationExpires` is acceptable.
 
-**Spending Limits**: Access key spending limits are enforced by the
-AccountKeychain precompile onchain. Servers cannot exceed the authorized
-limits even if compromised.
+If `recipient` and `operator` differ, clients SHOULD display both values.
 
-**Key Revocation**: Users can revoke access keys at any time via the
-AccountKeychain precompile. Servers SHOULD handle revocation gracefully
-by requesting new authorization.
+## Operator Power
 
-## Amount Verification
+The operator can capture escrowed funds without additional payer
+interaction. This is intentional for delayed fulfillment and metered
+billing. The escrow contract MUST bind the recipient, token, amount,
+expiry, and operator into the authorization identifier so the operator
+cannot redirect funds or exceed the authorized maximum.
 
-Clients MUST parse and verify the `request` payload before signing:
+## Replay Prevention
 
-1. Verify `amount` is reasonable for the service
-2. Verify `currency` is the expected token address
-3. Verify `authorizationExpires` is not unreasonably far in the future
-
-## Source Verification
-
-If a credential includes the optional `source` field (a DID identifying the
-payer), servers MUST NOT trust this value without verification.
-
-Servers MUST verify the payer identity by:
-
-- For `type="transaction"`: Recovering the signer address from the
-  transaction signature using standard ECDSA recovery
-- For `type="keyAuthorization"`: Recovering the root signer address from the
-  signed key authorization using {{TIP-1020}}-compatible verification
-  semantics over the encoded key authorization payload
-- For `type="hash"`: Retrieving the `from` address from the transaction
-  receipt onchain
+Tempo Transactions include chain ID, nonce, and optional `validBefore` /
+`validAfter` timestamps that prevent transaction replay. The escrow
+authorization identifier additionally binds the chain ID, escrow contract,
+payer, recipient, operator, token, amount, expiry, and salt.
 
 ## Caching
 
-Responses to authorization challenges (402 Payment Required) and
-responses that consume authorized value SHOULD include
-`Cache-Control: no-store` to prevent sensitive payment data from being
-cached by intermediaries.
+Responses to authorization challenges (402 Payment Required), responses
+that establish authorizations, and responses that consume authorized value
+SHOULD include `Cache-Control: no-store` to prevent sensitive payment data
+from being cached by intermediaries.
 
 # IANA Considerations
 
@@ -532,63 +548,13 @@ Intents" registry established by {{I-D.httpauth-payment}}:
 
 | Intent | Applicable Methods | Description | Reference |
 |--------|-------------------|-------------|-----------|
-| `authorize` | `tempo` | Pre-authorization for future TIP-20 charges | This document |
+| `authorize` | `tempo` | Escrow-backed authorization for future TIP-20 captures | This document |
 
 --- back
 
-# Example
-
-**Challenge:**
-
-~~~http
-HTTP/1.1 402 Payment Required
-WWW-Authenticate: Payment id="nR5tYuLpS8mWvXzQ1eCgHj",
-  realm="api.example.com",
-  method="tempo",
-  intent="authorize",
-  expires="2025-02-05T12:05:00Z",
-  request="<base64url-encoded JSON below>"
-~~~
-
-The `request` decodes to:
-
-~~~json
-{
-  "amount": "50000000",
-  "currency": "0x20c0000000000000000000000000000000000001",
-  "authorizationExpires": "2025-02-05T12:00:00Z",
-  "methodDetails": {
-    "chainId": 42431,
-    "feePayer": true
-  }
-}
-~~~
-
-This requests approval for up to 50.00 alphaUSD (50000000 base units).
-
-**Credential (via Key Authorization):**
-
-~~~json
-{
-  "challenge": {
-    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
-    "realm": "api.example.com",
-    "method": "tempo",
-    "intent": "authorize",
-    "request": "eyJ...",
-    "expires": "2025-02-05T12:05:00Z"
-  },
-  "payload": {
-    "signature": "0xf8b2...signed authorization bytes...",
-    "type": "keyAuthorization"
-  },
-  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
-}
-~~~
-
 # ABNF Collected
 
-~~~ abnf
+~~~abnf
 tempo-authorize-challenge = "Payment" 1*SP
   "id=" quoted-string ","
   "realm=" quoted-string ","
@@ -602,9 +568,205 @@ tempo-authorize-credential = "Payment" 1*SP base64url-nopad
 base64url-nopad = 1*( ALPHA / DIGIT / "-" / "_" )
 ~~~
 
+# Example
+
+**Challenge:**
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="nR5tYuLpS8mWvXzQ1eCgHj",
+  realm="api.example.com",
+  method="tempo",
+  intent="authorize",
+  expires="2026-05-13T12:05:00Z",
+  request="<base64url-encoded JSON below>"
+Cache-Control: no-store
+~~~
+
+Decoded request:
+
+~~~json
+{
+  "amount": "50000000",
+  "currency": "0x20c0000000000000000000000000000000000001",
+  "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+  "authorizationExpires": "2026-05-14T12:00:00Z",
+  "methodDetails": {
+    "chainId": 42431,
+    "escrowContract": "0x1234567890abcdef1234567890abcdef12345678",
+    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    "feePayer": true
+  }
+}
+~~~
+
+**Credential:**
+
+~~~json
+{
+  "challenge": {
+    "id": "nR5tYuLpS8mWvXzQ1eCgHj",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "authorize",
+    "request": "eyJ...",
+    "expires": "2026-05-13T12:05:00Z"
+  },
+  "payload": {
+    "transaction": "0x76f901...signed transaction bytes...",
+    "type": "transaction"
+  },
+  "source": "did:pkh:eip155:42431:0x1234567890abcdef1234567890abcdef12345678"
+}
+~~~
+
+**Authorization active response:**
+
+~~~http
+HTTP/1.1 200 OK
+Cache-Control: no-store
+Content-Type: application/json
+
+{
+  "authorization": {
+    "id": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+    "method": "tempo",
+    "status": "authorized",
+    "amount": "50000000",
+    "capturedAmount": "0",
+    "remainingAmount": "50000000",
+    "currency": "0x20c0000000000000000000000000000000000001",
+    "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+    "operator": "0xA1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    "authorizationExpires": "2026-05-14T12:00:00Z",
+    "reference": "0xauthorizeTxHash"
+  }
+}
+~~~
+
+## Capture Examples
+
+### First Capture
+
+The operator calls `capture(info, 10000000)`. Since the prior
+`capturedAmount` is zero, the contract transfers 10.00 tokens to
+`recipient`.
+
+Decoded receipt:
+
+~~~json
+{
+  "method": "tempo",
+  "intent": "authorize",
+  "reference": "0xcaptureTxHash1",
+  "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+  "capturedAmount": "10000000",
+  "delta": "10000000",
+  "status": "success",
+  "timestamp": "2026-05-13T12:10:00Z"
+}
+~~~
+
+### Capture Retry
+
+If the operator retries `capture(info, 10000000)`, the contract observes
+that `cumulativeCaptured <= capturedAmount` and transfers no additional
+funds. Implementations MAY return the original receipt from durable
+server-side state.
+
+Decoded receipt:
+
+~~~json
+{
+  "method": "tempo",
+  "intent": "authorize",
+  "reference": "0xcaptureTxHash1",
+  "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+  "capturedAmount": "10000000",
+  "delta": "0",
+  "status": "success",
+  "timestamp": "2026-05-13T12:10:00Z"
+}
+~~~
+
+### Later Incremental Capture
+
+The operator calls `capture(info, 25000000)`. Since the prior
+`capturedAmount` is 10.00 tokens, the contract transfers only the 15.00
+token delta.
+
+Decoded receipt:
+
+~~~json
+{
+  "method": "tempo",
+  "intent": "authorize",
+  "reference": "0xcaptureTxHash2",
+  "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+  "capturedAmount": "25000000",
+  "delta": "15000000",
+  "status": "success",
+  "timestamp": "2026-05-13T12:30:00Z"
+}
+~~~
+
+## Void Example
+
+If the operator determines no further captures are needed, it calls
+`voidAuthorization(info)`. With 25.00 tokens captured from a 50.00 token
+authorization, the contract returns the remaining 25.00 tokens to the
+payer and closes the authorization.
+
+~~~json
+{
+  "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+  "status": "voided",
+  "releasedAmount": "25000000",
+  "reference": "0xvoidTxHash"
+}
+~~~
+
+## Reclaim Example
+
+If the operator does not void before `authorizationExpires`, the payer can
+call `reclaim(info)` after expiry. The contract returns all remaining
+uncaptured funds to the payer and closes the authorization.
+
+~~~json
+{
+  "authorizationId": "0x6d0f4fdf1f2f6a1f6c1b0fbd6a7d5c2c0a8d3d7b1f6a9c1b3e2d4a5b6c7d8e9f",
+  "status": "reclaimed",
+  "releasedAmount": "25000000",
+  "reference": "0xreclaimTxHash"
+}
+~~~
+
+## Out-of-Band Refund Request Example
+
+Captured funds are not refunded by the escrow contract defined in this
+version. A merchant can expose a separate refund request interface:
+
+~~~http
+POST /payments/tempo/authorizations/0x6d0f4fdf/refund-requests HTTP/1.1
+Host: api.example.com
+Content-Type: application/json
+
+{
+  "reason": "requested_by_customer"
+}
+~~~
+
+~~~http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+  "refundRequestId": "rr_789",
+  "status": "pending_review"
+}
+~~~
+
 # Acknowledgements
 
 The authors thank the MPP community for their feedback on this
 specification.
-
-


### PR DESCRIPTION
## Summary

Adds the `authorize` intent as a full authorization-and-capture lifecycle for HTTP Payment Authentication, with method-specific capture, void, and refund-request semantics.

## Key design decisions

* Supports escrowed auth and capture flows, common with cards and many other payment methods
* Allows for multi-capture as well as single-capture
* Supports "voiding" a transaction, but *not* partial refunds

## Notes on implementations

## Tempo Implementation

Leverages the same underlying "escrow" contract as the tempo session method, with the server as an authorized signer

## Stripe Implementation

Leverages shared payment token, with restrictions on what parameters and shapes of payment methods can be used.

## Open questions

* should we allow partial refunds? 
* are there any other efficiencies that we could get from the tempo contract? 