### PR TITLE
lint: Update spec lints

### DIFF
--- a/scripts/lint_frontmatter.py
+++ b/scripts/lint_frontmatter.py
@@ -9,7 +9,9 @@ import frontmatter
 REQUIRED_FIELDS = ["title", "abbrev", "docname", "version", "category", "ipr", "submissiontype", "consensus", "author"]
 AUTHOR_FIELD_ORDER = ["name", "ins", "email", "org"]
 
+EXPECTED_IPR = "noModificationTrust200902"
 ID_HTTPAUTH_PAYMENT_TITLE = "The 'Payment' HTTP Authentication Scheme"
+ID_HTTPAUTH_PAYMENT_TARGET = "https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/"
 
 
 def lint_file(path: Path) -> list[str]:
@@ -22,6 +24,17 @@ def lint_file(path: Path) -> list[str]:
     for field in REQUIRED_FIELDS:
         if field not in meta:
             errors.append(f"missing required field '{field}'")
+
+    # Check IPR value
+    ipr = meta.get("ipr", "")
+    if ipr and ipr != EXPECTED_IPR:
+        errors.append(f"ipr should be '{EXPECTED_IPR}', got '{ipr}'")
+
+    # Check consensus/submissiontype compatibility
+    submissiontype = meta.get("submissiontype", "")
+    consensus = meta.get("consensus")
+    if submissiontype == "independent" and consensus is True:
+        errors.append("consensus must be false for independent submissions")
 
     # Check version format (two-digit string like "00", "01", … or int 0)
     version = meta.get("version")
@@ -45,6 +58,8 @@ def lint_file(path: Path) -> list[str]:
         actual = [k for k in keys if k in AUTHOR_FIELD_ORDER]
         if actual != expected:
             errors.append(f"author[{i}] field order should be {expected}, got {actual}")
+        if "organization" in author:
+            errors.append(f"author[{i}] uses 'organization' instead of 'org'; use 'org' for consistency")
 
     # Check I-D.httpauth-payment reference format (if present)
     normative = meta.get("normative", {})
@@ -53,6 +68,8 @@ def lint_file(path: Path) -> list[str]:
         if ref:
             if "target" not in ref:
                 errors.append("I-D.httpauth-payment missing 'target' field")
+            elif ref["target"] != ID_HTTPAUTH_PAYMENT_TARGET:
+                errors.append(f"I-D.httpauth-payment target should be '{ID_HTTPAUTH_PAYMENT_TARGET}', got '{ref['target']}'")
             title = ref.get("title", "")
             # Normalize title by stripping outer quotes for comparison
             normalized_title = title.strip('"').strip("'")

--- a/scripts/lint_frontmatter.py
+++ b/scripts/lint_frontmatter.py
@@ -9,7 +9,9 @@ import frontmatter
 REQUIRED_FIELDS = ["title", "abbrev", "docname", "version", "category", "ipr", "submissiontype", "consensus", "author"]
 AUTHOR_FIELD_ORDER = ["name", "ins", "email", "org"]
 
+EXPECTED_IPR = "noModificationTrust200902"
 ID_HTTPAUTH_PAYMENT_TITLE = "The 'Payment' HTTP Authentication Scheme"
+ID_HTTPAUTH_PAYMENT_TARGET = "https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/"
 
 
 def lint_file(path: Path) -> list[str]:
@@ -23,9 +25,20 @@ def lint_file(path: Path) -> list[str]:
         if field not in meta:
             errors.append(f"missing required field '{field}'")
 
+    # Check IPR value
+    ipr = meta.get("ipr", "")
+    if ipr and ipr != EXPECTED_IPR:
+        errors.append(f"ipr should be '{EXPECTED_IPR}', got '{ipr}'")
+
+    # Check consensus/submissiontype compatibility
+    submissiontype = meta.get("submissiontype", "")
+    consensus = meta.get("consensus")
+    if submissiontype == "independent" and consensus is True:
+        errors.append("consensus must be false for independent submissions")
+
     # Check version format (two-digit string like "00", "01", … or int 0)
     version = meta.get("version")
-    if not (isinstance(version, int) and 0 <= version <= 99) and not (
+    if not (type(version) is int and version == 0) and not (
         isinstance(version, str) and len(version) == 2 and version.isdigit()
     ):
         errors.append(f"version should be a two-digit revision (e.g. '00'), got '{version}'")
@@ -45,6 +58,8 @@ def lint_file(path: Path) -> list[str]:
         actual = [k for k in keys if k in AUTHOR_FIELD_ORDER]
         if actual != expected:
             errors.append(f"author[{i}] field order should be {expected}, got {actual}")
+        if "organization" in author:
+            errors.append(f"author[{i}] uses 'organization' instead of 'org'; use 'org' for consistency")
 
     # Check I-D.httpauth-payment reference format (if present)
     normative = meta.get("normative", {})
@@ -53,6 +68,8 @@ def lint_file(path: Path) -> list[str]:
         if ref:
             if "target" not in ref:
                 errors.append("I-D.httpauth-payment missing 'target' field")
+            elif ref["target"] != ID_HTTPAUTH_PAYMENT_TARGET:
+                errors.append(f"I-D.httpauth-payment target should be '{ID_HTTPAUTH_PAYMENT_TARGET}', got '{ref['target']}'")
             title = ref.get("title", "")
             # Normalize title by stripping outer quotes for comparison
             normalized_title = title.strip('"').strip("'")

--- a/scripts/test_lint_frontmatter.py
+++ b/scripts/test_lint_frontmatter.py
@@ -26,7 +26,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -47,7 +47,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 ---
@@ -65,7 +65,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -86,7 +86,7 @@ abbrev: Test
 docname: draft-test-00
 version: 0
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -107,7 +107,7 @@ abbrev: Test
 docname: draft-test-00
 version: 1
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -130,7 +130,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -151,7 +151,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -174,7 +174,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -195,7 +195,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -210,8 +210,29 @@ author:
         assert any("field order" in e for e in errors)
 
 
-class TestIDReference:
-    def test_valid_id_reference(self, tmp_path):
+class TestIPR:
+    def test_correct_ipr(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    org: Test Org
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert not any("ipr" in e for e in errors)
+
+    def test_wrong_ipr(self, tmp_path):
         content = """---
 title: Test Spec
 abbrev: Test
@@ -226,10 +247,121 @@ author:
     ins: T. Author
     email: test@example.com
     org: Test Org
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert any("ipr should be 'noModificationTrust200902'" in e for e in errors)
+
+
+class TestConsensusSubmissiontype:
+    def test_independent_with_consensus_false(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: independent
+consensus: false
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    org: Test Org
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert not any("consensus" in e for e in errors)
+
+    def test_independent_with_consensus_true(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: independent
+consensus: true
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    org: Test Org
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert any("consensus must be false for independent" in e for e in errors)
+
+
+class TestAuthorOrganization:
+    def test_org_is_correct(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    org: Test Org
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert not any("organization" in e for e in errors)
+
+    def test_organization_flagged(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    organization: Test Org
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert any("'organization' instead of 'org'" in e for e in errors)
+
+
+class TestIDReference:
+    def test_valid_id_reference(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    org: Test Org
 normative:
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
     author:
       - name: Jake Moxey
     date: 2026-01
@@ -246,7 +378,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -273,7 +405,7 @@ abbrev: Test
 docname: draft-test-00
 version: "00"
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 author:
@@ -284,7 +416,7 @@ author:
 normative:
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: https://datatracker.ietf.org/doc/draft-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
     author:
       - ins: J. Moxey
     date: 2026-01
@@ -293,3 +425,31 @@ normative:
         spec = write_spec(tmp_path, content)
         errors = lint_file(spec)
         assert any("should use 'name'" in e for e in errors)
+
+    def test_wrong_target_url(self, tmp_path):
+        content = """---
+title: Test Spec
+abbrev: Test
+docname: draft-test-00
+version: "00"
+category: info
+ipr: noModificationTrust200902
+submissiontype: IETF
+consensus: true
+author:
+  - name: Test Author
+    ins: T. Author
+    email: test@example.com
+    org: Test Org
+normative:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+---
+"""
+        spec = write_spec(tmp_path, content)
+        errors = lint_file(spec)
+        assert any("target should be" in e for e in errors)

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -4,7 +4,7 @@ abbrev: Payment Auth Scheme
 docname: draft-httpauth-payment-00
 version: 00
 category: std
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: IETF
 consensus: true
 

--- a/specs/methods/evm/draft-evm-charge-00.md
+++ b/specs/methods/evm/draft-evm-charge-00.md
@@ -12,15 +12,15 @@ author:
   - name: Brett DiNovi
     ins: B. DiNovi
     email: bread@megaeth.com
-    organization: MegaETH Labs
+    org: MegaETH Labs
   - name: Conner Swenberg
     ins: C. Swenberg
     email: conner.swenberg@coinbase.com
-    organization: Coinbase
+    org: Coinbase
   - name: Kyle Scott
     ins: K. Scott
     email: kscott@monad.foundation
-    organization: Monad Foundation
+    org: Monad Foundation
 
 normative:
   RFC2119:
@@ -40,7 +40,7 @@ normative:
     date: 2026
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
     author:
       - name: Jake Moxey
     date: 2026-01

--- a/specs/methods/hedera/draft-hedera-charge-00.md
+++ b/specs/methods/hedera/draft-hedera-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Hedera Charge
 docname: draft-hedera-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: independent
 consensus: false
 
@@ -37,8 +37,7 @@ normative:
     date: 2026
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: >
-      https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
     author:
       - name: Jake Moxey
     date: 2026-01

--- a/specs/methods/solana/draft-solana-charge-00.md
+++ b/specs/methods/solana/draft-solana-charge-00.md
@@ -4,7 +4,7 @@ abbrev: Solana Charge
 docname: draft-solana-charge-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: independent
 consensus: false
 

--- a/specs/methods/usdc/draft-usdc-charge-00.md
+++ b/specs/methods/usdc/draft-usdc-charge-00.md
@@ -28,7 +28,7 @@ normative:
   RFC9110:
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
     author:
       - name: Jake Moxey
     date: 2026-01


### PR DESCRIPTION
Adds 4 new frontmatter consistency checks to the linter:

| Check | What it catches | Violations on main |
|-------|----------------|-------------------|
| **IPR value** | `ipr` must be `noModificationTrust200902` | 2 (core, solana) |
| **Author key** | `organization` should be `org` | 6 (card, stripe ×2, tempo ×3) |
| **I-D target URL** | Must be `https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/` | 11 (all specs with stale URLs) |
| **Consensus/submission** | `independent` submissions must have `consensus: false` | 0 (preventive) |

Existing violations are fixed in #229.