### PR TITLE
Add direct PR spec asset links

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -29,7 +29,15 @@ jobs:
         id: pr
         run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
 
+      - name: Check PR state
+        id: pr_state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "state=$(gh pr view ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --json state --jq .state)" >> "$GITHUB_OUTPUT"
+
       - name: Download spec artifacts
+        if: steps.pr_state.outputs.state == 'OPEN'
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Publish preview release assets
+        if: steps.pr_state.outputs.state == 'OPEN'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -78,6 +87,7 @@ jobs:
             --prerelease
 
       - name: Comment on PR
+        if: steps.pr_state.outputs.state == 'OPEN'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   actions: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -38,6 +39,44 @@ jobs:
           path: /tmp/pr-artifacts
         continue-on-error: true
 
+      - name: Publish preview release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          TAG="pr-${PR_NUMBER}-spec-preview"
+          TITLE="Spec preview for PR #${PR_NUMBER}"
+          NOTES="Auto-generated spec preview assets for PR #${PR_NUMBER}."
+          SPEC_DIR="$(find /tmp/pr-artifacts -mindepth 1 -maxdepth 1 -type d -name '*specs*' | head -n1)"
+
+          if [[ -z "${SPEC_DIR}" ]]; then
+            echo "No spec artifact directory found; skipping preview release"
+            exit 0
+          fi
+
+          shopt -s nullglob
+          files=(
+            "$SPEC_DIR"/draft-*.html
+            "$SPEC_DIR"/draft-*.txt
+            "$SPEC_DIR"/draft-*.xml
+            "$SPEC_DIR"/draft-*.pdf
+          )
+
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No spec files found; skipping preview release"
+            exit 0
+          fi
+
+          gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag || true
+          gh release create "$TAG" "${files[@]}" \
+            --repo "$REPO" \
+            --title "$TITLE" \
+            --notes "$NOTES" \
+            --prerelease
+
       - name: Comment on PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -45,19 +84,33 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const prNumber = parseInt('${{ steps.pr.outputs.number }}');
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.event.workflow_run.id }}`;
+            const previewTag = `pr-${prNumber}-spec-preview`;
+            const releaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${previewTag}`;
+            const artifactsRoot = '/tmp/pr-artifacts';
 
             // Find spec artifacts
-            const specsDir = fs.readdirSync('/tmp/pr-artifacts').find(d => d.includes('specs'));
-            const diffsDir = fs.readdirSync('/tmp/pr-artifacts').find(d => d.includes('diffs'));
+            const artifactDirs = fs.existsSync(artifactsRoot) ? fs.readdirSync(artifactsRoot) : [];
+            const specsDir = artifactDirs.find(d => d.includes('specs'));
+            const diffsDir = artifactDirs.find(d => d.includes('diffs'));
 
-            let table = '| Spec | Changed |\n|------|--------|\n';
+            let table = '| Spec | Changed | Artifacts |\n|------|---------|-----------|\n';
 
             if (specsDir) {
               const specsPath = path.join('/tmp/pr-artifacts', specsDir);
               const htmlFiles = fs.readdirSync(specsPath)
                 .filter(f => f.startsWith('draft-') && f.endsWith('.html'))
                 .sort();
+
+              const linkFor = (name, ext, label) => {
+                const artifactFile = `${name}.${ext}`;
+                const artifactPath = path.join(specsPath, artifactFile);
+                if (!fs.existsSync(artifactPath)) {
+                  return label;
+                }
+
+                const assetUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/${previewTag}/${encodeURIComponent(artifactFile)}`;
+                return `[${label}](${assetUrl})`;
+              };
 
               for (const file of htmlFiles) {
                 const name = file.replace('.html', '');
@@ -66,21 +119,37 @@ jobs:
                   const diffFile = path.join('/tmp/pr-artifacts', diffsDir, `${name}-diff.txt`);
                   if (fs.existsSync(diffFile)) {
                     const content = fs.readFileSync(diffFile, 'utf8');
-                    if (content.trim() && !content.includes('New spec')) {
+                    if (content.includes('New spec')) {
+                      changed = 'New';
+                    } else if (content.trim()) {
                       changed = 'Yes';
                     }
                   }
                 }
-                table += `| \`${name}\` | ${changed} |\n`;
+
+                const artifacts = [
+                  linkFor(name, 'html', 'HTML'),
+                  linkFor(name, 'txt', 'TXT'),
+                  linkFor(name, 'xml', 'XML'),
+                  linkFor(name, 'pdf', 'PDF'),
+                ].join(' · ');
+
+                table += `| \`${name}\` | ${changed} | ${artifacts} |\n`;
               }
+            } else {
+              table += '| _No preview artifacts generated_ | - | - |\n';
             }
+
+            const footer = specsDir
+              ? `[Browse preview release assets](${releaseUrl})`
+              : 'Preview assets unavailable for this run.';
 
             const body = `<!-- ietf-spec-preview -->
             ## Spec Preview
 
             ${table}
 
-            **[Download spec artifacts](${runUrl}#artifacts)** (HTML, TXT, XML, PDF)
+            ${footer}
             `;
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,21 @@
+name: Cleanup PR Spec Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Delete preview release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview release and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: pr-${{ github.event.number }}-spec-preview
+        run: |
+          gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag || true

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,7 +1,7 @@
 name: Cleanup PR Spec Preview
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -16,6 +16,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          TAG: pr-${{ github.event.number }}-spec-preview
+          TAG: pr-${{ github.event.pull_request.number }}-spec-preview
         run: |
+          # This workflow intentionally avoids checking out or executing PR code.
+          # It only deletes the derived preview release for the closed PR.
           gh release delete "$TAG" --repo "$REPO" --yes --cleanup-tag || true


### PR DESCRIPTION
## Summary
- publish generated PR spec artifacts as per-PR prerelease assets from the trusted workflow_run job
- update the PR preview comment to link each spec's HTML/TXT/XML/PDF assets directly
- clean up per-PR preview releases when the PR closes

## Testing
- parsed all workflow YAML files with Python to verify syntax
