### PR TITLE
spec: add challenge-binding secret guidance

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -694,6 +694,18 @@ Implementations MUST treat Payment credentials with the same care as
 authentication passwords or session tokens. Credentials SHOULD be stored
 only in memory and cleared after use.
 
+### Challenge-Binding Secret Management
+
+Implementations that use a shared secret for stateless challenge binding
+(for example, HMAC) MUST keep that secret on trusted server-side systems
+only and MUST NOT disclose it to clients. Servers MUST NOT log the secret
+or include it in error messages, debugging output, or analytics.
+
+If a server rotates a challenge-binding secret, it SHOULD continue
+verifying challenges issued under the previous secret until those
+challenges expire, or use an equivalent migration strategy that avoids
+invalidating unexpired challenges.
+
 
 ## Replay Protection
 


### PR DESCRIPTION
## Summary
- add an implementation-agnostic security note for stateless challenge-binding secrets
- clarify that shared secrets stay server-side and out of logs
- recommend overlap during secret rotation so unexpired challenges remain valid

## Testing
- not run (markdown-only spec change)