### PR TITLE
chore: group dependabot updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      python-deps:
+        patterns: ["*"]
 
   - package-ecosystem: bundler
     directory: /
@@ -13,6 +16,9 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      ruby-deps:
+        patterns: ["*"]
 
   - package-ecosystem: github-actions
     directory: /
@@ -20,6 +26,9 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
 
   - package-ecosystem: docker
     directory: /
@@ -27,3 +36,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      docker-deps:
+        patterns: ["*"]


### PR DESCRIPTION
Group all dependabot updates (pip, bundler, github-actions, docker) into single weekly PRs per ecosystem instead of one PR per dependency.

Prompted by: brendan

Co-Authored-By: Brendan Ryan <1572504+brendanjryan@users.noreply.github.com>