### PR TITLE
spec: add currency and network parameters to Accept-Payment

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -556,8 +556,10 @@ negotiation fields: omitted `q` values are equivalent to `q=1`, and
 
 ~~~abnf
 Accept-Payment = #payment-range
-payment-range  = payment-token [ weight ]
-payment-token  = payment-method-or-wildcard "/" intent-or-wildcard
+payment-range  = payment-token *prefer-param [ weight ]
+payment-token  = payment-method-or-wildcard
+                 "/" intent-or-wildcard
+prefer-param   = OWS ";" OWS token "=" ( token / quoted-string )
 payment-method-or-wildcard = payment-method-id / "*"
 intent-or-wildcard         = intent-token / "*"
 ~~~
@@ -915,10 +917,12 @@ payment-credentials = "Payment" 1*SP base64url-nopad
 
 ; Client payment preferences
 Accept-Payment = #payment-range
-payment-range = payment-token [ weight ]
-payment-token = payment-method-or-wildcard "/" intent-or-wildcard
+payment-range  = payment-token *prefer-param [ weight ]
+payment-token  = payment-method-or-wildcard
+                 "/" intent-or-wildcard
+prefer-param   = OWS ";" OWS token "=" ( token / quoted-string )
 payment-method-or-wildcard = payment-method-id / "*"
-intent-or-wildcard = intent-token / "*"
+intent-or-wildcard         = intent-token / "*"
 
 ; Payment-Receipt header field value
 Payment-Receipt = base64url-nopad

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -564,6 +564,46 @@ payment-method-or-wildcard = payment-method-id / "*"
 intent-or-wildcard         = intent-token / "*"
 ~~~
 
+### Preference Parameters {#preference-parameters}
+
+Two parameters are defined for use with `Accept-Payment`.
+Implementations MUST ignore unknown parameters.
+
+**`currency`**: The currency or asset the client can pay
+  with. The value uses the same format as the `currency`
+  field in the corresponding payment method's request
+  schema: ISO 4217 lowercase for fiat methods (e.g.,
+  `usd`), token contract address for on-chain methods
+  (e.g., `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`),
+  or a method-defined identifier (e.g., `sat` for
+  Lightning). When present, the server SHOULD only return
+  challenges whose `request` object specifies a matching
+  currency.
+
+**`network`**: The payment network or chain the client can
+  use. The format is defined by the payment method
+  specification: EIP-155 chain ID for EVM methods (e.g.,
+  `8453`), CAIP-2 identifier for Stellar (e.g.,
+  `stellar:pubnet`), a network name for Solana and
+  Lightning (e.g., `mainnet`), or omitted entirely for
+  methods without a network concept (e.g., Stripe, card).
+  When present, the server SHOULD only return challenges
+  whose `request` object targets a matching network.
+
+Both parameters are method-scoped: the valid values for a
+given method are defined by that method's specification,
+not by this document. Payment method specifications SHOULD
+document the accepted values for use in `Accept-Payment`.
+
+Parameters are compared using case-sensitive byte-for-byte
+string matching. A `payment-range` without a parameter
+matches challenges regardless of that dimension, preserving
+backward compatibility.
+
+Payment method specifications MAY define additional
+preference parameters beyond `currency` and `network`.
+Implementations MUST ignore unknown parameters.
+
 Examples:
 
 ~~~http

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -854,6 +854,19 @@ Clients MUST NOT rely on the `description` parameter for payment
 verification. Malicious servers could provide a misleading description
 while the actual `request` payload requests a different amount.
 
+## Accept-Payment Information Disclosure
+
+The `Accept-Payment` header reveals which payment methods,
+currencies, and networks a client supports. This metadata
+is visible to the server and any intermediary that can
+observe request headers.
+
+Clients concerned about disclosing wallet capabilities
+SHOULD omit `Accept-Payment` and instead filter challenges
+locally after receiving the 402 response. Servers MUST NOT
+require `Accept-Payment` as a precondition for issuing
+challenges.
+
 ## Privacy
 
 - Servers MUST NOT require user accounts for payment.

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -1174,6 +1174,70 @@ WWW-Authenticate: Payment id="yR5tUvWxY6zAbCdE7fGhIj", realm="api.example.com", 
 WWW-Authenticate: Payment id="xR8sTuUvW9yZaBcD0eFgHi", realm="api.example.com", method="stripe", intent="charge", request="..."
 ~~~
 
+## Currency and Network Preferences
+
+Clients can narrow challenges by currency and network.
+In this example, the client holds USDC on Base (EVM chain
+8453) and also accepts Stripe in USD:
+
+~~~http
+GET /resource HTTP/1.1
+Host: api.example.com
+Accept-Payment: evm/charge;currency=0x833589fC;network=8453,
+  stripe/charge;currency=usd;q=0.5
+~~~
+
+The server offers both EVM and Stripe challenges but only
+returns the EVM challenge for chain 8453 with USDC (not an
+alternative chain or token the client did not request):
+
+~~~http
+HTTP/1.1 402 Payment Required
+Cache-Control: no-store
+WWW-Authenticate: Payment id="cN7xKmLp",
+  realm="api.example.com", method="evm",
+  intent="charge", request="eyJ..."
+WWW-Authenticate: Payment id="dP8yLnMq",
+  realm="api.example.com", method="stripe",
+  intent="charge", request="eyJ..."
+~~~
+
+## Cross-Method Preferences
+
+A client that supports multiple payment ecosystems can
+express a ranked preference across methods, currencies,
+and networks in a single header:
+
+~~~http
+GET /api/data HTTP/1.1
+Host: api.example.com
+Accept-Payment: evm/charge;network=8453;currency=0x833589fC,
+  solana/charge;network=mainnet;currency=EPjFWdd5Au;q=0.8,
+  lightning/charge;network=mainnet;q=0.5,
+  stripe/charge;currency=usd;q=0.3
+~~~
+
+The client prefers USDC on Base, then USDC on Solana
+mainnet, then Lightning on mainnet, and least prefers
+Stripe in USD. Methods without a network concept (such as
+Stripe) omit the `network` parameter. Methods with an
+implicit currency (such as Lightning, which always uses
+satoshis) may omit `currency`.
+
+## Partial Preferences
+
+A client can specify `currency` without `network`, or vice
+versa. Unspecified dimensions match any value.
+
+~~~http
+Accept-Payment: evm/charge;currency=0x833589fC,
+  solana/charge;network=mainnet;q=0.8
+~~~
+
+The first range matches any EVM chain offering the
+specified USDC contract. The second matches Solana mainnet
+regardless of token.
+
 ## Signed Authorization
 
 A payment method using cryptographic signatures:

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -617,10 +617,21 @@ choosing which Payment challenges to return.
 
 Specifically, servers SHOULD:
 
-- Filter challenges to those matching at least one declared range with `q>0`
+- Filter challenges to those matching at least one declared
+  range with `q>0`. A challenge matches a range when:
+  - The `method` and `intent` match (including wildcards)
+  - If the range specifies `currency`, the challenge request
+    object contains a matching `currency` value
+  - If the range specifies `network`, the challenge request
+    object targets a matching network (via `methodDetails`)
+  - A range that omits a parameter matches any value for
+    that dimension
 - Order matching challenges by descending client `q` value
-- Preserve server preference order when multiple matches have the same `q`
-- Prefer the most specific matching range when multiple ranges match the same challenge
+- Preserve server preference order when multiple matches
+  have the same `q`
+- Prefer the most specific matching range when multiple
+  ranges match the same challenge. Ranges with parameters
+  are more specific than ranges without.
 
 If `Accept-Payment` is absent, servers MUST behave as though the client
 accepts any method and intent combination.


### PR DESCRIPTION
Closes #254

## Summary

Extends Section 7.4 (Client Payment Preferences) of the core spec to support optional `currency` and `network` parameters in the `Accept-Payment` header, enabling clients to express fine-grained payment preferences beyond `method` and `intent`.

This mirrors the issue discussion at #254 — currency and network are currently locked inside the base64url-encoded `request` parameter, forcing clients to decode every challenge to find one they can fulfill.

## What Changed

### ABNF extension (Section 7.4 + Appendix A)

`payment-range` gains a `*prefer-param` production that allows semicolon-separated `key=value` pairs between the `method/intent` token and the `q` weight:

```abnf
payment-range  = payment-token *prefer-param [ weight ]
prefer-param   = OWS ";" OWS token "=" ( token / quoted-string )
```

### Two initial parameters

- **`currency`** — ISO 4217 lowercase for fiat, token contract address for on-chain, or method-defined identifier (`sat` for Lightning)
- **`network`** — EIP-155 chainId for EVM, CAIP-2 for Stellar, network name for Solana/Lightning, omitted for methods without a network concept

Both are method-scoped: valid values are defined by each method's specification. The core spec treats them as opaque strings.

### Server matching logic

Extended the "servers SHOULD" list in Section 7.4 to intersect `currency` and `network` when filtering challenges, with a specificity rule (ranges with parameters are more specific than ranges without).

### Examples

Added three new examples in Appendix B:
- Currency and Network Preferences (single-method filter)
- Cross-Method Preferences (EVM + Solana + Lightning + Stripe in one header)
- Partial Preferences (currency without network, or vice versa)

### Security consideration

New "Accept-Payment Information Disclosure" subsection notes that clients who want to avoid disclosing wallet capabilities can omit the header and filter locally.

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Generic `*prefer-param` syntax | Future parameters (`credential-type`, `max-amount`, `fee-payer`) added without core ABNF changes |
| Method-scoped opaque strings | Each method already uses different formats — no single canonical format exists |
| Absent parameter = match any | Backward compatibility — existing `Accept-Payment` headers work unchanged |
| Unknown parameters MUST be ignored | Forward compatibility — established HTTP evolution pattern |
| Case-sensitive byte-for-byte matching | Consistent with how `method` and `intent` are matched |

## Backward Compatibility

Fully backward compatible. Existing `Accept-Payment` headers without parameters continue to work exactly as before. A range without a parameter matches any value for that dimension.

## Validation

- `make check` — passed (kramdown-rfc + xml2rfc + rfclint)
- `make lint` — passed (frontmatter)
- `python3 scripts/lint_external_section_refs.py` — passed (no new `Section X.Y of {{I-D...}}` refs)
- All modified lines under 72 chars

## AI Assistance Disclosure

Per CONTRIBUTING.md: I used Claude to help draft the spec prose and validate the ABNF. All content has been reviewed for RFC compliance, technical accuracy against the existing spec structure, and consistency with the STYLE.md design principles.

## Files Changed

- `specs/core/draft-httpauth-payment-00.md` — single-file change across Section 7.4, Appendix A, Appendix B, and Security Considerations