### PR TITLE
fix: explicitly add externalId to PaymentWitness struct

### DIFF
--- a/specs/methods/evm/draft-evm-charge-00.md
+++ b/specs/methods/evm/draft-evm-charge-00.md
@@ -452,14 +452,16 @@ The Permit2 witness mechanism provides cryptographic
 binding between the payment authorization and the
 challenge. When `externalId` is present in the challenge
 request, the client MUST include it in the EIP-712
-witness struct. The server MUST verify the witness
-matches before submitting the transaction.
+witness struct. When `externalId` is absent from the challenge request,
+`PaymentWitness.externalId` is the empty string (`""`). The server MUST
+verify the witness matches before submitting the transaction.
 
 The witness type is defined as:
 
 ~~~solidity
 struct PaymentWitness {
     bytes32 challengeHash;
+    string externalId;
 }
 ~~~
 
@@ -478,7 +480,7 @@ against a different challenge, even if the payment
 parameters are identical.
 
 The witness type string for EIP-712 is:
-`"PaymentWitness witness)PaymentWitness(bytes32 challengeHash)TokenPermissions(address token,uint256 amount)"`
+`"PaymentWitness witness)PaymentWitness(bytes32 challengeHash, string externalId)TokenPermissions(address token,uint256 amount)"`
 
 This specification defines that witness schema directly for
 challenge binding. Implementations MUST use the exact type


### PR DESCRIPTION
Adds `externalId` to `PaymentWitness` to match the existing EIP-712 witness requirement.
This does not change the struct already described in spec, it clarifies the schema in the `PaymentWitness` codeblock.

Fixes #263