### PR TITLE
docs: require non-empty challenge ids

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -240,9 +240,13 @@ auth-param      = token BWS "=" BWS ( token / quoted-string )
 
 ### Required Parameters
 
-**`id`**: Unique challenge identifier. Servers MUST bind this value to the
-  challenge parameters (Section 5.1.3) to enable verification. Clients MUST
-  include this value unchanged in the credential.
+**`id`**: Unique challenge identifier. This parameter is REQUIRED and its
+  value MUST be non-empty after `auth-param` parsing and `quoted-string`
+  unescaping. Servers MUST NOT emit a Payment challenge with a missing or
+  empty `id`; clients and parsers MUST reject challenges whose `id` is
+  missing or empty. Servers MUST bind this value to the challenge parameters
+  (Section 5.1.3) to enable verification. Clients MUST include this value
+  unchanged in the credential.
 
 **`realm`**: Protection space identifier per {{RFC9110}}. Servers MUST
   include this parameter to define the scope of the payment requirement.
@@ -908,6 +912,7 @@ auth-params       = auth-param *( OWS "," OWS auth-param )
 auth-param        = token BWS "=" BWS ( token / quoted-string )
 
 ; Required parameters: id, realm, method, intent, request
+; The id parameter is required by prose to be non-empty after parsing.
 ; Optional parameters: expires, digest, description, opaque
 
 ; HTTP Authorization Credentials


### PR DESCRIPTION
## Summary
- Clarifies that Payment challenge `id` is required and must be non-empty after auth-param parsing and quoted-string unescaping.
- States that servers must not emit missing or empty ids and clients/parsers must reject them.
- Leaves the generic auth-param ABNF intact and records the non-empty constraint in prose.

This follows the direction in https://github.com/tempoxyz/mpp-tools/issues/19#issuecomment-4752175102.

## Verification
- Attempted `./scripts/check.sh`; blocked locally by missing `kramdown-rfc` and `xml2rfc`.
- Attempted `make check`; blocked because Docker/OrbStack socket was unavailable.