### PR TITLE
docs: align method naming guidance with split drafts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This ensures intents are battle-tested before standardization, preventing premat
 |------|---------|---------|
 | Core | `draft-httpauth-payment-XX` | `draft-httpauth-payment-00` |
 | Intent | `draft-payment-intent-{name}-XX` | `draft-payment-intent-charge-00` |
-| Method | `draft-{network}-payment-method-XX` | `draft-tempo-payment-method-00` |
+| Method | `draft-{network}-{intent}-XX` | `draft-tempo-charge-00` |
 | Extension | `draft-payment-{feature}-XX` | `draft-payment-discovery-00` |
 
 ## Writing Style

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,5 +82,5 @@ author:
 |------|---------|---------|
 | Core | `draft-httpauth-payment-XX` | `draft-httpauth-payment-00` |
 | Intent | `draft-payment-intent-{name}-XX` | `draft-payment-intent-charge-00` |
-| Method | `draft-{network}-payment-method-XX` | `draft-tempo-payment-method-00` |
+| Method | `draft-{network}-{intent}-XX` | `draft-tempo-charge-00` |
 | Extension | `draft-payment-{feature}-XX` | `draft-payment-discovery-00` |

--- a/examples/method-template.md
+++ b/examples/method-template.md
@@ -1,7 +1,7 @@
 ---
-title: "{Network}" Payment Method for HTTP Payment Authentication
-abbrev: "{Network}" Payment Method
-docname: draft-{network}-payment-method-00
+title: "{Network} {Intent} for HTTP Payment Authentication"
+abbrev: "{Network} {Intent}"
+docname: draft-{network}-{intent}-00
 version: 00
 category: info
 ipr: noModificationTrust200902
@@ -17,9 +17,10 @@ author:
 
 ## Abstract
 
-This document defines the "{network}" payment method for use with the Payment
-HTTP Authentication Scheme [I-D.httpauth-payment]. It specifies how clients
-and servers exchange payments using [Network Name]'s payment infrastructure.
+This document defines the "{intent}" intent for the "{network}" payment
+method using the Payment HTTP Authentication Scheme
+[I-D.httpauth-payment]. It specifies how clients and servers exchange
+payments using [Network Name]'s payment infrastructure.
 
 ## Status of This Memo
 


### PR DESCRIPTION
## Description

Align the contributor-facing method naming guidance with the repo's current split-per-intent draft layout.

This updates the method filename pattern in `CONTRIBUTING.md` and `examples/README.md`, and adjusts the top of `examples/method-template.md` so the template metadata and abstract match intent-scoped drafts like `draft-tempo-charge-00.md`.

## Validation

- `git diff --check`
- `make lint`
- `make check`

## AI assistance

Codex helped prepare this small docs/template change. I reviewed the diff and validation output before opening the PR.
