### PR TITLE
docs: fix rendered specification link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The open protocol for machine-to-machine payments.
 
 * **[IETF Draft](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/)**: the core specification
-* **[Full Rendered Spec](https://tempoxyz.github.io/payment-auth-spec/)**: all specs including methods and extensions
+* **[Full Rendered Spec](https://paymentauth.org/)**: all specs including methods and extensions
 * **[Learn more](https://mpp.dev)**
 
 ## What is MPP?


### PR DESCRIPTION
## What changed

Updated the README's rendered specification link from the retired GitHub Pages URL to `https://paymentauth.org/`.

## Why

Graphite's repository standard calls for current documentation links. The previous URL returned HTTP 404.

## Validation

- `git diff --check`
- confirmed `https://paymentauth.org/` returns HTTP 200