### PR TITLE
chore: batch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,30 @@
 version: 2
+
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+
 updates:
   - package-ecosystem: pip
     directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    groups:
-      python-deps:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies
 
   - package-ecosystem: bundler
     directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    groups:
-      ruby-deps:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies
 
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    groups:
-      actions:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies
 
   - package-ecosystem: docker
     directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    groups:
-      docker-deps:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,16 @@
+name: Dependabot
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@1d20c6f032568c0aea39c0e7e57e4ba350516281


### PR DESCRIPTION
## Motivation

Routine Python, Ruby, Docker, and GitHub Actions updates currently arrive as separate pull requests and require repetitive merge handling.

## Summary

- Batch all routine dependency ecosystems into one weekly pull request
- Call the reusable Dependabot workflow from tempoxyz/mpp-tools#67 at an exact commit
- Automatically approve and squash-merge patch and minor updates after every pull request check passes
- Keep major updates manual and security updates independent of the weekly version-update schedule

## Key design considerations

- Pin the shared workflow to commit `1d20c6f032568c0aea39c0e7e57e4ba350516281`
- Preserve the repository review rule through bot approval only for verified Dependabot updates
- Depend on tempoxyz/mpp-tools#67