### PR TITLE
fix(evm-charge): remove redundant externalId from Permit2 witness

### DIFF
--- a/specs/methods/evm/draft-evm-charge-00.md
+++ b/specs/methods/evm/draft-evm-charge-00.md
@@ -151,7 +151,7 @@ This specification defines four credential types:
   - The server naturally sponsors gas (fee payer)
   - Split payments are atomic via batch transfers
   - No nonce management burden on the client
-  - `externalId` is cryptographically bound via witness data
+  - `externalId` is cryptographically bound via the challenge hash
 
 - **`type="authorization"`**: The client signs an
   off-chain EIP-3009 {{EIP-3009}} `transferWithAuthorization`
@@ -450,10 +450,12 @@ in array order.
 
 The Permit2 witness mechanism provides cryptographic
 binding between the payment authorization and the
-challenge. When `externalId` is present in the challenge
-request, the client MUST include it in the EIP-712
-witness struct. When `externalId` is absent from the challenge request,
-`PaymentWitness.externalId` is the empty string (`""`). The server MUST
+challenge. The witness commits to `challengeHash`, which
+is derived from `challenge.id` and `challenge.realm`.
+Because `challenge.id` is an HMAC over the serialized
+challenge request (see {{I-D.httpauth-payment}}), every
+request field, including `externalId` when present, is
+already bound through `challengeHash`. The server MUST
 verify the witness matches before submitting the transaction.
 
 The witness type is defined as:
@@ -461,7 +463,6 @@ The witness type is defined as:
 ~~~solidity
 struct PaymentWitness {
     bytes32 challengeHash;
-    string externalId;
 }
 ~~~
 
@@ -480,7 +481,7 @@ against a different challenge, even if the payment
 parameters are identical.
 
 The witness type string for EIP-712 is:
-`"PaymentWitness witness)PaymentWitness(bytes32 challengeHash, string externalId)TokenPermissions(address token,uint256 amount)"`
+`"PaymentWitness witness)PaymentWitness(bytes32 challengeHash)TokenPermissions(address token,uint256 amount)"`
 
 This specification defines that witness schema directly for
 challenge binding. Implementations MUST use the exact type


### PR DESCRIPTION
Closes #287.

@Xeift is right: `externalId` in the Permit2 `PaymentWitness` is redundant.

The witness commits to `challengeHash = keccak256(challenge.id, challenge.realm)`, and `challenge.id` is an HMAC whose slot 3 is the **entire `request` object**, JCS-serialized per RFC 8785 (core `draft-httpauth-payment-00`). Since `externalId` is a member of `request`, it is already bound to `challenge.id` (and therefore to `challengeHash` and the signature) whenever present. The separate witness field binds nothing new.

Removing it is also a small hardening: the old text carried a `PaymentWitness.externalId == ""` absent-case rule that duplicated, at the witness layer, the absent-optional-field convention the core spec already resolves deterministically at HMAC slot 3 via JCS. Two separately-specified conventions for the same thing is a needless cross-implementation divergence risk.

No regression to the `type="hash"` mitigation ("Requiring unique `externalId` values per challenge") — that operates at the `challenge.id` layer, not the witness, so distinct `externalId` still yields distinct `challengeHash`.

**Changes (one file):**
- Drop `string externalId;` from the `PaymentWitness` struct and from the EIP-712 witness type string.
- Reword the Witness Data section to state binding flows through `challengeHash` -> `challenge.id` (which already commits to every request field, incl. `externalId`).
- Update the `type="permit2"` bullet accordingly.

`externalId` intentionally remains as the request field, the receipt echo, and the hash-mode mitigation.

**Validation:** builds clean through `kramdown-rfc` + `xml2rfc` (HTML/TXT); `rfclint --no-rng --no-spell` exit 0; `lint_frontmatter.py` clean. DCO signed-off.
