### PR TITLE
fix(hedera-session): align frontmatter with repo convention

### DIFF
--- a/specs/methods/hedera/draft-hedera-session-00.md
+++ b/specs/methods/hedera/draft-hedera-session-00.md
@@ -5,7 +5,7 @@ abbrev: Hedera Session
 docname: draft-hedera-session-00
 version: 00
 category: info
-ipr: trust200902
+ipr: noModificationTrust200902
 submissiontype: independent
 consensus: false
 
@@ -29,8 +29,7 @@ normative:
   RFC9457:
   I-D.httpauth-payment:
     title: "The 'Payment' HTTP Authentication Scheme"
-    target: >
-      https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
     author:
       - name: Jake Moxey
     date: 2026-01


### PR DESCRIPTION
Small frontmatter conformance fix for `draft-hedera-session-00` — it's the lone outlier on two fields the rest of the repo (and `scripts/lint_frontmatter.py`) standardize on:

- `ipr: trust200902` -> `noModificationTrust200902`. All 21 other specs use `noModificationTrust200902`, including this method's sibling `draft-hedera-charge-00`.
- `I-D.httpauth-payment` reference: collapse the folded `target: >` scalar (which appends a trailing newline the linter rejects) to the canonical inline form, and correct `draft-ietf-httpauth-payment` -> `draft-ryan-httpauth-payment` (the I-D is `draft-ryan-`, matching the 20 other specs).

Before this, `make lint` reported 2 errors on the file; after, `lint_frontmatter.py` reports `✓ All frontmatter checks passed`. Draft still builds clean through `kramdown-rfc` + `xml2rfc` + `rfclint`. DCO signed-off.
