### PR TITLE
fix(charge): require MUST NOT for partial access on verification failure

### DIFF
--- a/specs/intents/draft-payment-intent-charge-00.md
+++ b/specs/intents/draft-payment-intent-charge-00.md
@@ -107,10 +107,26 @@ of a specified amount in exchange for resource access.
 
 ## Atomicity
 
-The "charge" intent implies atomic exchange: the server SHOULD NOT
+The "charge" intent implies atomic exchange: the server MUST NOT
 provide partial access if payment verification fails. Either the full
 resource is provided (payment succeeded) or access is denied (payment
-failed).
+failed). This aligns with the unpaid-request side-effect boundary
+already required by {{I-D.httpauth-payment}} under "Idempotency and
+Side Effects".
+
+Partial access includes, but is not limited to:
+
+- Any response body bytes, including a partial buffered payload
+- Streamed output, including the first token or chunk of a streaming
+  response
+- Invocation of tools, functions, or external APIs on behalf of the
+  request
+- Initiation of an asynchronous task, job, or subscription
+
+If verification fails after any such effect has already occurred, the
+server MUST treat this as an implementation defect to be corrected,
+not as a conforming outcome; there is no MAY-level exception for
+"already-started" delivery.
 
 # Request Schema
 


### PR DESCRIPTION
## What

The Charge intent's Atomicity section used `SHOULD NOT` for withholding partial access when payment verification fails, while Core already mandates `MUST NOT` for unpaid-request side effects under "Idempotency and Side Effects". This left room for justified deviation on exactly the boundary Core treats as non-negotiable.

The gap matters most for delivery modes where the first effect is itself valuable or irreversible: a streamed token, a tool/external-API call made on the caller's behalf, or an initiated async task. `SHOULD NOT` lets different implementations draw that line in different places after an identical verification failure.

## Change

- Raise Charge's Atomicity requirement from `SHOULD NOT` to `MUST NOT`, matching Core.
- Enumerate what counts as "partial access": response bytes, streamed output, tool/external-API invocation, and async task initiation, so implementers don't have to infer scope from a single sentence.
- Note explicitly that an already-occurred effect after a failed verification is a defect, not a conforming outcome.

## Versioning

No wire-format or field changes here, just a normative strength change. Per the versioning strategy from #115 (intents are unversioned; breaking changes get a new identifier like `charge-v2`), this doesn't require a docname/version bump.

## Validation

- `python3 scripts/lint_frontmatter.py` passes for this file (the two pre-existing failures it reports are in `draft-hedera-session-00.md`, unrelated to this change).
- Didn't have Docker available to run the full `make check` (rfclint) locally — the change is pure prose inside an existing section, no structural markdown changes, so it should build cleanly, but flagging in case you want me to verify differently.

Fixes #316