### PR TITLE
fix(lightning-session): require refund fields in the close receipt schema

### DIFF
--- a/specs/methods/lightning/draft-lightning-session-00.md
+++ b/specs/methods/lightning/draft-lightning-session-00.md
@@ -910,6 +910,14 @@ refundStatus
   could not be routed), or "skipped" (refundSats was zero, no payment
   attempted). Omitted for non-close actions.
 
+On a close receipt, the top-level `status` field attests only to
+successful verification and settlement of the close action itself. It
+remains `"success"` per {{I-D.httpauth-payment}} even when `refundStatus`
+is `"failed"`. The outcome of the refund payment is conveyed solely by
+`refundStatus`; a consumer MUST inspect `refundStatus` to determine
+whether the unspent balance was returned and MUST NOT infer refund
+completion from the top-level `status`.
+
 ## Streaming Receipt Event
 
 For streaming responses, the Payment-Receipt header is attached at
@@ -1294,10 +1302,16 @@ Schema draft version is required or assumed.
   "type": "object",
   "required": ["method", "reference", "status", "timestamp"],
   "properties": {
-    "method":    { "type": "string", "const": "lightning" },
-    "reference": { "type": "string" },
-    "status":    { "type": "string", "const": "success" },
-    "timestamp": { "type": "string", "format": "date-time" }
+    "method":       { "type": "string", "const": "lightning" },
+    "reference":    { "type": "string" },
+    "status":       { "type": "string", "const": "success" },
+    "timestamp":    { "type": "string", "format": "date-time" },
+    "refundSats":   { "type": "integer", "minimum": 0 },
+    "refundStatus": { "type": "string", "enum": ["succeeded", "failed", "skipped"] }
+  },
+  "dependentRequired": {
+    "refundSats":   ["refundStatus"],
+    "refundStatus": ["refundSats"]
   }
 }
 ~~~


### PR DESCRIPTION
## Summary

The Lightning Session receipt prose requires `refundSats` and `refundStatus`
on every close receipt, but the Receipt Schema neither defines nor requires
them. This PR aligns the schema with the prose and adds one sentence defining
how the top-level `status` relates to `refundStatus` on a close receipt.

Fixes #307.

## The inconsistency

`specs/methods/lightning/draft-lightning-session-00.md`:

- Prose (Receipt section) states both fields are REQUIRED in a close receipt:
  "For close actions only. REQUIRED in the receipt when the action is close."
- The Receipt Schema requires only `["method","reference","status","timestamp"]`,
  hard-codes `status` to `{ "const": "success" }`, and does not list `refundSats`
  or `refundStatus` as properties at all.

Consequences of the gap:

1. A schema-conformant close receipt can omit `refundStatus`, dropping the only
   field that distinguishes a completed refund from a failed one, while the
   top-level `status` still validates as `"success"`.
2. Schema-derived client models do not surface the refund fields, so a generic
   wallet, audit pipeline, or support tool that consumes the schema records a
   failed-refund close as economically complete.
3. Core (`specs/core/draft-httpauth-payment-00.md`) defines top-level
   `status:"success"` as "payment was verified and settled successfully", so the
   relationship between that success and a `refundStatus:"failed"` is left
   undefined by the current text.

## Changes

1. Receipt Schema: add `refundSats` (`integer`, `minimum: 0`) and `refundStatus`
   (`enum: ["succeeded","failed","skipped"]`) to `properties`, and add
   `dependentRequired` both ways so a receipt that carries one MUST carry the
   other. This matches the concrete request in the issue thread: require
   `refundStatus` in the schema whenever `refundSats` is present, so it can no
   longer be silently dropped, and reject an out-of-range `refundStatus`.
2. Prose: one paragraph after the `refundStatus` field definition stating that a
   close receipt's top-level `status` attests only to verification and settlement
   of the close action, remains `"success"` per the core scheme even when
   `refundStatus` is `"failed"`, and that a consumer MUST read `refundStatus` and
   MUST NOT infer refund completion from `status`.

The change is additive and does not alter non-close receipts, which continue to
omit both fields.

## Validation

- Rendered clean through the repository toolchain (`make check`: kramdown-rfc
  then rfclint) with no new errors versus current `main`. The one pre-existing
  frontmatter-lint failure is in `specs/methods/hedera/draft-hedera-session-00.md`
  and is unrelated to this change.
- JSON Schema conformance (2020-12, matching `dependentRequired`): the three
  receipt examples in the draft (succeeded / failed / skipped) all validate under
  the new schema; a receipt carrying `refundSats` without `refundStatus` is
  accepted by the old schema and rejected by the new one; a non-close receipt
  with no refund fields validates under both.

## Two notes for the maintainers (your call)

- The receipt carries no `action` field, so the schema cannot make the refund
  fields unconditionally required for close only. `dependentRequired` closes the
  silent-drop-of-`refundStatus` case; the prose continues to require both on
  close. If you want full schema-level enforcement, the options are a dedicated
  close-receipt sub-schema, or adding an `action` discriminator to the receipt.
  Happy to follow whichever you prefer.
- I typed `refundSats` as `integer` (satoshis are indivisible); the prose says
  "as a number". Glad to switch to `number` if you would rather keep the schema
  wording aligned with the prose.

This addresses only the concrete schema/prose inconsistency named in #307. The
separate settlement-versus-delivery completeness question raised in #308 is left
to that thread.
