### PR TITLE
fix(tempo-charge): align the EIP-712 Proof contract with shipped v3

### DIFF
--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -460,6 +460,23 @@ from the challenge, binding the proof to the issuing origin and
 preventing cross-realm replay of a proof obtained from a different
 server.
 
+### Proof Contract Versions
+
+The domain `version` identifies the proof contract. Three versions have
+shipped:
+
+| Version | `Proof` fields | Description |
+|---------|----------------|-------------|
+| `"1"` | `challengeId` | Initial contract. Binds a proof to a single challenge. |
+| `"2"` | `challengeId`, `realm` | Adds realm binding, so a proof obtained from one server cannot be replayed against another. |
+| `"3"` | `account`, `challengeId`, `realm` | Adds payer binding, so a proof cannot be replayed against a different account, including across an access key authorized for multiple accounts. |
+
+Implementations MUST use version `"3"`. The domain `version` is part of
+the EIP-712 digest, so a signature produced under version `"1"` or
+`"2"` does not verify against the version `"3"` typed data. Servers
+MUST NOT accept proof signatures made under domain version `"1"` or
+`"2"`.
+
 ### Proof Verification
 
 Servers MUST verify proof credentials as follows:

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -431,24 +431,34 @@ The typed-data domain and types are:
 {
   "domain": {
     "name": "MPP",
-    "version": "1",
+    "version": "3",
     "chainId": <challenge methodDetails.chainId>
   },
   "types": {
     "Proof": [
-      { "name": "challengeId", "type": "string" }
+      { "name": "account", "type": "address" },
+      { "name": "challengeId", "type": "string" },
+      { "name": "realm", "type": "string" }
     ]
   },
   "primaryType": "Proof",
   "message": {
-    "challengeId": "<challenge.id>"
+    "account": "<address from credential.source>",
+    "challengeId": "<challenge.id>",
+    "realm": "<challenge realm>"
   }
 }
 ~~~
 
 The `challengeId` in the message MUST be the `id` from the challenge
 that was issued to the client. This binds the signature to exactly one
-challenge, preventing cross-challenge replay.
+challenge, preventing cross-challenge replay. The `account` MUST be
+the address from `credential.source`, binding the proof to the paying
+account so that a signature cannot be replayed against another account
+controlled by the same signing key. The `realm` MUST be the `realm`
+from the challenge, binding the proof to the issuing origin and
+preventing cross-realm replay of a proof obtained from a different
+server.
 
 ### Proof Verification
 
@@ -458,9 +468,19 @@ Servers MUST verify proof credentials as follows:
    `did:pkh:eip155:<chainId>:<address>`
 2. Verify the chain ID from `source` matches
    `methodDetails.chainId` from the challenge
-3. Recover the signer from `payload.signature` using the EIP-712
-   domain, types, and message described above
-4. Verify the recovered signer matches the address in `source`
+3. Reconstruct the typed data described above with `account` set to
+   the address from `source`, `challengeId` set to the challenge `id`,
+   and `realm` set to the challenge `realm`
+4. Verify `payload.signature` is a valid signature over that typed
+   data by the address from `source`. Recovering the signer and
+   comparing it to the address from `source` satisfies this check;
+   servers MAY additionally accept contract-account signatures
+   (ERC-1271).
+5. If step 4 fails, servers MAY instead recover the signer of
+   `payload.signature` and accept the credential only if that signer
+   is an access key currently authorized on-chain for the account in
+   `source`. Servers MUST NOT otherwise accept a credential whose
+   signer differs from the address in `source`.
 
 ### Proof Receipt
 


### PR DESCRIPTION
The Proof Payload section specifies the v1 EIP-712 contract: domain version `"1"`, message `Proof(string challengeId)`. All three shipping SDKs sign and verify v3, `Proof(address account, string challengeId, string realm)` with domain version `"3"`:

- mpp-go [pkg/tempo/proof.go#L28-L37](https://github.com/tempoxyz/mpp-go/blob/fd01098f563b0bba96ddafd3b55a03ed424a0524/pkg/tempo/proof.go#L28-L37)
- mpp-rs [src/protocol/methods/tempo/proof.rs#L14-L22](https://github.com/tempoxyz/mpp-rs/blob/85c62c59205789d6506ad0c77f543a8680f02612/src/protocol/methods/tempo/proof.rs#L14-L22) (v3 since [#318](https://github.com/tempoxyz/mpp-rs/pull/318))
- mppx [src/tempo/internal/proof.ts#L13-L23](https://github.com/wevm/mppx/blob/a74b20b925d63b4f86962c140808db1858089b88/src/tempo/internal/proof.ts#L13-L23)

The digests diverge, so a server implementing the spec as written recovers a non-matching address and rejects every valid zero-amount proof. For chainId 42431, challengeId `kM9xPqWvT2nJrHsY4aDfEb`, realm `api.example.com`, account `0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1`:

```
spec v1    0xc5c155e34a264f8a8ff363f3e989f402356697303a4e1102d512c25b1b2afb11
shipped v3 0x3860a700a55e02ad3c2dc047e92489feceecbdb0a801d948e1d9f0b61ea9bc3f
```

The v3 value matches the constant mpp-rs pins in `test_signing_hash_matches_mppx_v3_vector`.

This updates the typed data and the Proof Verification steps to the shipped contract. ERC-1271 and on-chain access-key delegation are written as MAY, since mppx and mpp-rs implement delegation as a fallback and mpp-go does not; adjust the strength if you intend otherwise.

Related, not in this PR: stripe/mpp-rb is still on v2 (migration open at stripe/mpp-rb#38) and the mpp-tools tempo-proof vector pins v2.

`make check` and the frontmatter/section-ref linters pass locally. Prepared with AI assistance per CONTRIBUTING; the SDK citations and digests were reproduced independently.
