### PR TITLE
Alternate payment credential header

### DIFF
--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -1,8 +1,8 @@
 ---
 title: The "Payment" HTTP Authentication Scheme
 abbrev: Payment Auth Scheme
-docname: draft-httpauth-payment-01
-version: "01"
+docname: draft-httpauth-payment-00
+version: 00
 category: std
 ipr: noModificationTrust200902
 submissiontype: IETF

--- a/specs/core/draft-httpauth-payment-00.md
+++ b/specs/core/draft-httpauth-payment-00.md
@@ -103,8 +103,8 @@ Payment Challenge
 Payment Credential
 : An HTTP header field with scheme "Payment" containing payment
   authorization data. The default field name is `Authorization`. A
-  Payment challenge MAY select a different field with the `header`
-  parameter (see {{credential-header}}).
+  Payment challenge MAY select `Payment-Authorization` with the
+  `header` parameter (see {{credential-header}}).
 
 Payment Method
 : A mechanism for transferring value, identified by a registered
@@ -231,9 +231,9 @@ unauthenticated clients.
 
 When authentication succeeds but the resource also requires payment, the
 server MAY include the `header` parameter in its Payment challenge to
-select a field other than the default `Authorization` for the Payment
-credential (see {{credential-header}}). A challenge that omits `header`
-defaults to `Authorization`. A challenge that includes
+select `Payment-Authorization` instead of the default `Authorization`
+for the Payment credential (see {{credential-header}}). A challenge that
+omits `header` defaults to `Authorization`. A challenge that includes
 `header="Payment-Authorization"` requires the client to send the Payment
 credential in the `Payment-Authorization` header. This allows the client
 to retain its ordinary authentication credential in `Authorization`.
@@ -323,22 +323,21 @@ auth-param      = token BWS "=" BWS ( token / quoted-string )
   relied upon for payment verification (see {{amount-verification}}).
 
 **`header`**: Selects the HTTP field for the Payment credential, as
-  specified in {{credential-header}}. The value MUST be a valid
-  `field-name` as defined by {{RFC9110}}. The default field is
+  specified in {{credential-header}}. When present, the value MUST be
+  `Payment-Authorization` to avoid collision with other HTTP fields.
+  The default field is
   `Authorization`. A challenge that omits this parameter selects that
   default: the client MUST send the credential in the `Authorization`
-  header. A challenge that includes this parameter selects the named
-  field instead of the default; the client MUST send the credential in
-  that field. For example, `header="Payment-Authorization"` requires
-  the credential to be sent in the `Payment-Authorization` header.
-  Clients MUST NOT send the credential in a different field than the
-  one selected by the challenge. Clients that do not support the named
-  field MUST NOT send a Payment credential for that challenge. Servers
-  MUST include this parameter in the challenge binding when it is
-  present. Clients MUST echo it unchanged in the credential's
-  `challenge` object. `Payment-Authorization` is RECOMMENDED when a
-  resource needs to preserve `Authorization` for ordinary
-  authentication.
+  header. A challenge that includes this parameter selects
+  `Payment-Authorization`; the client MUST send the credential in that
+  field. Clients MUST NOT send the credential in a different field than
+  the one selected by the challenge. Clients that do not support
+  `Payment-Authorization` MUST NOT send a Payment credential for that
+  challenge. Servers MUST include this parameter in the challenge
+  binding when it is present. Clients MUST echo it unchanged in the
+  credential's `challenge` object. `Payment-Authorization` is
+  RECOMMENDED when a resource needs to preserve `Authorization` for
+  ordinary authentication.
 
 **`opaque`**: Base64url-encoded {{RFC4648}} JSON {{RFC8259}} containing
   server-defined correlation data (e.g., a payment processor intent
@@ -387,7 +386,7 @@ challenges issued by earlier implementations. The slots are:
 | 4 | `expires` | Optional. String value if present; empty string if absent. |
 | 5 | `digest` | Optional. String value if present; empty string if absent. |
 | 6 | `opaque` | Optional. JCS-serialized per {{RFC8785}}, then base64url-encoded if present; empty string if absent. |
-| 7 | `header` | Present only when the `header` parameter is present. Its field-name value. |
+| 7 | `header` | Present only when the `header` parameter is present. The value `Payment-Authorization`. |
 
 The computation proceeds as follows:
 
@@ -501,12 +500,16 @@ A challenge that omits the `header` parameter selects this default.
 Clients receiving such a challenge MUST send the Payment credential in
 the `Authorization` header.
 
-A challenge that includes the `header` parameter selects the named field
-instead of the default. Clients receiving such a challenge MUST send the
-Payment credential in that field. For example, a challenge containing
-`header="Payment-Authorization"` requires the credential to be sent in
-the `Payment-Authorization` header. Clients MUST NOT send the credential
-in a different field than the one selected by the challenge.
+A challenge that includes the `header` parameter selects
+`Payment-Authorization` instead of the default. The value MUST be
+`Payment-Authorization`; this specification does not allow any other
+field name, to avoid collision with other HTTP fields. Servers MUST NOT
+emit a `header` parameter with any other value. Clients receiving such a
+challenge MUST send the Payment credential in the
+`Payment-Authorization` header. Clients MUST NOT send the credential in
+a different field than the one selected by the challenge. Clients MUST
+treat any other `header` value as an unrecognized challenge and MUST NOT
+send a Payment credential for it.
 
 Servers MUST accept a Payment credential for a given challenge only from
 the field selected by that challenge. A Payment credential received in
@@ -542,7 +545,7 @@ The `challenge` object contains the parameters from the original challenge:
 | `opaque` | string | Base64url-encoded server correlation data (if present in challenge) |
 | `digest` | string | Content digest  |
 | `expires` | string | Challenge expiration timestamp |
-| `header` | string | HTTP field name selected by the challenge (included only when the challenge contained `header`) |
+| `header` | string | `Payment-Authorization` when the challenge selected that field (included only when the challenge contained `header`) |
 
 The `payload` field contains the payment-method-specific data needed to
 complete the payment challenge. Payment method specifications define the
@@ -583,9 +586,9 @@ Decoded credential:
 ### Example Credential with Alternate Header
 
 This credential corresponds to a challenge that included
-`header="Payment-Authorization"`. The client MUST send it in that
-named field, and MUST echo `header` in the credential's `challenge`
-object:
+`header="Payment-Authorization"`. The client MUST send it in
+`Payment-Authorization`, and MUST echo `header` in the credential's
+`challenge` object:
 
 ~~~http
 GET /api/data HTTP/1.1
@@ -986,6 +989,14 @@ Responses containing `Payment-Receipt` headers MUST include
 `Cache-Control: private` to prevent shared caches from storing
 payment receipts.
 
+When a request carries a Payment credential in a field other than
+`Authorization`, every corresponding response MUST include
+`Cache-Control: private` or `Cache-Control: no-store`. {{RFC9111}}
+Section 3.5 restricts shared caching of responses to requests that
+contain `Authorization`; that protection does not apply to
+`Payment-Authorization`. `Payment-Receipt` is optional and does not by
+itself prevent shared caches from storing those responses.
+
 ## Cross-Origin Considerations
 
 Clients (particularly browser-based wallets) SHOULD:
@@ -1018,6 +1029,7 @@ This document registers the following header fields:
 | Field Name | Status | Reference |
 |------------|--------|-----------|
 | Accept-Payment | permanent | This document, {{client-payment-preferences}} |
+| Payment-Authorization | permanent | This document, {{credential-header}} |
 | Payment-Receipt | permanent | This document, {{payment-receipt-header}} |
 
 ## Payment Method Registry {#payment-method-registry}
@@ -1062,8 +1074,9 @@ auth-param        = token BWS "=" BWS ( token / quoted-string )
 ; Optional parameters: expires, digest, description, header, opaque
 
 ; Payment credential field value (Authorization by default;
-; a different field when the challenge includes header)
+; Payment-Authorization when the challenge includes header)
 payment-credentials = "Payment" 1*SP base64url-nopad
+Payment-Authorization = payment-credentials
 
 ; Client payment preferences
 Accept-Payment = #payment-range
@@ -1337,7 +1350,7 @@ based on their capabilities and user preferences. Clients MUST send only
 one Payment credential in the subsequent request, in the field selected
 by that challenge ({{credential-header}}). A selected challenge that
 omits `header` uses `Authorization`; a selected challenge that includes
-`header` requires the credential in the named field.
+`header` requires the credential in `Payment-Authorization`.
 
 Servers receiving multiple Payment credentials in a single request
 SHOULD reject with 400 (Bad Request).

--- a/specs/core/draft-httpauth-payment-01.md
+++ b/specs/core/draft-httpauth-payment-01.md
@@ -1,8 +1,8 @@
 ---
 title: The "Payment" HTTP Authentication Scheme
 abbrev: Payment Auth Scheme
-docname: draft-httpauth-payment-00
-version: 00
+docname: draft-httpauth-payment-01
+version: 01
 category: std
 ipr: noModificationTrust200902
 submissiontype: IETF
@@ -101,8 +101,8 @@ Payment Challenge
   payment requirements for accessing a resource.
 
 Payment Credential
-: An `Authorization` header with scheme "Payment" containing payment
-  authorization data.
+: An HTTP header field with scheme "Payment" containing payment
+  authorization data. Its field name is selected by the Payment challenge.
 
 Payment Method
 : A mechanism for transferring value, identified by a registered
@@ -224,6 +224,23 @@ When a resource requires both authentication and payment, servers SHOULD:
 This ordering prevents information leakage about payment requirements to
 unauthenticated clients.
 
+When authentication succeeds but the resource also requires payment, the
+server MAY include the `header` parameter in its Payment challenge to
+select a header field other than `Authorization` for the Payment credential.
+This allows the client to retain its ordinary authentication credential in
+`Authorization`. Servers that do not include `header` retain the default
+behavior defined in {{credential-header}}.
+
+For example, a request can carry both a Bearer credential and a Payment
+credential:
+
+~~~http
+GET /resource HTTP/1.1
+Host: api.example.com
+Authorization: Bearer mF_9.B5f-4.1JqM
+Payment-Authorization: Payment eyJjaGFsbGVuZ2UiOiJ...
+~~~
+
 # The Payment Authentication Scheme
 
 ## Challenge (WWW-Authenticate)
@@ -286,6 +303,16 @@ auth-param      = token BWS "=" BWS ( token / quoted-string )
   purpose. This parameter is for display purposes only and MUST NOT be
   relied upon for payment verification (see {{amount-verification}}).
 
+**`header`**: The HTTP field name in which the client MUST send the Payment
+  credential. The value MUST be a valid `field-name` as defined by
+  {{RFC9110}}. When this parameter is absent, the client MUST send the
+  credential in the `Authorization` header. Clients that do not support the
+  named field MUST NOT send a Payment credential for that challenge. Servers
+  MUST include this parameter in the challenge binding when it is present.
+  Clients MUST echo it unchanged in the credential's `challenge` object.
+  `Payment-Authorization` is RECOMMENDED when a resource needs to preserve
+  `Authorization` for ordinary authentication.
+
 **`opaque`**: Base64url-encoded {{RFC4648}} JSON {{RFC8259}} containing
   server-defined correlation data (e.g., a payment processor intent
   identifier). The value MUST be a JSON object whose values are strings
@@ -300,7 +327,7 @@ Unknown parameters MUST be ignored by clients.
 #### Challenge Binding
 
 Servers MUST bind the challenge `id` to `realm`, `method`, `intent`, and
-`request`, and to `expires`, `digest`, and `opaque` when present. This
+`request`, and to `expires`, `digest`, `opaque`, and `header` when present. This
 prevents request integrity attacks where a client signs or submits a
 payment different from what the server intended. The `description`
 parameter is excluded because it is not used for payment verification.
@@ -318,9 +345,11 @@ authenticated encryption) to validate the binding.
 Servers using HMAC-SHA256 for stateless challenge binding SHOULD compute
 the challenge `id` as follows:
 
-The HMAC input is constructed from exactly seven fixed positional
-slots. Required fields supply their string value; optional fields use
-an empty string (`""`) when absent. The slots are:
+The HMAC input is constructed from seven fixed positional slots. Required
+fields supply their string value; optional fields use an empty string (`""`)
+when absent. When the `header` parameter is present, an eighth slot is
+appended with its value. This preserves the HMAC input for header-less
+challenges issued by earlier implementations. The slots are:
 
 | Slot | Field | Value |
 |------|-------|-------|
@@ -331,15 +360,18 @@ an empty string (`""`) when absent. The slots are:
 | 4 | `expires` | Optional. String value if present; empty string if absent. |
 | 5 | `digest` | Optional. String value if present; empty string if absent. |
 | 6 | `opaque` | Optional. JCS-serialized per {{RFC8785}}, then base64url-encoded if present; empty string if absent. |
+| 7 | `header` | Present only when the `header` parameter is present. Its field-name value. |
 
 The computation proceeds as follows:
 
-1. Populate all seven slots as described above.
+1. Populate all seven base slots as described above. If `header` is present,
+   append the eighth slot.
 
-2. Join all seven slots with the pipe character (`|`) as delimiter.
-   Every slot is always present in the joined string; absent optional
+2. Join the populated slots with the pipe character (`|`) as delimiter.
+   Every base slot is always present in the joined string; absent optional
    fields appear as empty segments (e.g., `...|expires||opaque_b64url`
-   when `digest` is absent).
+   when `digest` is absent). The header slot is omitted entirely when the
+   `header` parameter is absent.
 
 3. Compute HMAC-SHA256 over the resulting string using a server secret.
 
@@ -355,16 +387,18 @@ input = "|".join([
     expires or "",
     digest or "",
     opaque_b64url or "",
+    # append header only when it is present
 ])
+if header is present:
+    input = input + "|" + header
 id = base64url(HMAC-SHA256(server_secret, input))
 ~~~
 
-Optional fields use fixed positional slots with empty strings when
+The base optional fields use fixed positional slots with empty strings when
 absent, rather than being omitted. This avoids ambiguity between
-combinations of optional fields — for example, `(expires set, no
-digest)` and `(no expires, digest set)` produce distinct inputs — and
-ensures that adding a new optional slot in a future revision does not
-change the HMAC for challenges that omit it.
+combinations of optional fields — for example, `(expires set, no digest)`
+and `(no expires, digest set)` produce distinct inputs. The conditional
+header slot preserves compatibility with challenges that predate `header`.
 
 #### Example Challenge
 
@@ -411,10 +445,12 @@ When verifying a credential with a `digest` parameter, servers MUST:
 3. Reject the credential if the digests do not match
 
 
-## Credentials (Authorization)
+## Credentials {#credential-header}
 
-The Payment credential is sent in the `Authorization` header using
-base64url encoding without padding per {{RFC4648}} Section 5:
+The Payment credential is sent in the HTTP field named by the challenge's
+`header` parameter. When `header` is absent, it is sent in the
+`Authorization` header. The field value uses base64url encoding without
+padding per {{RFC4648}} Section 5:
 
 ~~~abnf
 credentials     = "Payment" 1*SP base64url-nopad
@@ -443,6 +479,7 @@ The `challenge` object contains the parameters from the original challenge:
 | `opaque` | string | Base64url-encoded server correlation data (if present in challenge) |
 | `digest` | string | Content digest  |
 | `expires` | string | Challenge expiration timestamp |
+| `header` | string | Credential header field name (if present in challenge) |
 
 The `payload` field contains the payment-method-specific data needed to
 complete the payment challenge. Payment method specifications define the
@@ -820,7 +857,7 @@ while the actual `request` payload requests a different amount.
 
 ## Credential Storage
 
-Implementations MUST treat `Authorization: Payment` headers and
+Implementations MUST treat any header carrying a Payment credential and
 `Payment-Receipt` headers as sensitive data.
 
 ## Intermediary Handling of 402
@@ -920,7 +957,7 @@ auth-param        = token BWS "=" BWS ( token / quoted-string )
 
 ; Required parameters: id, realm, method, intent, request
 ; The id parameter is required by prose to be non-empty after parsing.
-; Optional parameters: expires, digest, description, opaque
+; Optional parameters: expires, digest, description, header, opaque
 
 ; HTTP Authorization Credentials
 payment-credentials = "Payment" 1*SP base64url-nopad
@@ -1193,9 +1230,9 @@ WWW-Authenticate: Payment id="mF8uJkLpO3qRtYsA6wDcVb", realm="api.example.com", 
 ~~~
 
 When a server returns multiple challenges, clients SHOULD select one
-based on their capabilities and user preferences. Clients MUST send
-only one `Authorization: Payment` header in the subsequent request,
-corresponding to the selected challenge.
+based on their capabilities and user preferences. Clients MUST send only
+one Payment credential in the subsequent request, in the header prescribed
+by the selected challenge.
 
 Servers receiving multiple Payment credentials in a single request
 SHOULD reject with 400 (Bad Request).

--- a/specs/core/draft-httpauth-payment-01.md
+++ b/specs/core/draft-httpauth-payment-01.md
@@ -102,7 +102,9 @@ Payment Challenge
 
 Payment Credential
 : An HTTP header field with scheme "Payment" containing payment
-  authorization data. Its field name is selected by the Payment challenge.
+  authorization data. The default field name is `Authorization`. A
+  Payment challenge MAY select a different field with the `header`
+  parameter (see {{credential-header}}).
 
 Payment Method
 : A mechanism for transferring value, identified by a registered
@@ -149,6 +151,9 @@ Payload
       │<────────────────────────────────────────────────┤
       │                                                 │
 ~~~
+
+Step (4) uses the default `Authorization` header because the challenge
+did not include a specific header field.
 
 ## Status Codes {#response-status-codes}
 
@@ -226,13 +231,27 @@ unauthenticated clients.
 
 When authentication succeeds but the resource also requires payment, the
 server MAY include the `header` parameter in its Payment challenge to
-select a header field other than `Authorization` for the Payment credential.
-This allows the client to retain its ordinary authentication credential in
-`Authorization`. Servers that do not include `header` retain the default
-behavior defined in {{credential-header}}.
+select a field other than the default `Authorization` for the Payment
+credential (see {{credential-header}}). A challenge that omits `header`
+defaults to `Authorization`. A challenge that includes
+`header="Payment-Authorization"` requires the client to send the Payment
+credential in the `Payment-Authorization` header. This allows the client
+to retain its ordinary authentication credential in `Authorization`.
 
-For example, a request can carry both a Bearer credential and a Payment
-credential:
+For example, the server can issue:
+
+~~~http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="x7Tg2pLqR9mKvNwY3hBcZa",
+    realm="api.example.com",
+    method="example",
+    intent="charge",
+    header="Payment-Authorization",
+    request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJVU0QiLCJyZWNpcGllbnQiOiJhY2N0XzEyMyJ9"
+~~~
+
+The subsequent request can then carry both a Bearer credential and a
+Payment credential:
 
 ~~~http
 GET /resource HTTP/1.1
@@ -303,15 +322,23 @@ auth-param      = token BWS "=" BWS ( token / quoted-string )
   purpose. This parameter is for display purposes only and MUST NOT be
   relied upon for payment verification (see {{amount-verification}}).
 
-**`header`**: The HTTP field name in which the client MUST send the Payment
-  credential. The value MUST be a valid `field-name` as defined by
-  {{RFC9110}}. When this parameter is absent, the client MUST send the
-  credential in the `Authorization` header. Clients that do not support the
-  named field MUST NOT send a Payment credential for that challenge. Servers
-  MUST include this parameter in the challenge binding when it is present.
-  Clients MUST echo it unchanged in the credential's `challenge` object.
-  `Payment-Authorization` is RECOMMENDED when a resource needs to preserve
-  `Authorization` for ordinary authentication.
+**`header`**: Selects the HTTP field for the Payment credential, as
+  specified in {{credential-header}}. The value MUST be a valid
+  `field-name` as defined by {{RFC9110}}. The default field is
+  `Authorization`. A challenge that omits this parameter selects that
+  default: the client MUST send the credential in the `Authorization`
+  header. A challenge that includes this parameter selects the named
+  field instead of the default; the client MUST send the credential in
+  that field. For example, `header="Payment-Authorization"` requires
+  the credential to be sent in the `Payment-Authorization` header.
+  Clients MUST NOT send the credential in a different field than the
+  one selected by the challenge. Clients that do not support the named
+  field MUST NOT send a Payment credential for that challenge. Servers
+  MUST include this parameter in the challenge binding when it is
+  present. Clients MUST echo it unchanged in the credential's
+  `challenge` object. `Payment-Authorization` is RECOMMENDED when a
+  resource needs to preserve `Authorization` for ordinary
+  authentication.
 
 **`opaque`**: Base64url-encoded {{RFC4648}} JSON {{RFC8259}} containing
   server-defined correlation data (e.g., a payment processor intent
@@ -402,6 +429,9 @@ header slot preserves compatibility with challenges that predate `header`.
 
 #### Example Challenge
 
+This challenge omits `header` and therefore selects the default
+credential field `Authorization` (see {{credential-header}}).
+
 ~~~http
 HTTP/1.1 402 Payment Required
 Cache-Control: no-store
@@ -421,6 +451,24 @@ Decoded `request` example:
   "currency": "usd",
   "recipient": "acct_123"
 }
+~~~
+
+#### Example Challenge Selecting an Alternate Header
+
+This challenge includes `header="Payment-Authorization"`. The client
+MUST send the corresponding Payment credential in the
+`Payment-Authorization` header, not in `Authorization`.
+
+~~~http
+HTTP/1.1 402 Payment Required
+Cache-Control: no-store
+WWW-Authenticate: Payment id="x7Tg2pLqR9mKvNwY3hBcZa",
+    realm="api.example.com",
+    method="example",
+    intent="charge",
+    header="Payment-Authorization",
+    expires="2025-01-15T12:05:00Z",
+    request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJVU0QiLCJyZWNpcGllbnQiOiJhY2N0XzEyMyJ9"
 ~~~
 
 ### Request Body Digest Binding
@@ -447,9 +495,24 @@ When verifying a credential with a `digest` parameter, servers MUST:
 
 ## Credentials {#credential-header}
 
-The Payment credential is sent in the HTTP field named by the challenge's
-`header` parameter. When `header` is absent, it is sent in the
-`Authorization` header. The field value uses base64url encoding without
+The default HTTP field for the Payment credential is `Authorization`.
+
+A challenge that omits the `header` parameter selects this default.
+Clients receiving such a challenge MUST send the Payment credential in
+the `Authorization` header.
+
+A challenge that includes the `header` parameter selects the named field
+instead of the default. Clients receiving such a challenge MUST send the
+Payment credential in that field. For example, a challenge containing
+`header="Payment-Authorization"` requires the credential to be sent in
+the `Payment-Authorization` header. Clients MUST NOT send the credential
+in a different field than the one selected by the challenge.
+
+Servers MUST accept a Payment credential for a given challenge only from
+the field selected by that challenge. A Payment credential received in
+any other field MUST NOT satisfy the challenge.
+
+The field value uses base64url encoding without
 padding per {{RFC4648}} Section 5:
 
 ~~~abnf
@@ -479,13 +542,19 @@ The `challenge` object contains the parameters from the original challenge:
 | `opaque` | string | Base64url-encoded server correlation data (if present in challenge) |
 | `digest` | string | Content digest  |
 | `expires` | string | Challenge expiration timestamp |
-| `header` | string | Credential header field name (if present in challenge) |
+| `header` | string | HTTP field name selected by the challenge (included only when the challenge contained `header`) |
 
 The `payload` field contains the payment-method-specific data needed to
 complete the payment challenge. Payment method specifications define the
 exact structure.
 
+When the original challenge omitted `header`, clients MUST NOT include a
+`header` field in the credential's `challenge` object.
+
 ### Example Credential
+
+This credential corresponds to a challenge that omitted `header`, so it
+is sent in the default `Authorization` field:
 
 ~~~http
 GET /api/data HTTP/1.1
@@ -503,6 +572,39 @@ Decoded credential:
     "method": "example",
     "intent": "charge",
     "request": "eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJVU0QiLCJyZWNpcGllbnQiOiJhY2N0XzEyMyJ9",
+    "expires": "2025-01-15T12:05:00Z"
+  },
+  "payload": {
+    "proof": "0xabc123..."
+  }
+}
+~~~
+
+### Example Credential with Alternate Header
+
+This credential corresponds to a challenge that included
+`header="Payment-Authorization"`. The client MUST send it in that
+named field, and MUST echo `header` in the credential's `challenge`
+object:
+
+~~~http
+GET /api/data HTTP/1.1
+Host: api.example.com
+Authorization: Bearer mF_9.B5f-4.1JqM
+Payment-Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJ4N1RnMnBMcVI5bUt2TndZM2hCY1phIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJtZXRob2QiOiJleGFtcGxlIiwiaW50ZW50IjoiY2hhcmdlIiwicmVxdWVzdCI6ImV5SmhiVzkxYm5RaU9pSXhNREF3SWl3aVkzVnljbVZ1WTNraU9pSlZVMFFpTENKeVpXTnBjR2xsYm5RaU9pSmhZMk4wWHpFeU15SjkiLCJoZWFkZXIiOiJQYXltZW50LUF1dGhvcml6YXRpb24iLCJleHBpcmVzIjoiMjAyNS0wMS0xNVQxMjowNTowMFoifSwicGF5bG9hZCI6eyJwcm9vZiI6IjB4YWJjMTIzLi4uIn19
+~~~
+
+Decoded credential:
+
+~~~json
+{
+  "challenge": {
+    "id": "x7Tg2pLqR9mKvNwY3hBcZa",
+    "realm": "api.example.com",
+    "method": "example",
+    "intent": "charge",
+    "request": "eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJVU0QiLCJyZWNpcGllbnQiOiJhY2N0XzEyMyJ9",
+    "header": "Payment-Authorization",
     "expires": "2025-01-15T12:05:00Z"
   },
   "payload": {
@@ -959,7 +1061,8 @@ auth-param        = token BWS "=" BWS ( token / quoted-string )
 ; The id parameter is required by prose to be non-empty after parsing.
 ; Optional parameters: expires, digest, description, header, opaque
 
-; HTTP Authorization Credentials
+; Payment credential field value (Authorization by default;
+; a different field when the challenge includes header)
 payment-credentials = "Payment" 1*SP base64url-nopad
 
 ; Client payment preferences
@@ -1231,8 +1334,10 @@ WWW-Authenticate: Payment id="mF8uJkLpO3qRtYsA6wDcVb", realm="api.example.com", 
 
 When a server returns multiple challenges, clients SHOULD select one
 based on their capabilities and user preferences. Clients MUST send only
-one Payment credential in the subsequent request, in the header prescribed
-by the selected challenge.
+one Payment credential in the subsequent request, in the field selected
+by that challenge ({{credential-header}}). A selected challenge that
+omits `header` uses `Authorization`; a selected challenge that includes
+`header` requires the credential in the named field.
 
 Servers receiving multiple Payment credentials in a single request
 SHOULD reject with 400 (Bad Request).

--- a/specs/core/draft-httpauth-payment-01.md
+++ b/specs/core/draft-httpauth-payment-01.md
@@ -2,7 +2,7 @@
 title: The "Payment" HTTP Authentication Scheme
 abbrev: Payment Auth Scheme
 docname: draft-httpauth-payment-01
-version: 01
+version: "01"
 category: std
 ipr: noModificationTrust200902
 submissiontype: IETF


### PR DESCRIPTION
In step with the proposed change to `mppx`, include a spec change that outlines an 'alternate payment credential header'.

**Proposed new header field in challenge**

```
  HTTP/1.1 402 Payment Required
  WWW-Authenticate: Payment id="pay_abc123",
    realm="api.example.com",
    method="tempo",
    intent="charge",
    // This field says you should not use the default Authorization header, but instead use Payment-Authorization
    header="Payment-Authorization", 
    request="eyJhbW91bnQiOiIxMDAwIn0"
```

If header is not included, the challenge should be included in the Authorization header.