### PR TITLE
fix(stellar/charge): add expiry, network, and ledger-time checks to push mode verification

### DIFF
--- a/specs/methods/stellar/draft-stellar-charge-00.md
+++ b/specs/methods/stellar/draft-stellar-charge-00.md
@@ -555,19 +555,30 @@ For push mode credentials (`type="hash"`), the server MUST fetch the
 transaction via Stellar RPC `getTransaction` {{STELLAR-RPC}} and verify:
 
 1. The challenge `id` matches an outstanding, unsettled challenge issued
-   by this server.
+   by this server, and the current time is before the challenge `expires`
+   auth-param.
 
 2. The transaction hash has not been previously consumed (see
    {{replay-protection}}).
 
 3. The transaction exists and has status `SUCCESS`.
 
-4. The transaction contains exactly one `invokeHostFunction` operation
+4. The transaction's network passphrase MUST correspond to
+   `methodDetails.network`.
+
+5. The transaction's ledger close time MUST fall within the challenge
+   validity window. Servers MUST reject transactions that were confirmed
+   before the challenge was issued: because the ledger is public and the
+   challenge publishes `recipient` and `amount`, an unrelated prior
+   payment matching those values would otherwise satisfy the remaining
+   checks.
+
+6. The transaction contains exactly one `invokeHostFunction` operation
    calling `transfer(from, to, amount)` on the contract matching
    `currency`. The `to` argument MUST equal `recipient` and the `amount`
    argument MUST equal `amount` (as i128) from the challenge request.
 
-5. Mark the transaction hash as consumed.
+7. Mark the transaction hash as consumed.
 
 # Error Codes {#error-codes}
 


### PR DESCRIPTION
Push-mode verification (`type="hash"`) in the Stellar charge method omits checks that this same document requires for pull mode, which lets a caller present a transaction that was never made for this challenge.

## What was missing

Comparing "Push Mode Verification" against "Pull Mode Verification" in the same file:

| Check | Pull (sponsored) | Pull (unsponsored) | Push |
|---|---|---|---|
| Current time before `expires` | yes | yes | **no** |
| Network passphrase matches `methodDetails.network` | yes | yes | **no** |
| Any constraint on transaction freshness | `timeBounds` / auth entry expiration | `timeBounds.maxTime` <= `expires` | **no** |

Because the ledger is public and the challenge itself publishes `recipient` and `amount`, an unrelated successful transfer paying that amount to that merchant satisfies every remaining push-mode check. On a fixed-price endpoint such transactions exist: other customers' payments, or the caller's own earlier payment. The consumed-hash set only prevents a second use of the same hash; it does not establish that the first use belongs to this challenge. A side effect is that the legitimate payer's later submission of their own hash is rejected as already consumed.

## What this PR changes

Adds the three checks to push mode, bringing it to parity with pull mode:

1. Challenge expiry check in step 1, matching the wording already used by both pull flows.
2. Network passphrase check, matching pull mode step 4.
3. Ledger close time must fall within the challenge validity window, with transactions confirmed before challenge issuance rejected.

No wire format or client behavior changes; these are server-side verification steps only. The remaining steps are renumbered.

## Deliberately not included

Issue #331 also proposes a challenge-bound transaction memo, which would give push mode the same explicit binding that hedera and tempo have. That does change client behavior, so it is left for discussion in the issue rather than bundled here.

Refs #331
