### PR TITLE
fix(card-charge): require same-credential match before cached-200 replay

### DIFF
--- a/specs/methods/card/draft-card-charge-00.md
+++ b/specs/methods/card/draft-card-charge-00.md
@@ -578,8 +578,14 @@ method:
 5. Verify network acceptance: confirm `payload.network` is in the
     `acceptedNetworks` list from methodDetails.
 
-6. Reject replays: confirm this `challenge.id` has not been previously
-    fulfilled.  Mark it as consumed.
+6. Reject replays: if `challenge.id` has already been consumed by a
+    prior credential, compare the presented credential to the one
+    that consumed it (see "Idempotency and Replay Protection" below)
+    and branch accordingly instead of continuing verification.
+    Otherwise, mark `challenge.id` as consumed, recording enough of
+    the presented credential (e.g. a digest of the raw
+    `Authorization: Payment` header value) to perform that comparison
+    on a later replay.
 
 7. Verify payment amount: the Server Enabler MUST confirm the
     authorization amount matches the amount from the request
@@ -619,13 +625,32 @@ Servers MUST use `challenge.id` as an idempotency key when forwarding
 to the Server Enabler.  This prevents duplicate charges from
 retried requests.
 
+The cached-response behavior below exists to support idempotent
+retries -- a client resending the identical HTTP request after losing
+the original response (e.g. to a network failure) -- and MUST NOT be
+reachable by a credential that merely shares a `challenge.id` with one
+already consumed. `challengeId` is a required `Payment-Receipt` field
+(see below) and is therefore observable to intermediaries; without a
+same-credential check, an attacker who observes a fulfilled
+`challenge.id` could submit an arbitrary credential echoing it and
+receive the cached response without paying. Servers MUST compare the
+presented credential to the one that originally consumed the
+`challenge.id` -- for example, by comparing the raw
+`Authorization: Payment` header value byte-for-byte, or a digest of
+it -- before taking the cached-response branch.
+
 Replay behavior:
 
-- Same `challenge.id`, credential already successfully processed:
-  server MUST return the cached 200 response with `Payment-Receipt`.
+- Same `challenge.id`, this exact credential (per the comparison
+  above) already successfully processed: server MUST return the
+  cached 200 response with `Payment-Receipt`.
 
-- Same `challenge.id`, prior processing failed: server MUST return
-  HTTP 409 Conflict.
+- Same `challenge.id`, a *different* credential presented after this
+  `challenge.id` was already consumed: server MUST reject with HTTP
+  409 Conflict. This is not an idempotent retry.
+
+- Same `challenge.id`, this exact credential's prior processing
+  failed: server MUST return HTTP 409 Conflict.
 
 - Same `challenge.id`, challenge expired: server MUST return HTTP
   402 with a fresh challenge.


### PR DESCRIPTION
## What

Verification step 6 and the "Idempotency and Replay Protection" section made directly conflicting normative claims about the same `challenge.id`: step 6 says a fulfilled `challenge.id` MUST be rejected, while the replay-behavior block says a fulfilled `challenge.id` MUST be served a cached 200. A conformant server can't satisfy both.

The cached-200 branch was keyed only on `challenge.id`, with no requirement that the presented credential match the one that originally consumed it — no byte-identity check, no payer/source match, no body digest. Since `challengeId` is a required `Payment-Receipt` field (observable to intermediaries, logs, and client telemetry), an attacker who observes a fulfilled `challenge.id` could submit an arbitrary credential echoing it and receive the cached response without paying.

Fixes #330.

## Fix

The cached-200 branch exists for a legitimate reason — an idempotent retry after a client loses the original HTTP response to a network failure — so the fix isn't to remove it, but to require the presented credential actually match the one that consumed the challenge before taking that branch (e.g. byte-comparing the raw `Authorization: Payment` header value, or a digest of it). A different credential sharing the same `challenge.id` now gets 409 Conflict instead of a free 200, resolving the step 6 / replay-behavior contradiction in favor of "reject" — exactly as step 6 and the upstream single-use rule in `draft-payment-intent-charge-00` already require — while still serving genuine idempotent retries from cache.

Also completes step 6, which previously said "mark it as consumed" with no guidance on what to do when `challenge.id` hasn't been consumed yet; now explicitly says to record enough of the credential (e.g. a digest) to perform the same-credential comparison on a later replay.

## Versioning

No wire-format or field changes — this is a normative-behavior fix to an existing MUST, not a breaking change to `methodDetails.version`'s scope per the versioning strategy in #115.

## Validation

`python3 scripts/lint_frontmatter.py` passes for this file.

Fixes #330