### PR TITLE
ci(resubmit-draft): open the bump PR via github-sts

### DIFF
--- a/.github/sts/resubmit-draft.sts.yaml
+++ b/.github/sts/resubmit-draft.sts.yaml
@@ -1,0 +1,10 @@
+# Allow the Resubmit IETF Draft workflow (schedule/workflow_dispatch on main)
+# to mint a short-lived token that pushes the revision-bump branch and opens
+# the resubmission PR. Replaces the built-in GITHUB_TOKEN so the org can turn
+# off "Allow GitHub Actions to create and approve pull requests".
+subject: repo:tempoxyz@211589300/mpp-specs@1128606548:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: tempoxyz/mpp-specs/\.github/workflows/resubmit-draft\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/resubmit-draft.yml
+++ b/.github/workflows/resubmit-draft.yml
@@ -11,9 +11,14 @@ on:
     - cron: "0 12 * * 1"
   workflow_dispatch:
 
+# The bump branch is pushed and the PR opened with a short-lived GitHub App
+# token minted via github-sts (authorized by .github/sts/resubmit-draft.sts.yaml)
+# rather than the built-in GITHUB_TOKEN, which is not allowed to create pull
+# requests. id-token lets the job request the OIDC token the STS exchange
+# verifies.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write
 
 jobs:
   bump-and-pr:
@@ -48,14 +53,24 @@ jobs:
           NEW_VER=$(scripts/bump_and_rename.sh)
           echo "new_ver=$NEW_VER" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch GitHub token via STS
+        if: steps.check.outputs.skip == 'false'
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: resubmit-draft
+
       - name: Create PR
         if: steps.check.outputs.skip == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.sts.outputs.token }}
         run: |
           BRANCH="ietf/resubmit-${{ steps.bump.outputs.new_ver }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Checkout runs with persist-credentials: false; authenticate the
+          # push through the gh credential helper using GH_TOKEN instead.
+          gh auth setup-git
+          git config user.name "tempo-github-sts[bot]"
+          git config user.email "312736176+tempo-github-sts[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "chore: bump draft revision to -${{ steps.bump.outputs.new_ver }}"


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. This workflow opened the revision-bump PR with `secrets.GITHUB_TOKEN`.

## Changes

- Mint a short-lived GitHub App token via STS (`tempoxyz/gh-actions/actions/github-sts`, SHA-pinned) and use it for the branch push and `gh pr create`.
- Drop the workflow's built-in token to `contents: read` and add `id-token: write`.
- Add `gh auth setup-git` before the push — checkout runs with `persist-credentials: false`, so the previous plain `git push origin` had no credentials to use; the push now authenticates with the STS token.
- Add `.github/sts/resubmit-draft.sts.yaml`: subject pinned to this repo's `main` ref with a `job_workflow_ref` claim check on this workflow, granting `contents: write` + `pull_requests: write`.

## Notes

- Bonus: PRs opened by the STS App trigger `pull_request` workflows normally, so checks actually run on the bump PR before an author merges it.
- Verify by dispatching **Resubmit IETF Draft** after merge (it exits early unless 165+ days have passed, so a dispatch exercises only the check path until then).

