### PR TITLE
ci: replace dawidd6/action-download-artifact with actions/download-artifact

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -56,15 +56,30 @@ jobs:
           mkdir -p .cache
           docker run --rm --user $(id -u):$(id -g) -e HOME=/data -v ${{ github.workspace }}:/data ietf-spec-tools:latest /data/scripts/check.sh
 
-      - name: Download main branch artifacts
+      # deploy.yml uploads the published specs as an ietf-specs-<sha> artifact on each
+      # successful run on main. Resolve the newest such run, then fetch with the
+      # GitHub-authored action; each artifact is extracted into its own directory.
+      - name: Find latest main deploy run
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        id: main-deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_id=$(gh run list -R "$GITHUB_REPOSITORY" --workflow deploy.yml --branch main --status success \
+            --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          if [[ -z "$run_id" ]]; then
+            echo "::warning::No successful deploy.yml run on main; every spec will be reported as new"
+          fi
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download main branch artifacts
+        if: github.event_name == 'pull_request' && steps.main-deploy.outputs.run-id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          workflow: deploy.yml
-          name_is_regexp: true
-          name: ietf-specs-.*
+          run-id: ${{ steps.main-deploy.outputs.run-id }}
+          github-token: ${{ github.token }}
+          pattern: ietf-specs-*
           path: /tmp/main-artifacts
         continue-on-error: true
 


### PR DESCRIPTION
## Why

The org is moving to a GitHub Actions policy that only allows tempoxyz-owned and GitHub-authored actions (see the vendoring work in `tempoxyz/gh-actions`). `dawidd6/action-download-artifact` is the largest third-party action in that inventory (92 MB with its committed `node_modules`), and everything it does here can be done by the GitHub-authored `actions/download-artifact` once the workflow run is resolved with `gh`.

## What changed

- A small `gh` step resolves the newest successful `deploy.yml` run on `main`. If there is none it warns, and the diff step falls back to treating every spec as new, as before.
- `actions/download-artifact` downloads that run's `ietf-specs-*` artifacts by `run-id`. Without `merge-multiple` each artifact is extracted into its own directory under `/tmp/main-artifacts`, which is the layout the "Generate diffs against main" step already expects.

Same semantics as the old step (`branch: main`, successful runs only, artifact name `ietf-specs-.*`), with the download done by a GitHub-authored action pinned to v8.0.1.

## Validation

`actionlint` and `zizmor` report exactly the same findings as before the change.