### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      - uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: .
           load: true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,9 +33,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      - uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: .
           load: true

--- a/.github/workflows/resubmit-draft.yml
+++ b/.github/workflows/resubmit-draft.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fetch GitHub token via STS
         if: steps.check.outputs.skip == 'false'
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
         with:
           policy: resubmit-draft
 

--- a/.github/workflows/submit-draft.yml
+++ b/.github/workflows/submit-draft.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      - uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: .
           load: true


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `docker/build-push-action` | [`tempoxyz/gh-actions/vendor/docker/build-push-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/docker/build-push-action) |
| `docker/setup-buildx-action` | [`tempoxyz/gh-actions/vendor/docker/setup-buildx-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/docker/setup-buildx-action) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 10 -> 10, zizmor 13 -> 13).

## Pin comments

- `# main` comments next to full-SHA pins of tempoxyz actions are removed: they claim the pin tracks `main`, which stops being true as soon as `main` moves and trips zizmor's `ref-version-mismatch` audit. The pinned commits are unchanged.
