### PR TITLE
Add XRPL payment method with charge and session intents

### DIFF
--- a/specs/methods/xrpl/draft-xrpl-charge-00.md
+++ b/specs/methods/xrpl/draft-xrpl-charge-00.md
@@ -1,0 +1,765 @@
+---
+title: XRP Ledger Charge Intent for HTTP Payment Authentication
+abbrev: XRPL Charge
+docname: draft-xrpl-charge-00
+version: 00
+category: info
+ipr: noModificationTrust200902
+submissiontype: independent
+consensus: false
+
+author:
+  - name: Maxime Dienger
+    ins: M. Dienger
+    email: maximed@ripple.com
+    org: RippleX
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC8174:
+  RFC8259:
+  RFC9457:
+  I-D.payment-intent-charge:
+    title: "'charge' Intent for HTTP Payment Authentication"
+    target: https://datatracker.ietf.org/doc/draft-payment-intent-charge/
+    author:
+      - name: Jake Moxey
+      - name: Brendan Ryan
+      - name: Tom Meagher
+    date: 2026
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+
+informative:
+  XLS-33:
+    title: "XLS-33: Multi-Purpose Tokens"
+    target: >
+      https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0033-multi-purpose-tokens
+    author:
+      - org: XRP Ledger Standards
+    date: 2024
+  XRPL-PAYMENT:
+    title: "Payment Transaction"
+    target: https://xrpl.org/docs/references/protocol/transactions/types/payment
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-PARTIAL:
+    title: "Partial Payments"
+    target: https://xrpl.org/docs/concepts/payment-types/partial-payments
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-CURRENCY:
+    title: "Currency Formats"
+    target: https://xrpl.org/docs/references/protocol/data-types/currency-formats
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-TRUSTLINES:
+    title: "Trust Lines and Issuing"
+    target: https://xrpl.org/docs/concepts/tokens/fungible-tokens
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-RESERVES:
+    title: "Reserves"
+    target: https://xrpl.org/docs/concepts/accounts/reserves
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-FINALITY:
+    title: "Finality of Results"
+    target: https://xrpl.org/docs/concepts/transactions/finality-of-results
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XLS-39:
+    title: "XLS-39: Clawback"
+    target: >
+      https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0039-clawback
+    author:
+      - org: XRP Ledger Standards
+    date: 2023
+  XRPL-DEPOSITAUTH:
+    title: "Deposit Authorization"
+    target: https://xrpl.org/docs/concepts/accounts/depositauth
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-AMENDMENTS:
+    title: "Known Amendments"
+    target: https://xrpl.org/resources/known-amendments
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-TX-RESULTS:
+    title: "Transaction Results"
+    target: https://xrpl.org/docs/references/protocol/transactions/transaction-results
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+---
+
+--- abstract
+
+This document defines the "charge" intent for the "xrpl" payment
+method within the Payment HTTP Authentication Scheme. A charge
+settles as a single XRP Ledger Payment transaction carrying XRP, an
+issued currency, or a Multi-Purpose Token.
+
+Two credential types are supported. In `type="transaction"` (the
+default) the client signs a Payment and hands the serialized blob to
+the server, which submits it and observes the result. In
+`type="hash"` the client submits the transaction itself and presents
+the transaction hash as proof.
+
+The default is the signed blob rather than the hash, which is the
+inverse of several other methods: a payer who broadcasts first has
+already parted with funds before learning whether the server will
+honour them.
+
+--- middle
+
+# Introduction
+
+The XRP Ledger settles payments in three to five seconds under a
+consensus protocol with deterministic finality: a
+transaction in a validated ledger cannot be reordered or reversed
+{{XRPL-FINALITY}}. There is no
+probabilistic confirmation depth to reason about, which makes it a
+natural fit for the synchronous request-response shape of
+{{I-D.httpauth-payment}} -- a server can decide within one HTTP
+round trip whether payment has settled.
+
+This document specifies how the "charge" intent
+{{I-D.payment-intent-charge}} maps onto an XRP Ledger Payment
+transaction {{XRPL-PAYMENT}}.
+
+## Pull Mode (Default) {#pull-mode}
+
+The client signs a Payment transaction but does not submit it. The
+serialized blob travels in the credential; the server submits it and
+watches for validation.
+
+~~~
+Client                                   Server
+  |                                        |
+  |------------- GET /resource ----------->|
+  |<-- 402, WWW-Authenticate: Payment -----|
+  |                                        |
+  | sign Payment (not submitted)           |
+  |                                        |
+  |-- GET /resource                        |
+  |   Authorization: Payment <cred> ------>|
+  |                                        | submit blob
+  |                                        | await validated ledger
+  |                                        | verify fields
+  |<-- 200, Payment-Receipt: <receipt> ----|
+~~~
+
+Pull mode is the default for a reason worth stating plainly. If the
+client broadcasts first, it has irrevocably spent funds before
+knowing whether the server will deliver: a server that crashes,
+rejects the credential, or simply never replies leaves the payer with
+an on-chain debit and nothing to show for it. In pull mode the
+payer's exposure begins only once the server has taken custody of the
+blob and committed to submitting it.
+
+Pull mode also gets replay protection for free from the ledger. A
+Payment consumes the sender's account sequence number, so a
+resubmitted blob fails with `tefPAST_SEQ`. This is a property of the
+ledger, not of the server's bookkeeping, and it holds even if the
+server's replay store is lost.
+
+## Push Mode {#push-mode}
+
+The client submits the transaction itself and sends only the 64-hex
+transaction hash. The server looks the transaction up and verifies it.
+
+Push mode suits clients that already have a signing and broadcast
+pipeline and do not wish to hand a signed blob to a counterparty. It
+carries the exposure described above, and it has no sequence-number
+protection: a hash of an already-validated transaction can be
+presented repeatedly, and to any server. [](#binding) therefore makes
+the challenge binding mandatory in push mode.
+
+## Relationship to the Charge Intent
+
+This document constrains {{I-D.payment-intent-charge}}; it does not
+redefine it. Fields defined there keep their meaning. Everything
+introduced here lives under `methodDetails`, except where this
+document narrows the permitted values of a shared field.
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+Drops:
+: The indivisible unit of XRP. One XRP is 10^6 drops. All XRP amounts
+  on the wire are integer drop counts expressed as decimal strings.
+  Implementations MUST NOT represent drop counts as IEEE-754 doubles:
+  the total supply is 10^17 drops, which exceeds the 2^53 range of
+  exactly representable integers.
+
+Classic address:
+: An XRPL account identifier in base58, beginning with `r`.
+
+Issued currency:
+: A token on the XRP Ledger denominated by a currency code and the
+  classic address of its issuer {{XRPL-CURRENCY}}, held through a
+  trustline {{XRPL-TRUSTLINES}}.
+
+Multi-Purpose Token (MPT):
+: A token type defined by {{XLS-33}}, identified by an
+  `mpt_issuance_id` naming an `MPTokenIssuance` entry, and held
+  through an MPToken object rather than a trustline.
+
+InvoiceID:
+: An optional 256-bit field on a Payment transaction, covered by the
+  transaction signature and indexed by the ledger. This document uses
+  it to bind a payment to one challenge ([](#binding)).
+
+Validated ledger:
+: A ledger version agreed by consensus. A transaction reported inside
+  a validated ledger is final.
+
+# Method Identifier
+
+The method identifier is the string `xrpl`.
+
+Servers advertising this method in a challenge MUST use exactly this
+value. The identifier names the ledger, not any particular asset on
+it: XRP, issued currencies and MPTs are all carried by this one
+method and distinguished by the `currency` field.
+
+Which of them a given network carries may be gated by amendments
+{{XRPL-AMENDMENTS}}; MPT support in particular arrives with
+{{XLS-33}}. A server SHOULD determine the assets it can accept from
+the network it is connected to rather than from this document.
+
+# Intent: "charge"
+
+The `charge` intent settles a single Payment transaction. It is the
+only intent defined by this document; the `session` intent for the
+same method is specified separately in draft-xrpl-session.
+
+# Encoding Conventions {#encoding}
+
+Amounts:
+: XRP amounts are integer drop counts as decimal strings, for example
+  `"1000000"` for 1 XRP. Issued-currency and MPT amounts are decimal
+  strings in the token's own units. Implementations MUST compare
+  amounts as exact decimal values, never as floating-point numbers.
+
+Credentials and challenges are JSON {{RFC8259}}.
+
+Hex fields:
+: `InvoiceID` and transaction hashes are 64 hexadecimal characters. The
+  ledger reports them uppercase, and implementations MUST emit
+  uppercase, but hex is case-insensitive as a value and an
+  implementation MUST accept either casing on input.
+
+  Case MUST NOT be load-bearing anywhere downstream. Comparisons and
+  any key derived from such an identifier MUST be canonicalised first.
+  A store keyed on the raw string while the signature check and the
+  ledger lookup both accept either casing is a replay hole: the same
+  credential resubmitted with the casing changed verifies, resolves,
+  and finds a different key holding nothing.
+
+Addresses:
+: Classic addresses only. X-addresses (which pack a destination tag
+  into the address) MUST NOT appear in the `recipient` field; a
+  destination tag is carried in `methodDetails.destinationTag` so
+  that it remains independently verifiable.
+
+# Request Schema
+
+## Shared Fields
+
+The `charge` intent's shared fields apply, with these constraints:
+
+| Field | Type | Required | Constraint |
+|---|---|---|---|
+| `amount` | string | yes | positive decimal, no sign, no exponent |
+| `currency` | string | yes | see below |
+| `recipient` | string | yes | classic address |
+| `description` | string | no | display only, see [](#display-fields) |
+| `externalId` | string | no | merchant reconciliation handle |
+
+The `currency` field is `"XRP"` for the native asset. For an issued
+currency it is a JSON object with `currency` and `issuer`. For an MPT
+it is a JSON object with `mpt_issuance_id`. Servers MUST reject a
+credential whose settled asset does not match the challenged
+`currency` exactly, including the issuer: an amount of the right size
+in the wrong issuer's token is not payment.
+
+## Method Details
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `network` | string | no | `mainnet`, `testnet` or `devnet` |
+| `reference` | string | no | server-generated correlation ID |
+| `invoiceId` | 64-hex | no | explicit challenge binding, [](#binding) |
+| `destinationTag` | uint32 | no | enforced on verification when present |
+| `sourceTag` | uint32 | no | enforced on verification when present |
+| `memos` | array | no | UTF-8 memo entries embedded in the Payment |
+
+Servers SHOULD set `network` explicitly. This document defines no
+default: an implementation that assumes one risks disagreeing with a
+counterparty that assumed the other, and the mistake is only visible
+after a payment has settled on the wrong ledger.
+
+Clients SHOULD refuse to sign when the challenge's network does not
+match the ledger they are connected to. A testnet payment presented
+against a mainnet challenge is worthless, and the mismatch is
+detectable before signing rather than after.
+
+## Recipient Prerequisites
+
+A charge in XRP needs nothing of the recipient beyond a funded
+account. The other two asset types do, and the requirement falls on
+the recipient before any client is ever challenged.
+
+For an issued currency, a recipient that is not the issuer MUST
+already hold a trustline {{XRPL-TRUSTLINES}} to the issuer for that
+currency code. For an MPT, a recipient that is not the issuer MUST
+already have opted in, which creates its `MPToken` object; a balance
+is not required. Where the issuance was created requiring
+authorization, the issuer MUST additionally have authorized that
+holder.
+
+The issuer is exempt in both cases: a payment returning a token to
+the account that issued it redeems the token rather than
+transferring it, and redemption requires nothing on the issuer's
+side.
+
+Neither prerequisite is something a payer can supply. A server
+advertising a charge it cannot receive produces a payment that fails
+on submission, after the client has signed and, in push mode, after
+it has already parted with the funds. A server SHOULD therefore
+confirm the prerequisite once at startup rather than per challenge:
+the condition is a property of the recipient account, not of any
+particular payment.
+
+How it is established -- `TrustSet` for a trustline,
+`MPTokenAuthorize` for an MPT holding -- is ordinary ledger
+operation and outside this document. What matters here is that a
+charge advertised without it is a charge that cannot settle.
+
+# Credential Schema
+
+The credential payload is a discriminated union on `type`.
+
+## Transaction Payload -- Pull Mode {#transaction-payload}
+
+~~~ json
+{
+  "type": "transaction",
+  "blob": "120000228000000024012E..."
+}
+~~~
+
+`blob` is the hex-encoded, signed but unsubmitted Payment
+transaction.
+
+## Hash Payload -- Push Mode {#hash-payload}
+
+~~~ json
+{
+  "type": "hash",
+  "hash": "BE3DE95F52CC58E22F78CD5D2F7DE9084F596D88B390D479259D7DEC62EBDB49"
+}
+~~~
+
+# Verification Procedure {#verification}
+
+A server MUST perform every check in this section before returning a
+receipt. The order given is normative where one step guards another;
+in particular, cheap local checks precede any network call so that an
+unauthenticated caller cannot use verification as an amplifier.
+
+## Challenge Freshness
+
+The server MUST reject a credential whose challenge carries no
+`expires`, one whose `expires` is not a valid {{RFC3339}}
+timestamp, and one whose `expires` has passed. `expires` is covered
+by the challenge's integrity protection and is the only authenticated
+statement of time the challenge carries; treating its absence as
+"unbounded" would let a credential be presented indefinitely.
+
+## Single Use {#single-use}
+
+The server MUST record, atomically, that a given challenge has been
+answered, and reject a second credential for the same challenge.
+
+The record MUST be created by a compare-and-set that fails if the key
+already exists, not by a read followed by a write. Two replicas
+presented with the same credential concurrently will both observe an
+empty store on a read-then-write, and both will accept. The store
+MUST therefore be shared across every process serving the realm, and
+MUST be durable: a store lost on restart re-opens every window it was
+protecting.
+
+## Transaction Field Verification {#field-verification}
+
+The server MUST verify, against the transaction as recorded on the
+ledger rather than as presented by the client:
+
+1. `TransactionType` is `Payment`. An `EscrowCreate` or a
+   `PaymentChannelCreate` can carry the right
+   destination and amount
+   while delivering nothing: an escrow can be cancelled back to the
+   sender and a channel deposit reclaimed after its settle delay.
+2. `Destination` equals the challenged `recipient`.
+3. The delivered amount equals the challenged `amount`. The server
+   MUST use `delivered_amount` from the transaction metadata where it
+   is present, not the `Amount` field, which is an upper bound.
+4. The asset matches the challenged `currency`, including issuer for
+   an issued currency and `mpt_issuance_id` for an MPT.
+5. The `tfPartialPayment` flag is not set {{XRPL-PARTIAL}}. With that
+   flag a Payment may deliver less than `Amount` and still succeed.
+6. `Account` matches the address encoded in the credential's `source`
+   DID. Without this check a client can present a third party's
+   transaction as its own.
+7. `DestinationTag` and `SourceTag` match the challenge where the
+   challenge specifies them.
+
+## Challenge Binding {#binding}
+
+Field verification alone does not tie a payment to a challenge. Any
+earlier payment by the same account, for the same amount, to the same
+recipient satisfies every check in [](#field-verification). The
+binding closes this.
+
+The expected `InvoiceID` is either the value the server placed in
+`methodDetails.invoiceId`, or -- absent that -- a value derived from
+the challenge identifier. When derived, it is the SHA-512Half of the
+challenge identifier, rendered as 64 uppercase hexadecimal
+characters. SHA-512Half is the ledger's own digest convention.
+
+Because the challenge identifier is itself integrity-protected over
+the whole challenge, binding to it transitively binds the payment to
+the amount, recipient, currency and expiry the server issued.
+
+A server MUST require a matching `InvoiceID` when the credential is a
+`hash` payload, and when the challenge carried an explicit
+`invoiceId`. On the `transaction` path the binding SHOULD be verified
+when present but MAY be absent, since sequence-number consumption
+already prevents reuse there; this keeps clients predating the field
+working.
+
+## Finality {#finality}
+
+A `tesSUCCESS` result is not settlement {{XRPL-FINALITY}}. Nodes
+report metadata for transactions in the open ledger, which can still
+be reordered or dropped. The server MUST confirm the transaction is
+reported in a validated ledger before returning a receipt, and MAY
+require the
+validated ledger to be buried under further closed ledgers as
+defence against a single node reporting a validation its peers have
+not seen.
+
+## Transaction Age {#age}
+
+The server SHOULD reject a transaction that settled before the
+challenge could plausibly have been issued. Combined with the
+binding, this narrows the window in which any transaction can be
+offered as proof.
+
+# Settlement Procedure
+
+## Pull Mode {#settle-pull}
+
+The server deserializes the blob, verifies it, submits, and polls
+until the transaction appears in a validated ledger or the submission
+window closes.
+
+Verification MUST happen twice, against two different objects.
+
+First against the decoded blob, before submission. A blob that fails
+a check is rejected without being broadcast, so a malformed or
+mistargeted credential costs the payer nothing.
+
+Then again against the transaction as the ledger recorded it. The two
+are normally identical, and checking only the first would trust the
+server's own decode of client-supplied bytes over what actually
+settled. The second pass is also the only one that can read
+`delivered_amount`, which exists only in the metadata.
+
+## Push Mode {#settle-push}
+
+The server looks the hash up. A node that does not yet know the
+transaction is not evidence of absence -- propagation takes time --
+so the server SHOULD retry a small number of times before treating a
+hash as unknown, and MUST NOT hold the request open for the full poll
+budget on a hash that is simply fabricated.
+
+## Failure Handling
+
+An XRPL result code {{XRPL-TX-RESULTS}} is not an error shape a
+client can reason about. Servers MUST map result codes to the error
+vocabulary below and MUST
+NOT surface raw ledger strings.
+
+| Result | Condition |
+|---|---|
+| `tecUNFUNDED_PAYMENT` | sender cannot cover amount plus reserve {{XRPL-RESERVES}} |
+| `tecNO_DST` | destination account does not exist |
+| `tecPATH_DRY` | no usable path for the issued currency |
+| `tecPATH_PARTIAL` | path cannot deliver the full amount |
+| `tecNO_LINE` | no trustline for the issued currency |
+| `tecNO_AUTH` | trustline exists but is not authorized |
+| `tecFROZEN` | trustline or issuer is frozen |
+| `tecMPT_NOT_AUTHORIZED` | holder not authorized for the MPT |
+| `tecINSUFFICIENT_RESERVE` | reserve requirement unmet |
+| `tefPAST_SEQ` | sequence consumed; blob already settled |
+| `tecNO_PERMISSION` | context-dependent: MPT holder not authorized, or the recipient requires deposit authorization {{XRPL-DEPOSITAUTH}} |
+| `temBAD_AMOUNT` | amount malformed or zero |
+| `tecMPT_LOCKED` | MPT holding is locked |
+| `tecINSUFF_FEE`, `terINSUF_FEE_B` | fee below the current load-scaled minimum |
+| `tefBAD_AUTH`, `tefMASTER_DISABLED` | signing key not valid for the account |
+
+# Error Responses {#errors}
+
+Errors are Problem Details {{RFC9457}} carried on a `402` response.
+Every payment failure is a `402`; `401` is reserved for
+non-payment authentication failures.
+
+The type URIs are those {{I-D.httpauth-payment}} already defines,
+under its base URI `https://paymentauth.org/problems/`. A malformed
+or unparseable credential is `malformed-credential`; a challenge
+that is unknown, expired or already spent is `invalid-challenge`;
+every other failure of the procedure in [](#verification) is
+`verification-failed`. This document defines no type of its own.
+
+A server MUST NOT disclose, in an error, whether a given challenge
+was previously used by a different caller, nor any part of the
+transaction beyond what the caller supplied.
+
+# Security Considerations
+
+## Transport Security
+
+The server's ledger connection carries the evidence on which payment
+decisions rest. Implementations MUST use TLS (`wss://` or `https://`)
+for any non-loopback node, and MUST NOT accept a plaintext node
+address outside a development configuration that says so explicitly.
+
+## Replay Protection
+
+[](#single-use) is the load-bearing requirement. Three properties are
+each necessary and none is sufficient alone: the check must be
+atomic, the store must be shared across replicas, and it must be
+durable.
+
+Retention is not optional either. A record deleted while its
+challenge is still presentable re-opens the window it existed to
+close, so a record MUST be retained at least until the challenge
+expires plus the longest time verification may take.
+
+## Push Mode Exposure
+
+A transaction hash is public the moment it is validated. Anyone who
+observes the ledger can present another party's hash. Two checks make
+this ineffective: the sender must match the credential's DID
+([](#field-verification)), and the binding must match
+([](#binding)). A server that relaxes either on the push path has no
+defence.
+
+## Amount Precision
+
+The total XRP supply is 10^17 drops, beyond the 2^53 integers exactly
+representable in IEEE-754. An implementation that converts drops to a
+floating-point XRP figure -- for display, comparison, or signing --
+loses precision above 2^53 drops, which is 9,007,199,254 XRP, or
+about nine percent of the total supply.
+
+That threshold is far above any plausible single payment, so the
+practical exposure is small. It is stated as a MUST regardless,
+because the failure is silent: the converted value differs from the
+intended one by a few drops, and a signature computed over it will
+not verify against the amount actually submitted. Implementations
+MUST use exact integer arithmetic throughout.
+
+## Settlement Is Final, Token Balances Are Not
+
+A validated Payment cannot be reversed. That is a property of the
+ledger, and it is what lets a server decide within one round trip.
+
+It does not follow that the value received is permanent. For an
+issued currency whose issuer has enabled clawback {{XLS-39}}, the
+issuer may reclaim the tokens from any holder afterwards with a
+`Clawback` transaction. The payment settled; the balance later left.
+
+This is a property of the asset, not of this method, and no
+verification step can detect it after the fact. A server accepting an
+issued currency is extending trust to its issuer, and SHOULD decide
+which issuers it accepts rather than accepting any token that arrives
+with the right code. Servers that cannot make that judgement SHOULD
+charge in XRP, which has no issuer.
+
+## Deposit Authorization Can Refuse the Payment
+
+An account may set Deposit Authorization {{XRPL-DEPOSITAUTH}}, after
+which it receives no payment from an unauthorized sender. A recipient
+configured this way rejects every charge until each payer is
+preauthorized, which is a deployment error rather than an attack, but
+it presents as a payment that cannot be made rather than as a
+misconfiguration.
+
+A server MAY confirm before advertising a charge that its recipient can
+receive from arbitrary senders. Whether that check is worth a round
+trip per challenge is a deployment question: the condition is static,
+so checking once at startup is usually enough.
+
+What is not optional is the reporting. `tecNO_PERMISSION` covers
+more than one cause and the result code alone does not say which, so
+a server MUST NOT report it as though it did. What the transaction
+carried does narrow it: on a payment moving an MPT the cause is an
+unauthorized holder, and a server SHOULD say so. Otherwise the
+server SHOULD name the destination's refusal, and MAY name deposit
+authorization as the usual cause without asserting it -- only
+reading the destination's account flags settles that. A
+configuration condition on the recipient, reported as a failure of
+the payment, sends the operator looking at the wrong account.
+
+## The Challenge Must Match the Resource
+
+A verifier reads what to expect from the challenge the credential
+carries. That is sound only while the challenge is known to be the
+one this resource issued. A server MUST confirm that the terms it is
+about to verify are the terms the requested resource charges, and
+MUST refuse the credential otherwise.
+
+The check covers every term the verifier acts on, not only the
+priced ones. Amount, currency and recipient decide what is owed; a
+destination tag decides which sub-account the funds land in, and an
+invoice identifier decides what the payment is bound to. A term the
+resource sets and the verifier honours is a term that MUST be
+confirmed. Terms the resource leaves unset are not demands and MUST
+NOT be treated as such.
+
+Without this a server offering more than one priced resource under
+one challenge-issuing key accepts a challenge minted for the cheaper
+or less-constrained one against the stricter one. Where a scheme
+re-derives the resource's own challenge before dispatch, that
+binding already holds for the fields the derivation covers; a
+verifier reachable outside that path has no such protection, and
+embedded and script callers routinely are.
+
+Identifier comparisons here follow the same rule as everywhere else
+in this document: hex is compared as a value, not as a string.
+
+## Display Fields Are Not Decisions {#display-fields}
+
+`description` and `externalId` are attacker-influenced strings that
+travel through the challenge. They MUST NOT participate in any
+authorization decision, and MUST be treated as untrusted input by
+anything that renders them.
+
+## Key Material
+
+A charge requires the payer's signing key. Implementations SHOULD
+keep the key out of any value that can be serialized, logged or
+included in an error, and SHOULD prefer injecting a signing
+capability over a raw seed.
+
+# IANA Considerations
+
+## Payment Method Registration
+
+This document requests registration of the following entry in the
+"HTTP Payment Methods" registry established by
+{{I-D.httpauth-payment}}:
+
+| Method Identifier | Description | Reference |
+|---|---|---|
+| `xrpl` | XRP Ledger payments: XRP, issued currencies, MPTs | This document |
+
+Contact: Maxime Dienger (<maximed@ripple.com>)
+
+## Payment Intent Registration
+
+This document requests registration of the following entry in the
+"HTTP Payment Intents" registry established by
+{{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|---|---|---|---|
+| `charge` | `xrpl` | One-time XRP, issued currency or MPT transfer | This document |
+
+## Problem Types
+
+This document registers no problem type URI. Every condition in
+[](#errors) is reported with a type {{I-D.httpauth-payment}} already
+establishes.
+
+--- back
+
+# Examples
+
+## Challenge
+
+~~~ json
+{
+  "method": "xrpl",
+  "intent": "charge",
+  "amount": "1000000",
+  "currency": "XRP",
+  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv",
+  "expires": "2026-08-21T10:32:00Z",
+  "methodDetails": {
+    "network": "testnet",
+    "reference": "3f7a1c02-9e44-4b1e-8a10-0c2b5d6e7f80"
+  }
+}
+~~~
+
+## Settled Transaction
+
+The Payment produced by the challenge above, as recorded on the XRP
+Ledger testnet. `InvoiceID` is the derived binding; `SourceTag`
+identifies the originating SDK.
+
+~~~ json
+{
+  "TransactionType": "Payment",
+  "Account": "rBkRQZrL4K8Rg2Bg2UzyQUSzYyNeBAK95Z",
+  "Destination": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv",
+  "Amount": "1000000",
+  "Fee": "12",
+  "Sequence": 19831823,
+  "InvoiceID":
+    "0B4F21A0C9A47D3351CD611AD7D41390AA64C22E7D61CFC78B52A814D0359CCB",
+  "SourceTag": 593184257,
+  "LastLedgerSequence": 19831855
+}
+~~~
+
+Validated in ledger 19831837 with result `tesSUCCESS`.
+
+## Issued Currency Challenge
+
+~~~ json
+{
+  "method": "xrpl",
+  "intent": "charge",
+  "amount": "10",
+  "currency": "{\"currency\":\"USD\",\"issuer\":\"rwzRswng9sqR9Buw2T8FG18K4n8xdd1dCa\"}",
+  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv",
+  "expires": "2026-08-21T10:32:00Z",
+  "methodDetails": { "network": "testnet" }
+}
+~~~
+
+Settling this requires a trustline to the issuer on the recipient
+side and rippling enabled on the issuer. Absent either, the ledger
+answers `tecPATH_DRY` and no payment occurs.

--- a/specs/methods/xrpl/draft-xrpl-charge-00.md
+++ b/specs/methods/xrpl/draft-xrpl-charge-00.md
@@ -12,7 +12,7 @@ author:
   - name: Maxime Dienger
     ins: M. Dienger
     email: maximed@ripple.com
-    org: RippleX
+    org: Ripple
 
 normative:
   RFC2119:

--- a/specs/methods/xrpl/draft-xrpl-charge-00.md
+++ b/specs/methods/xrpl/draft-xrpl-charge-00.md
@@ -280,7 +280,7 @@ Addresses:
   destination tag is carried in `methodDetails.destinationTag` so
   that it remains independently verifiable.
 
-# Request Schema
+# Request Schema {#request-schema}
 
 ## Shared Fields
 
@@ -728,20 +728,37 @@ establishes.
 
 ## Challenge
 
+The `402` carries the challenge in a `WWW-Authenticate` header, with
+the request object base64url-encoded in the `request` parameter, as
+{{I-D.httpauth-payment}} defines:
+
+~~~ http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="PgHorYGpATG5ifG-QKCa2OVPjOku...",
+  realm="api.example.com", method="xrpl", intent="charge",
+  request="eyJhbW91bnQiOiIxMDAwMDAwIiwiY3VycmVuY3kiOiJYUlAiLC...",
+  expires="2026-08-21T10:32:00Z"
+~~~
+
+The `request` parameter decodes to the object this document
+specifies in [](#request-schema):
+
 ~~~ json
 {
-  "method": "xrpl",
-  "intent": "charge",
   "amount": "1000000",
   "currency": "XRP",
-  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv",
-  "expires": "2026-08-21T10:32:00Z",
   "methodDetails": {
     "network": "testnet",
     "reference": "3f7a1c02-9e44-4b1e-8a10-0c2b5d6e7f80"
-  }
+  },
+  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv"
 }
 ~~~
+
+The header parameters and the request object are distinct: `method`,
+`intent` and `expires` are the scheme's, while `amount`, `currency`
+and `recipient` belong to the encoded request. The line breaks above
+are for presentation.
 
 ## Settled Transaction
 

--- a/specs/methods/xrpl/draft-xrpl-charge-00.md
+++ b/specs/methods/xrpl/draft-xrpl-charge-00.md
@@ -527,6 +527,26 @@ NOT surface raw ledger strings.
 | `tecINSUFF_FEE`, `terINSUF_FEE_B` | fee below the current load-scaled minimum |
 | `tefBAD_AUTH`, `tefMASTER_DISABLED` | signing key not valid for the account |
 
+# Receipts
+
+A receipt for a settled charge carries the base fields
+{{I-D.httpauth-payment}} defines, and the following in addition:
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `txHash` | string | REQUIRED | Hash of the settled transaction, 64 uppercase hexadecimal characters |
+| `ledgerIndex` | number | OPTIONAL | Index of the validated ledger it settled in |
+
+The base `reference` MUST also carry the transaction hash, which is
+what the core specification asks of a method-specific reference. The
+named field exists because one opaque value cannot be read without
+method knowledge: a consumer looking for a transaction hash finds no
+field called one, and confirming the value means testing whether it
+resolves on the ledger.
+
+Servers SHOULD emit both. Clients SHOULD read `txHash` and fall back
+to `reference`.
+
 # Error Responses {#errors}
 
 Errors are Problem Details {{RFC9457}} carried on a `402` response.

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -1,0 +1,697 @@
+---
+title: XRP Ledger Session Intent for HTTP Payment Authentication
+abbrev: XRPL Session
+docname: draft-xrpl-session-00
+version: 00
+category: info
+ipr: noModificationTrust200902
+submissiontype: independent
+consensus: false
+
+author:
+  - name: Maxime Dienger
+    ins: M. Dienger
+    email: maximed@ripple.com
+    org: RippleX
+
+normative:
+  RFC2119:
+  RFC3339:
+  RFC8174:
+  RFC8259:
+  RFC9457:
+  I-D.httpauth-payment:
+    title: "The 'Payment' HTTP Authentication Scheme"
+    target: https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/
+    author:
+      - name: Jake Moxey
+    date: 2026-01
+  I-D.xrpl-charge:
+    title: "XRP Ledger Charge Intent for HTTP Payment Authentication"
+    target: https://datatracker.ietf.org/doc/draft-xrpl-charge/
+    author:
+      - name: Maxime Dienger
+    date: 2026
+
+informative:
+  XRPL-PAYCHAN:
+    title: "Payment Channels"
+    target: https://xrpl.org/docs/concepts/payment-types/payment-channels
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-PAYCHAN-OBJECT:
+    title: "PayChannel Ledger Entry"
+    target: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/paychannel
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-CHAN-CREATE:
+    title: "PaymentChannelCreate Transaction"
+    target: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelcreate
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-CHAN-CLAIM:
+    title: "PaymentChannelClaim Transaction"
+    target: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelclaim
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-CHAN-FUND:
+    title: "PaymentChannelFund Transaction"
+    target: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelfund
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-CHANNEL-VERIFY:
+    title: "channel_verify Method"
+    target: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-CHANNEL-AUTHORIZE:
+    title: "channel_authorize Method"
+    target: https://xrpl.org/docs/references/http-websocket-apis/admin-api-methods/signing-methods/channel_authorize
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-RESERVES:
+    title: "Reserves"
+    target: https://xrpl.org/docs/concepts/accounts/reserves
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-FINALITY:
+    title: "Finality of Results"
+    target: https://xrpl.org/docs/concepts/transactions/finality-of-results
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-TX-RESULTS:
+    title: "Transaction Results"
+    target: https://xrpl.org/docs/references/protocol/transactions/transaction-results
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-KEYS:
+    title: "Cryptographic Keys"
+    target: https://xrpl.org/docs/concepts/accounts/cryptographic-keys
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-BASIC-TYPES:
+    title: "Basic Data Types"
+    target: https://xrpl.org/docs/references/protocol/data-types/basic-data-types
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+  XRPL-AMENDMENTS:
+    title: "Known Amendments"
+    target: https://xrpl.org/resources/known-amendments
+    author:
+      - org: XRP Ledger Foundation
+    date: 2026
+---
+
+--- abstract
+
+This document defines the "session" intent for the "xrpl" payment
+method within the Payment HTTP Authentication Scheme. A session is
+carried by an XRP Ledger Payment Channel: the client locks XRP
+on-chain once, then authorises a series of off-chain claims, each a
+signature over a cumulative total. The server redeems the final
+claim in a single closing transaction.
+
+Two on-chain transactions therefore settle an unbounded number of
+payments, which is what makes per-request and per-token billing
+viable at amounts where a transaction fee would otherwise dominate.
+
+The "session" intent is experimental. It is defined here rather than
+in a standalone intent document because it is not yet formalized in
+the intent registry.
+
+--- middle
+
+# Introduction
+
+The charge intent {{I-D.xrpl-charge}} settles every payment on-chain.
+That is correct and final, but it costs a transaction and several
+seconds each time, which rules out the cases this intent exists for:
+paying per API call, per inference token, or per streamed chunk.
+
+An XRP Ledger Payment Channel {{XRPL-PAYCHAN}} decouples
+authorisation from settlement. The funder locks XRP in a channel
+naming a destination, which also locks an owner reserve for the new
+ledger entry {{XRPL-RESERVES}}. Thereafter it signs claims
+off-chain, each stating a *cumulative* total rather than an
+increment. The destination may redeem the highest claim it holds at
+any time, in one transaction.
+
+Cumulative rather than incremental is the property that makes this
+safe with no coordination: a lost or reordered claim costs nothing,
+because the next one supersedes it. The server need only retain the
+largest.
+
+## Session Flow
+
+~~~
+Client                                   Server
+  |                                        |
+  |  PaymentChannelCreate (on-chain)       |
+  |                                        |
+  |------------- GET /resource ----------->|
+  |<-- 402, challenge: cumulative so far --|
+  |                                        |
+  | sign claim over (channelId, total)     |
+  |                                        |
+  |-- Authorization: Payment <voucher> --->|
+  |                                        | verify signature
+  |                                        | check channel on-chain
+  |                                        | advance high-water mark
+  |<-- 200, Payment-Receipt ---------------|
+  |                                        |
+  |          ... N more requests ...        |
+  |                                        |
+  |                                        | PaymentChannelClaim
+  |                                        | (on-chain, tfClose)
+~~~
+
+## Channels Are XRP-Only
+
+Payment Channels carry XRP exclusively. Issued currencies and MPTs
+cannot fund a channel, so every amount in this document is an integer
+drop count. A server needing off-chain settlement in another asset
+must use a different mechanism; this intent does not provide one.
+
+# Requirements Language
+
+{::boilerplate bcp14-tagged}
+
+# Terminology
+
+Channel:
+: A `PayChannel` ledger entry {{XRPL-PAYCHAN-OBJECT}} created by
+  `PaymentChannelCreate` {{XRPL-CHAN-CREATE}},
+  identified by a 256-bit channel ID, naming an `Account` (the
+  funder), a `Destination`, an `Amount` deposited, a `Balance`
+  already redeemed, a `PublicKey` authorised to sign claims, and a
+  `SettleDelay`.
+
+Claim (voucher):
+: A signature by the channel's `PublicKey` over the tuple of channel
+  ID and a cumulative drop amount. Not a ledger transaction.
+
+Cumulative amount:
+: The running total authorised since the channel opened
+  {{XRPL-BASIC-TYPES}}, not the
+  amount owed for one request.
+
+High-water mark:
+: The largest cumulative amount a server has accepted for a channel.
+
+SettleDelay:
+: Seconds the funder must wait, after initiating closure, before the
+  channel can be destroyed. The window in which the destination can
+  still redeem.
+
+# Method Identifier
+
+The method identifier is `xrpl`, as in {{I-D.xrpl-charge}}, carried
+in the challenge and credential fields the Payment HTTP
+Authentication Scheme {{I-D.httpauth-payment}} defines. This
+document defines only the `session` intent for it.
+
+# Intent: "session"
+
+`session` is the intent identifier on the wire. An implementation MAY
+expose a local alias for its own API, but MUST advertise and accept
+`session` in challenges and credentials.
+
+# Encoding Conventions {#encoding}
+
+The encoding rules of {{I-D.xrpl-charge}} apply to this document
+unchanged. They are inherited rather than restated: the rule that
+case must not be load-bearing in a hex identifier is the one a
+divergent copy would quietly break, and one statement cannot diverge
+from itself.
+
+What this intent adds is narrower.
+
+Amounts:
+: Every amount is an integer count of drops, as a decimal string,
+  with no fractional part. A channel carries XRP alone, so the token
+  units of {{I-D.xrpl-charge}} do not arise here.
+
+Cumulative amounts:
+: A voucher states the running total authorised over the channel's
+  life, not the increment it adds. It is an integer drop count on
+  the same terms as any other amount here, and it is compared and
+  accumulated as an exact integer -- see [](#amount-precision) for
+  why, and for the boundary that makes it a MUST.
+
+Channel identifiers:
+: A `channelId` is 64 hexadecimal characters, carrying the case
+  rules {{I-D.xrpl-charge}} states. A claim signature is verified
+  over the hex-decoded identifier, so two spellings of one channel
+  are one channel, and anything derived from it -- a high-water mark
+  above all -- MUST be keyed on a canonical form.
+
+# Request Schema
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `amount` | string | yes | increment charged for this request, in drops |
+| `channelId` | string | yes | 64-hex channel ID, or `""` on an open |
+| `recipient` | string | yes | classic address the channel must pay |
+| `currency` | string | no | always `"XRP"` when present |
+| `description` | string | no | display only |
+
+`amount` is the increment for this request. The cumulative total is
+the server's business: it knows the high-water mark and the client
+does not need to be trusted with the arithmetic.
+
+`channelId` is empty only on an open-action challenge, because the
+channel does not exist until its creating transaction is validated
+and the ID can be read from the metadata. A credential payload MUST
+always carry a full 64-hex channel ID; the empty form is confined to
+the challenge.
+
+# Credential Schema
+
+Credentials and challenges are JSON {{RFC8259}}; timestamps such as a
+challenge's `expires` are {{RFC3339}}.
+
+The payload is discriminated by `action`.
+
+## action = "open"
+
+~~~ json
+{
+  "action": "open",
+  "transaction": "1200...",
+  "amount": "100000",
+  "signature": "304402..."
+}
+~~~
+
+`transaction` is a signed but unsubmitted `PaymentChannelCreate`
+{{XRPL-CHAN-CREATE}}. The
+server broadcasts it, reads the channel ID from the validated
+metadata, then treats `amount` and `signature` as the first claim.
+
+This folds channel establishment into the 402 exchange, so no
+out-of-band endpoint is needed. A server MAY instead require the
+client to open the channel itself and supply the ID by other means.
+
+## action = "voucher"
+
+~~~ json
+{
+  "action": "voucher",
+  "channelId": "2D398F9458B0CF96284E3602E57A83E787C1A01658512F972CEDDB1819607E89",
+  "amount": "200000",
+  "signature": "304402..."
+}
+~~~
+
+`amount` is the new cumulative total, not the increment.
+
+## action = "close"
+
+Requests that the server redeem and close. The payload carries the
+final cumulative amount and its signature.
+
+# Verification Procedure {#verification}
+
+The order is normative. Cheap local checks precede network calls so
+that an unauthenticated caller cannot use verification to generate
+ledger traffic.
+
+## Size and Shape
+
+The server MUST bound the credential size before parsing, and reject
+a payload whose fields do not match the schema.
+
+## Signature {#signature}
+
+The server MUST verify the claim signature over the tuple of channel
+ID and cumulative amount, against the channel's authorised public
+key {{XRPL-KEYS}}, **before** any ledger lookup.
+
+Verification MAY be performed locally or through the ledger's
+`channel_verify` method {{XRPL-CHANNEL-VERIFY}}. Local verification is
+preferred: it costs no round trip, and it does not disclose to a node
+which channels a server is being paid through.
+
+A matching `channel_authorize` {{XRPL-CHANNEL-AUTHORIZE}} exists for
+producing claim signatures, but it is an admin method and takes a
+secret, so a client signs locally in practice.
+
+Ordering matters. A signature check is local arithmetic; a channel
+lookup is a network round trip. Verifying the signature first means a
+caller supplying random channel IDs is rejected without the server
+making a request on its behalf.
+
+The claim signs an XRP-denominated figure. Implementations MUST
+derive it from the drop count by exact integer arithmetic. A
+conversion through a binary floating-point value is lossy above 2^53
+drops and, where it is lossy, produces a signature over a figure
+differing from the amount that will be submitted, which then fails to
+verify on-chain. See [](#amount-precision).
+
+## Sender Binding
+
+The address derived from the channel's authorised public key MUST
+match the address in the credential's `source` DID. Without this, a
+claim can be replayed under another party's identity.
+
+## Channel State {#channel-state}
+
+The server MUST confirm, against the ledger, that:
+
+1. the channel exists;
+2. its `Destination` is the recipient this server is charging for --
+   a funder can otherwise open a channel to an address of its own
+   choosing and receive service against claims this server can never
+   redeem;
+3. its `PublicKey` matches the key the server verifies against;
+4. its `SettleDelay` is at least the server's configured minimum;
+5. the cumulative claimed does not exceed `Amount` less `Balance`;
+6. the channel is not expired, and not within the settlement margin
+   of expiry.
+
+A server MAY cache this state briefly, but the two fields that can
+move against it need care of different kinds.
+
+`Amount` only ever grows, since a funder may add to a channel and
+cannot withdraw from it. A stale value is therefore pessimistic: it
+under-reports the deposit and can only cause an unnecessary refusal,
+which a single re-read resolves.
+
+`Expiration` is not monotone. A funder may set or shorten it at any
+time, so a stale absence of an expiry is optimistic in exactly the
+wrong direction. A cache lifetime as long as the settlement margin of
+[](#closing-window) spends that whole margin on staleness: the
+channel may have entered its closing window a full lifetime ago,
+leaving no real
+time to redeem. Implementations MUST keep the cache lifetime
+materially below the margin, or read `Expiration` fresh.
+
+## Settle Delay Floor {#settle-delay}
+
+The server MUST reject a channel whose `SettleDelay` is below a
+configured minimum, and that minimum SHOULD be no less than one hour.
+
+The delay is the whole of the destination's protection. Once the
+funder initiates closure, the destination has exactly `SettleDelay`
+to submit its claim. A channel with a delay of sixty seconds lets a
+funder consume service and close before any realistic operator can
+detect and respond, and the unredeemed value returns to the funder.
+
+## Closing Window {#closing-window}
+
+The server MUST refuse a voucher when the channel is within a
+configured margin of `Expiration` or `CancelAfter`.
+
+One ledger amendment {{XRPL-AMENDMENTS}} bears directly on this
+window. `fixPayChanCancelAfter` makes `PaymentChannelCreate` fail
+when `CancelAfter` is already in the past; without it a channel
+could be created that was unusable from the moment it existed. A
+server MUST NOT assume the amendment is enabled on the network it is
+talking to. It does not need to: reading `CancelAfter` from the
+channel, which [](#channel-state) requires anyway, settles the
+question for that channel whatever the network has enabled.
+
+Accepting a claim in that window earns value the server has no time
+left to redeem. Treating those fields as advisory -- reporting them
+while still accepting the claim -- is not sufficient: after
+`CancelAfter` anyone may delete the channel and the deposit returns
+to the funder.
+
+## Monotonicity {#monotonicity}
+
+The server MUST reject a cumulative amount that is not strictly
+greater than its high-water mark for that channel, and MUST perform
+the comparison and the update as one atomic operation.
+
+The mark MUST be keyed on a canonical form of the channel ID. Hex is
+case-insensitive as a value, and both layers beneath the store treat it
+that way: `verifyPaymentChannelClaim` hex-decodes the ID, so a claim
+signed over one casing verifies against another, and the ledger
+resolves either. A mark keyed on the raw string is therefore not one
+mark but one per casing, and the same voucher can be spent once for
+each -- which is unbounded in practice, since a 64-character
+identifier has as many casings as it has letters.
+
+Three outcomes are distinct and MUST be distinguished:
+
+| Condition | Meaning |
+|---|---|
+| cumulative equals the mark | replay of an accepted claim |
+| cumulative below the mark | attempt to roll back |
+| cumulative above, but increment below what was requested | underpayment |
+
+The third is the one most easily missed. A first claim on a fresh
+channel has no previous mark to exceed, so a check written only
+against the mark accepts any positive amount -- one drop satisfies a
+one-XRP request.
+
+The update MUST be a compare-and-set, shared across every process
+serving the channel and durable across restarts. A read followed by a
+write lets two replicas accept the same claim concurrently, and a
+mark lost on restart lets every claim be replayed.
+
+## Finalized Channels
+
+Once the server has closed a channel, it MUST record that and reject
+later claims against it. A closed channel cannot be redeemed again,
+so a claim accepted afterwards is service given away.
+
+# Settlement Procedure
+
+## Redemption
+
+The server submits `PaymentChannelClaim` {{XRPL-CHAN-CLAIM}}
+carrying the highest cumulative amount it holds and the matching
+signature.
+
+The `tfClose` flag is accepted from the source and from the
+destination alike, and its effect differs by sender. From the
+destination the channel closes at once: the claim settles, the entry
+is deleted, and the unspent deposit returns to the funder. From the
+source it schedules closure for once `SettleDelay` has elapsed,
+which is what preserves the destination's window described in
+[](#settle-delay).
+
+A server ending a session SHOULD set it. One transaction then both
+collects what was earned and releases the funder's deposit and owner
+reserve, where a claim without it leaves the entry in place holding
+both.
+
+Implementations MUST verify which flag they set. `tfClose` and
+`tfRenew` are adjacent values, and `tfRenew` clears the channel's
+`Expiration` rather than closing anything. Substituting one for the
+other fails silently: the claim still settles and the transaction
+still succeeds, so only reading the channel entry afterwards
+distinguishes a close from a renewal.
+
+The submitted `Balance` MUST be the exact drop count the signature
+covers. If the two disagree the ledger rejects the signature and the
+earned value becomes unredeemable.
+
+## Idle Channels
+
+A funder may extend a channel's deposit or expiry with
+`PaymentChannelFund` {{XRPL-CHAN-FUND}}, but is under no obligation
+to. A client that disappears mid-session leaves value authorised but
+unclaimed, and the funder may begin closure at any time. A server
+SHOULD therefore redeem proactively rather than waiting for a client
+that may not return.
+
+Where `fixPayChanRecipientOwnerDir` {{XRPL-AMENDMENTS}} is enabled,
+a channel is listed in the recipient's owner directory as well as
+the funder's, so a server can enumerate the channels paying it
+rather than relying solely on its own records. The owner reserve for
+the entry stays with the funder, who created it; being listed costs
+the recipient nothing.
+
+## Receipts
+
+A receipt for a session payment identifies the claim, not a
+transaction: the channel ID and the cumulative total. There is no
+transaction hash until redemption.
+
+# Error Responses {#errors}
+
+Problem Details {{RFC9457}} on a `402`. Ledger result codes
+{{XRPL-TX-RESULTS}} MUST NOT be surfaced raw. Distinct conditions
+MUST be distinguishable by the client, and a server SHOULD report
+each with the type named here:
+
+| Condition | Meaning | Problem type |
+|---|---|---|
+| channel not found | no such channel on the ledger | `session/channel-not-found` |
+| destination mismatch | channel does not pay this server | `verification-failed` |
+| settle delay too short | below the server's floor | `verification-failed` |
+| channel expired | past `Expiration`/`CancelAfter` | `session/channel-finalized` |
+| channel closing | inside the settlement margin | `session/channel-finalized` |
+| channel exhausted | claim exceeds the deposit left | `session/amount-exceeds-deposit` |
+| invalid signature | claim does not verify | `session/invalid-signature` |
+| replay detected | cumulative not above the mark | `verification-failed` |
+
+The types are relative to `https://paymentauth.org/problems/`, the
+base URI {{I-D.httpauth-payment}} establishes. Those in the
+`session` namespace are the ones payment-channel methods already
+share; this document adds none. Three conditions carry
+`verification-failed` because they are refusals of the procedure in
+[](#verification) rather than states of the channel, and the detail
+field distinguishes them.
+
+# Security Considerations
+
+## The Server Bears the Settlement Risk
+
+The asymmetry is structural and worth stating plainly. The funder's
+exposure is bounded by the deposit. The server's exposure is every
+claim it has accepted but not yet redeemed, and it can lose that
+value in three ways: the funder closes and the delay elapses
+unnoticed, `CancelAfter` passes, or the server's high-water record is
+lost before redemption. Only a redemption in a validated ledger
+settles the matter {{XRPL-FINALITY}}.
+
+Sections 7.5, 7.6, 7.7 and 8.2 each close one of these. None is
+optional.
+
+## Signature Malleability
+
+For secp256k1 keys an ECDSA signature has two valid encodings
+differing in the sign of S. An implementation MUST NOT treat the two
+as distinct claims -- a distinct encoding of an accepted claim is
+still that claim, and accepting it as new would credit the funder
+twice.
+
+Enforcing canonical low-S form on verification is the direct defence.
+Implementations SHOULD confirm their verifier does so rather than
+assume it.
+
+## Cache Staleness
+
+Caching channel state trades a round trip for a window in which the
+server acts on a stale view. The deposit is safe to cache because it
+only grows. The expiry is not, and a cache lifetime at or above the
+settlement margin makes that margin nominal -- see [](#closing-window).
+
+## Replay Store Durability
+
+The high-water mark is the only record that a claim has been spent.
+It is not reconstructible from the ledger, which sees only the final
+redemption. A store lost on restart therefore does not degrade
+gracefully: every claim ever issued becomes replayable.
+
+## Amount Precision {#amount-precision}
+
+Drop counts up to the total supply exceed the 2^53 integers exactly
+representable in IEEE-754; the boundary is 9,007,199,254 XRP. Above
+it, a conversion through a floating-point value yields a signature
+over a figure differing from the submitted amount, and the ledger
+rejects it. The threshold is far above any plausible channel, but the
+failure is silent and the arithmetic is not hard to get right, so
+exact integer handling is a MUST.
+
+## The Challenge Must Match the Resource
+
+A verifier reads the increment, the channel and the recipient from
+the challenge the credential carries, so the requirement in "The
+Challenge Must Match the Resource" of {{I-D.xrpl-charge}} applies
+here unchanged: a server MUST confirm that the terms it is about to
+verify are the terms the requested resource charges, and MUST refuse
+the credential otherwise. A session compounds the consequence,
+because a challenge accepted against the wrong resource moves that
+resource's high-water mark for every voucher that follows.
+
+## Transport Security
+
+As {{I-D.xrpl-charge}}: TLS for any non-loopback ledger connection.
+
+# IANA Considerations
+
+The `xrpl` payment method is registered in the "HTTP Payment
+Methods" registry by {{I-D.xrpl-charge}}; this document does not
+register it again.
+
+## Payment Intent Registration
+
+This document requests registration of the following entry in the
+"HTTP Payment Intents" registry established by
+{{I-D.httpauth-payment}}:
+
+| Intent | Applicable Methods | Description | Reference |
+|---|---|---|---|
+| `session` | `xrpl` | Off-ledger payment channel vouchers | This document |
+
+Contact: Maxime Dienger (<maximed@ripple.com>)
+
+`session` is an experimental intent, defined by method documents
+rather than by an intent document of its own. Should it be
+formalized, this document should be updated to reference that
+document rather than define the intent here.
+
+## Problem Types
+
+This document registers no problem type URI. The conditions in
+[](#errors) are reported with types already established: the core
+types of {{I-D.httpauth-payment}}, and the `session` namespace that
+payment-channel methods share.
+
+--- back
+
+# Examples
+
+## Voucher Challenge
+
+~~~ json
+{
+  "method": "xrpl",
+  "intent": "session",
+  "amount": "100000",
+  "channelId":
+    "2D398F9458B0CF96284E3602E57A83E787C1A01658512F972CEDDB1819607E89",
+  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv",
+  "expires": "2026-08-21T10:32:00Z"
+}
+~~~
+
+## Voucher Credential
+
+Third request in a session, each charging 100,000 drops. The
+cumulative total is 300,000; the increment is 100,000.
+
+~~~ json
+{
+  "action": "voucher",
+  "channelId":
+    "2D398F9458B0CF96284E3602E57A83E787C1A01658512F972CEDDB1819607E89",
+  "amount": "300000",
+  "signature": "3044022057..."
+}
+~~~
+
+## Redemption
+
+After five such requests the server holds a claim for 500,000 drops
+and submits:
+
+~~~ json
+{
+  "TransactionType": "PaymentChannelClaim",
+  "Channel":
+    "2D398F9458B0CF96284E3602E57A83E787C1A01658512F972CEDDB1819607E89",
+  "Balance": "500000",
+  "Amount": "500000",
+  "Signature": "3044022057...",
+  "PublicKey": "ED690468FD78177F3158..."
+}
+~~~
+
+Five payments, two on-chain transactions.

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -342,19 +342,14 @@ key {{XRPL-KEYS}}.
 That key is a property of the channel, not of the server. A funder
 chooses it in its own `PaymentChannelCreate` {{XRPL-CHAN-CREATE}},
 so a server accepting channels from callers it has not met cannot
-know it in advance and MUST read it from the channel. A server MAY
-additionally pin one expected key and refuse channels naming any
-other, which restricts it to a single funder; a server that does so
-still verifies against the channel's key, and the pin is a
-restriction on which channels are acceptable rather than a
-substitute for reading one.
+know it in advance and MUST read it from the channel.
 
-Ordering follows from where the key came from. A server holding a
-pinned key SHOULD verify the signature before any ledger lookup: the
-check is local, and a caller can otherwise force a lookup for every
-forged voucher it sends. A server reading the key from the channel
-has nothing to verify against until that read completes, and MUST
-NOT accept a claim on the strength of the read alone.
+The signature check therefore follows the read rather than
+preceding it. A consequence worth stating: a forged claim on a
+channel identifier the server has not seen costs it one read.
+Servers SHOULD cache channel state per channel, which reduces this
+to established channels costing nothing, and SHOULD rate-limit
+ahead of verification.
 
 Verification MAY be performed locally or through the ledger's
 `channel_verify` method {{XRPL-CHANNEL-VERIFY}}. Local verification is
@@ -392,10 +387,8 @@ funder from the key therefore rejects the funders that hold their
 keys most carefully, and where it does succeed it establishes only
 that the account and the channel key coincide.
 
-A server that has not read the channel -- see [](#channel-state) --
-has no `Account` to compare against, and can bind only to an address
-derived from a key it pinned itself. That is one of the checks such a
-server gives up.
+A server therefore has to have read the channel before it can make
+this comparison, which is one more reason the read is not optional.
 
 ## Channel State {#channel-state}
 
@@ -407,7 +400,7 @@ The server MUST confirm, against the ledger, that:
    choosing and receive service against claims this server can never
    redeem;
 3. its `PublicKey` is the key the claim signature was verified
-   against, and, where the server pins an expected key, is that key;
+   against;
 4. its `SettleDelay` is at least the server's configured minimum;
 5. the cumulative claimed does not exceed `Amount` less `Balance`;
 6. the channel is not expired, and not within the settlement margin

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -267,15 +267,26 @@ Channel identifiers:
 | `currency` | string | no | always `"XRP"` when present |
 | `description` | string | no | display only |
 
-`amount` is the increment for this request. The cumulative total is
-the server's business: it knows the high-water mark and the client
-does not need to be trusted with the arithmetic.
+`amount` is the increment for this request, and the cumulative total
+is the server's to state where it can. A challenge that names a
+channel SHOULD report the mark for it, so a client resumes from
+server state rather than its own bookkeeping.
 
-`channelId` is empty only on an open-action challenge, because the
-channel does not exist until its creating transaction is validated
-and the ID can be read from the metadata. A credential payload MUST
-always carry a full 64-hex channel ID; the empty form is confined to
-the challenge.
+A challenge that names no channel cannot: there is nothing to look
+the mark up by, and reporting zero is all it can do. A client MUST
+therefore track the highest cumulative it has signed per channel and
+sign above that, taking whichever of the two is greater. Signing
+from a reported zero alone re-sends an accepted cumulative, which
+the server MUST refuse as a replay -- see [](#monotonicity).
+
+`channelId` is empty when the server names no channel, for either
+of two reasons. On an open-action challenge the channel does not
+exist yet: its ID cannot be read until the creating transaction is
+validated. Otherwise, a server accepting callers it has not met has
+no channel to name, because a client learns its channel ID from its
+own `PaymentChannelCreate`. In both cases the client supplies the
+channel, and a credential payload MUST always carry a full 64-hex
+channel ID -- the empty form is confined to the challenge.
 
 # Credential Schema
 

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -294,14 +294,28 @@ exist yet: its ID cannot be read until the creating transaction is
 validated. Otherwise, a server accepting callers it has not met has
 no channel to name, because a client learns its channel ID from its
 own `PaymentChannelCreate`. In both cases the client supplies the
-channel, and a credential payload MUST always carry a full 64-hex
-channel ID -- the empty form is confined to the challenge.
+channel. A `voucher` or `close` payload MUST carry a full 64-hex
+channel ID; the empty form is confined to the challenge. An `open`
+payload carries none, and cannot: the channel does not exist until
+the transaction it carries has been validated, and the server reads
+the ID from that transaction's metadata.
 
 ## Network
 
-Servers SHOULD set `network` in `methodDetails`, as
-{{I-D.xrpl-charge}} requires of a charge, and this document defines
-no default either.
+Servers MUST set `network` in `methodDetails`, and a server MUST
+refuse a credential whose challenge omits it or names a network other
+than the one the server settles on. A charge only recommends it
+{{I-D.xrpl-charge}}; a session requires it.
+
+The reason is that a session spans requests. Absent the field, each
+side falls back to a default of its own, and those can differ
+silently: a claim signed for a channel the client believes is on one
+ledger, verified and redeemed by a server on another. It also leaves
+a client that pinned a network nothing to compare against, so that
+guard cannot fire. A challenge naming a network the server does not
+settle on is the same divergence stated out loud, and is reachable
+where two deployments share a secret and settle on different
+ledgers.
 
 Clients SHOULD refuse a challenge naming a network other than the
 one they were configured for. The stake is higher here than on a
@@ -362,8 +376,29 @@ belong to the funder.
 
 ## action = "close"
 
-Requests that the server redeem and close. The payload carries the
-final cumulative amount and its signature.
+~~~ json
+{
+  "action": "close",
+  "channelId": "2D398F9458B0CF96284E3602E57A83E787C1A01658512F972CEDDB1819607E89",
+  "amount": "500000",
+  "signature": "304402..."
+}
+~~~
+
+Asks the server to redeem and close. The fields are those of a
+`voucher`, and carry the same meaning: `amount` is the final
+cumulative total, not an increment, and the signature covers it.
+
+A server MUST verify a `close` payload exactly as it verifies a
+`voucher` before acting on it. The request is a claim like any other,
+and being the last one confers no standing: a `close` carrying a
+cumulative below the mark, or a signature that does not verify, MUST
+be refused on the same terms.
+
+Redemption itself is the server's to perform and its timing the
+server's to choose -- see [](#redemption). A client cannot compel a
+close by asking for one, and a server MAY treat the action as a
+voucher that also signals the session is over.
 
 # Verification Procedure {#verification}
 
@@ -445,9 +480,23 @@ The server MUST confirm, against the ledger, that:
 3. its `PublicKey` is the key the claim signature was verified
    against;
 4. its `SettleDelay` is at least the server's configured minimum;
-5. the cumulative claimed does not exceed `Amount` less `Balance`;
+5. the cumulative claimed is greater than `Balance` and no greater
+   than `Amount`;
 6. the channel is not expired, and not within the settlement margin
    of expiry.
+
+`Amount` is everything the channel holds and `Balance` is what it has
+already delivered, so a cumulative claim is bounded by `Amount`
+alone. Subtracting `Balance` from it would reject valid claims: a
+channel holding 1,000,000 drops that has delivered 500,000 still
+honours a claim for 600,000.
+
+The drops a claim delivers on redemption are
+`claimed - Balance`. A server tracking what it has earned SHOULD
+compute the increment against `max(Balance, mark)` rather than
+against its own high-water mark alone, since a claim redeemed
+outside this exchange advances `Balance` without the server
+observing it.
 
 A server MAY cache this state briefly, but the two fields that can
 move against it need care of different kinds.
@@ -497,20 +546,34 @@ while still accepting the claim -- is not sufficient: after
 `CancelAfter` anyone may delete the channel and the deposit returns
 to the funder.
 
+## State Keys {#state-keys}
+
+Every piece of state a server keeps for a channel -- its high-water
+mark, any cached ledger metadata, and any record that the channel is
+finalized -- MUST be keyed on the pair of network and channel ID, not
+on the channel ID alone.
+
+A channel ID does not identify a channel on its own. It derives from
+the funder, the destination and a sequence number, and one seed
+controls the same address on every network, so the same funder
+opening to the same destination from a fresh account produces the
+same ID twice. Keyed on the ID alone, testnet activity moves a
+mainnet channel's mark, and a channel finalized on one network is
+refused on the other.
+
+The channel ID MUST be canonicalised before use as a key. Hex is
+case-insensitive as a value, and both layers beneath the store treat
+it that way: a claim signed over one casing verifies against another,
+and the ledger resolves either. A key built on the raw string is
+therefore not one key but one per casing, and the same voucher can be
+spent once for each -- unbounded in practice, since a 64-character
+identifier has as many casings as it has letters.
+
 ## Monotonicity {#monotonicity}
 
 The server MUST reject a cumulative amount that is not strictly
 greater than its high-water mark for that channel, and MUST perform
 the comparison and the update as one atomic operation.
-
-The mark MUST be keyed on a canonical form of the channel ID. Hex is
-case-insensitive as a value, and both layers beneath the store treat it
-that way: `verifyPaymentChannelClaim` hex-decodes the ID, so a claim
-signed over one casing verifies against another, and the ledger
-resolves either. A mark keyed on the raw string is therefore not one
-mark but one per casing, and the same voucher can be spent once for
-each -- which is unbounded in practice, since a 64-character
-identifier has as many casings as it has letters.
 
 Three outcomes are distinct and MUST be distinguished:
 
@@ -538,7 +601,7 @@ so a claim accepted afterwards is service given away.
 
 # Settlement Procedure
 
-## Redemption
+## Redemption {#redemption}
 
 The server submits `PaymentChannelClaim` {{XRPL-CHAN-CLAIM}}
 carrying the highest cumulative amount it holds and the matching
@@ -589,16 +652,22 @@ the recipient nothing.
 A receipt for a session payment identifies the claim, not a
 transaction. Beyond the base fields {{I-D.httpauth-payment}} defines:
 
-| Field | Type | Voucher | Open | Meaning |
-|---|---|---|---|---|
-| `channelId` | string | REQUIRED | REQUIRED | Channel the payment went through |
-| `cumulative` | string | REQUIRED | OPTIONAL | Drop total authorised after this claim |
-| `txHash` | string | absent | REQUIRED | Hash of the submitted `PaymentChannelCreate` |
+| Field | Type | Open | Voucher | Close | Meaning |
+|---|---|---|---|---|---|
+| `channelId` | string | REQUIRED | REQUIRED | REQUIRED | Channel the payment went through |
+| `cumulative` | string | OPTIONAL | REQUIRED | REQUIRED | Drop total authorised after this claim |
+| `txHash` | string | REQUIRED | absent | conditional | Transaction the server submitted |
 
 A voucher receipt carries no `txHash`, and MUST NOT invent one: the
 claim settles nothing by itself, and no transaction exists until the
-channel is closed. An open receipt does carry one, because the server
-submitted a transaction to create the channel.
+channel is closed. An open receipt does carry one, for the
+`PaymentChannelCreate` the server submitted.
+
+A `close` receipt carries one when the server redeemed in the course
+of answering, and none when it accepted the claim and deferred
+redemption, which [](#redemption) permits. Its presence is therefore
+what tells a client whether settlement has happened, and a client
+MUST NOT infer settlement from the action alone.
 
 The base `reference` remains method-specific and MAY carry these
 values in a composite form. A server MUST NOT rely on a client
@@ -733,17 +802,36 @@ payment-channel methods share.
 
 ## Voucher Challenge
 
+As on a charge, the challenge travels as `WWW-Authenticate`
+parameters with the request object base64url-encoded in `request`:
+
+~~~ http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment id="qp9htNPwjAcnwDQqNTfHEulIIuAd...",
+  realm="api.example.com", method="xrpl", intent="session",
+  request="eyJhbW91bnQiOiIxMDAwMDAiLCJjaGFubmVsSWQiOiIyRDM5OEY5NDU...",
+  expires="2026-08-21T10:32:00Z"
+~~~
+
+Decoding `request`:
+
 ~~~ json
 {
-  "method": "xrpl",
-  "intent": "session",
   "amount": "100000",
   "channelId":
     "2D398F9458B0CF96284E3602E57A83E787C1A01658512F972CEDDB1819607E89",
-  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv",
-  "expires": "2026-08-21T10:32:00Z"
+  "methodDetails": {
+    "cumulativeAmount": "200000",
+    "network": "testnet",
+    "reference": "a55d88b1-0174-4542-9c63-83aa7ac0db2f"
+  },
+  "recipient": "rhewi79quXUDwcqjkpj4bXuw3cuHYC9fwv"
 }
 ~~~
+
+`amount` is the increment for this request and `cumulativeAmount` the
+total already accepted, so the credential below signs their sum. The
+line breaks are for presentation.
 
 ## Voucher Credential
 
@@ -760,7 +848,7 @@ cumulative total is 300,000; the increment is 100,000.
 }
 ~~~
 
-## Redemption
+## Redemption Transaction
 
 After five such requests the server holds a claim for 500,000 drops
 and submits:

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -274,10 +274,19 @@ server state rather than its own bookkeeping.
 
 A challenge that names no channel cannot: there is nothing to look
 the mark up by, and reporting zero is all it can do. A client MUST
-therefore track the highest cumulative it has signed per channel and
-sign above that, taking whichever of the two is greater. Signing
-from a reported zero alone re-sends an accepted cumulative, which
-the server MUST refuse as a replay -- see [](#monotonicity).
+therefore track the highest cumulative it has signed, per network
+and channel together, and sign above that, taking whichever of the
+two is greater. Signing from a reported zero alone re-sends an
+accepted cumulative, which the server MUST refuse as a replay --
+see [](#monotonicity).
+
+Per network as well as per channel because a channel ID does not
+identify a channel on its own: it derives from the funder, the
+destination and a sequence number, and one seed controls the same
+address on every network, so the same funder opening to the same
+destination from a fresh account produces the same ID twice. A mark
+shared between them makes the second network sign above what it was
+asked for.
 
 `channelId` is empty when the server names no channel, for either
 of two reasons. On an open-action challenge the channel does not
@@ -287,6 +296,21 @@ no channel to name, because a client learns its channel ID from its
 own `PaymentChannelCreate`. In both cases the client supplies the
 channel, and a credential payload MUST always carry a full 64-hex
 channel ID -- the empty form is confined to the challenge.
+
+## Network
+
+Servers SHOULD set `network` in `methodDetails`, as
+{{I-D.xrpl-charge}} requires of a charge, and this document defines
+no default either.
+
+Clients SHOULD refuse a challenge naming a network other than the
+one they were configured for. The stake is higher here than on a
+charge: answering an open-action challenge means submitting a
+`PaymentChannelCreate`, so a client that follows the challenge
+deposits real XRP on a ledger its operator did not choose. The same
+seed controls the same address on every network, so the deposit
+comes from a funded account whatever the client believed it was
+configured for.
 
 # Credential Schema
 
@@ -314,6 +338,14 @@ metadata, then treats `amount` and `signature` as the first claim.
 This folds channel establishment into the 402 exchange, so no
 out-of-band endpoint is needed. A server MAY instead require the
 client to open the channel itself and supply the ID by other means.
+
+A client SHOULD take the transaction's `Destination` from the
+challenge's `recipient`, which makes the exchange self-contained:
+nothing about the server has to be known before the resource is
+asked for. The deposit and the `SettleDelay` are not in the
+challenge and MUST NOT be inferred from one -- they bound what the
+funder stands to lose and how long it waits to recover it, so they
+belong to the funder.
 
 ## action = "voucher"
 

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -12,7 +12,7 @@ author:
   - name: Maxime Dienger
     ins: M. Dienger
     email: maximed@ripple.com
-    org: RippleX
+    org: Ripple
 
 normative:
   RFC2119:

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -337,7 +337,24 @@ a payload whose fields do not match the schema.
 
 The server MUST verify the claim signature over the tuple of channel
 ID and cumulative amount, against the channel's authorised public
-key {{XRPL-KEYS}}, **before** any ledger lookup.
+key {{XRPL-KEYS}}.
+
+That key is a property of the channel, not of the server. A funder
+chooses it in its own `PaymentChannelCreate` {{XRPL-CHAN-CREATE}},
+so a server accepting channels from callers it has not met cannot
+know it in advance and MUST read it from the channel. A server MAY
+additionally pin one expected key and refuse channels naming any
+other, which restricts it to a single funder; a server that does so
+still verifies against the channel's key, and the pin is a
+restriction on which channels are acceptable rather than a
+substitute for reading one.
+
+Ordering follows from where the key came from. A server holding a
+pinned key SHOULD verify the signature before any ledger lookup: the
+check is local, and a caller can otherwise force a lookup for every
+forged voucher it sends. A server reading the key from the channel
+has nothing to verify against until that read completes, and MUST
+NOT accept a claim on the strength of the read alone.
 
 Verification MAY be performed locally or through the ledger's
 `channel_verify` method {{XRPL-CHANNEL-VERIFY}}. Local verification is
@@ -362,9 +379,23 @@ verify on-chain. See [](#amount-precision).
 
 ## Sender Binding
 
-The address derived from the channel's authorised public key MUST
-match the address in the credential's `source` DID. Without this, a
-claim can be replayed under another party's identity.
+The channel's `Account` MUST match the address in the credential's
+`source` DID. Without this, a claim can be replayed under another
+party's identity.
+
+The comparison MUST NOT be made against an address derived from the
+channel's authorised public key. A channel may name any valid key
+{{XRPL-PAYCHAN-OBJECT}}, and a funder is well advised to dedicate a
+key pair to the channel so that its loss costs that channel alone;
+the address derived from such a key belongs to nobody. Deriving the
+funder from the key therefore rejects the funders that hold their
+keys most carefully, and where it does succeed it establishes only
+that the account and the channel key coincide.
+
+A server that has not read the channel -- see [](#channel-state) --
+has no `Account` to compare against, and can bind only to an address
+derived from a key it pinned itself. That is one of the checks such a
+server gives up.
 
 ## Channel State {#channel-state}
 
@@ -375,7 +406,8 @@ The server MUST confirm, against the ledger, that:
    a funder can otherwise open a channel to an address of its own
    choosing and receive service against claims this server can never
    redeem;
-3. its `PublicKey` matches the key the server verifies against;
+3. its `PublicKey` is the key the claim signature was verified
+   against, and, where the server pins an expected key, is that key;
 4. its `SettleDelay` is at least the server's configured minimum;
 5. the cumulative claimed does not exceed `Amount` less `Balance`;
 6. the channel is not expired, and not within the settlement margin

--- a/specs/methods/xrpl/draft-xrpl-session-00.md
+++ b/specs/methods/xrpl/draft-xrpl-session-00.md
@@ -555,8 +555,23 @@ the recipient nothing.
 ## Receipts
 
 A receipt for a session payment identifies the claim, not a
-transaction: the channel ID and the cumulative total. There is no
-transaction hash until redemption.
+transaction. Beyond the base fields {{I-D.httpauth-payment}} defines:
+
+| Field | Type | Voucher | Open | Meaning |
+|---|---|---|---|---|
+| `channelId` | string | REQUIRED | REQUIRED | Channel the payment went through |
+| `cumulative` | string | REQUIRED | OPTIONAL | Drop total authorised after this claim |
+| `txHash` | string | absent | REQUIRED | Hash of the submitted `PaymentChannelCreate` |
+
+A voucher receipt carries no `txHash`, and MUST NOT invent one: the
+claim settles nothing by itself, and no transaction exists until the
+channel is closed. An open receipt does carry one, because the server
+submitted a transaction to create the channel.
+
+The base `reference` remains method-specific and MAY carry these
+values in a composite form. A server MUST NOT rely on a client
+parsing one: a composite cannot be read without method knowledge,
+which is what the named fields are for.
 
 # Error Responses {#errors}
 


### PR DESCRIPTION
## Summary

Adds the `xrpl` payment method for the XRP Ledger, as two documents under
`specs/methods/xrpl/`.

**`draft-xrpl-charge-00`** settles a single Payment transaction, in XRP, an
issued currency, or a Multi-Purpose Token. Two modes: pull, where the client
returns a signed transaction blob and the server submits it, and push, where
the client submits and returns the hash. Registers the `xrpl` method.

**`draft-xrpl-session-00`** covers off-ledger payment channels. The client
signs a cumulative claim per request, the server verifies it locally against
the channel's public key with no round trip to the ledger, and redeems the
last claim when it closes. Registers the `session` intent for `xrpl`. The
method itself is registered by the charge document.

Per the AI tools policy in CONTRIBUTING.md: this draft was written with AI
assistance.
