### PR TITLE
docs(tempo): cite TEMPO-TX-SPEC in the charge method

### DIFF
--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -341,9 +341,10 @@ chain ID applicable to the challenge and the payer's Ethereum address.
 ## Transaction Payload (type="transaction")
 
 When `type` is `"transaction"`, `signature` contains the complete signed
-Tempo Transaction (type 0x76) serialized as RLP and hex-encoded with
-`0x` prefix. The transaction MUST authorize payment in the requested
-TIP-20 token sufficient to satisfy the challenge parameters, using one
+Tempo Transaction (type 0x76) {{TEMPO-TX-SPEC}} serialized as RLP and
+hex-encoded with `0x` prefix. The transaction MUST authorize payment in
+the requested TIP-20 token sufficient to satisfy the challenge
+parameters, using one
 or more `transfer` and/or `transferWithMemo` calls. When `splits` are
 present, the transaction MUST include transfers for each split entry
 (see {{split-payments}}). This payload type corresponds to `pull` mode.
@@ -535,8 +536,9 @@ transaction fees on behalf of the client.
 When `feePayer: true`:
 
 1. **Client signs with placeholder**: The client signs the Tempo Transaction
-   with `fee_payer_signature` set to a placeholder value (`0x00`) and
-   `fee_token` left empty. The client uses signature domain `0x76`.
+   {{TEMPO-TX-SPEC}} with `fee_payer_signature` set to a placeholder value
+   (`0x00`) and `fee_token` left empty. The client uses signature domain
+   `0x76`.
 
 2. **Server receives credential**: The server extracts the client-signed
    transaction from the credential payload.


### PR DESCRIPTION
## Summary

`draft-tempo-charge-00` defines the `TEMPO-TX-SPEC` reference (Tempo Transaction Specification) in its front matter but never cites it in the body, so the reference is unused and does not appear in the rendered References section.

The sibling `draft-tempo-session-00` cites `{{TEMPO-TX-SPEC}}` in the same two sentences — the signed-transaction credential (`type` `"transaction"`, type `0x76` serialized as RLP) and the fee-payer placeholder-signing step. This adds the matching citations to the charge method so it links to the transaction spec it relies on, bringing it to citation parity with the session method.

No normative changes; wrapping of the two affected paragraphs is adjusted to fit the inline citations.
