### PR TITLE
docs(titles): use Title Case for the Stripe and Tempo charge intent titles

### DIFF
--- a/specs/methods/stripe/draft-stripe-charge-00.md
+++ b/specs/methods/stripe/draft-stripe-charge-00.md
@@ -1,5 +1,5 @@
 ---
-title: Stripe charge Intent for HTTP Payment Authentication
+title: Stripe Charge Intent for HTTP Payment Authentication
 abbrev: Stripe Charge
 docname: draft-stripe-charge-00
 version: 00

--- a/specs/methods/tempo/draft-tempo-charge-00.md
+++ b/specs/methods/tempo/draft-tempo-charge-00.md
@@ -1,5 +1,5 @@
 ---
-title: Tempo charge Intent for HTTP Payment Authentication
+title: Tempo Charge Intent for HTTP Payment Authentication
 abbrev: Tempo Charge
 docname: draft-tempo-charge-00
 version: 00


### PR DESCRIPTION
## Summary

The `title:` front matter of the Stripe and Tempo charge intent specs uses a lowercase "charge":

- `draft-stripe-charge-00`: `Stripe charge Intent for HTTP Payment Authentication`
- `draft-tempo-charge-00`: `Tempo charge Intent for HTTP Payment Authentication`

Every other method charge spec uses Title Case (`Card Network Charge Intent…`, `EVM Charge Intent…`, `Solana Charge Intent…`, etc.). Capitalize "Charge" in these two so the rendered document titles are consistent across the suite.
