### PR TITLE
fix: renew IETF draft from Datatracker expiry

### DIFF
--- a/.github/workflows/resubmit-draft.yml
+++ b/.github/workflows/resubmit-draft.yml
@@ -1,13 +1,13 @@
 name: Resubmit IETF Draft
 
 # IETF I-Ds expire after 185 days (~6 months).
-# This checks weekly and opens a version-bump PR once 165 days have passed.
+# This checks weekly and opens a version-bump PR within 35 days of expiry.
 # Merging the PR triggers submit-draft.yml which submits to the IETF
 # datatracker automatically. An author must then confirm via email.
 
 on:
   schedule:
-    # Check weekly; the job skips unless 165+ days since last revision bump
+    # Check weekly; the job skips while the draft has more than 35 days left
     - cron: "0 12 * * 1"
   workflow_dispatch:
 
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: read
 
 jobs:
   bump-and-pr:
@@ -29,21 +30,50 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Check if 165+ days since last bump
+      - name: Check IETF expiry and revision
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          DRAFT=draft-httpauth-payment
           SPEC=$(find specs/core -name 'draft-httpauth-payment-*.md' | head -1)
-          LAST_TOUCH=$(git log -1 --format=%ct -- "$SPEC")
+          LOCAL_VER=$(basename "$SPEC" .md | grep -oE '[0-9]+$')
+          METADATA=$(curl --fail --silent --show-error --retry 3 \
+            "https://datatracker.ietf.org/api/v1/doc/document/$DRAFT/")
+          REMOTE_VER=$(echo "$METADATA" | jq -er '.rev')
+          EXPIRES=$(echo "$METADATA" | jq -er '.expires')
           NOW=$(date +%s)
-          DAYS_AGO=$(( (NOW - LAST_TOUCH) / 86400 ))
-          echo "days_since_bump=$DAYS_AGO" >> "$GITHUB_OUTPUT"
-          if [[ "$DAYS_AGO" -lt 165 ]]; then
-            echo "Only $DAYS_AGO days since last bump — skipping (threshold: 165)"
+          EXPIRY=$(date --date="$EXPIRES" +%s)
+          DAYS_LEFT=$(( (EXPIRY - NOW) / 86400 ))
+          echo "days_left=$DAYS_LEFT" >> "$GITHUB_OUTPUT"
+
+          if (( 10#$LOCAL_VER > 10#$REMOTE_VER )); then
+            echo "Repository revision -$LOCAL_VER is awaiting publication; IETF has -$REMOTE_VER"
             echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "$DAYS_AGO days since last bump — time to resubmit"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if (( 10#$LOCAL_VER < 10#$REMOTE_VER )); then
+            echo "::error::Repository revision -$LOCAL_VER is behind IETF revision -$REMOTE_VER"
+            exit 1
+          fi
+          if (( DAYS_LEFT > 35 )); then
+            echo "$DAYS_LEFT days until expiry — skipping (threshold: 35)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NEW_VER=$(printf '%02d' $((10#$REMOTE_VER + 1)))
+          OPEN_PRS=$(gh pr list --state open --head "ietf/resubmit-$NEW_VER" \
+            --json number --jq 'length')
+          if (( OPEN_PRS > 0 )); then
+            echo "Revision -$NEW_VER PR already exists — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$DAYS_LEFT days until expiry — preparing revision -$NEW_VER"
+          echo "new_ver=$NEW_VER" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Bump revision
         if: steps.check.outputs.skip == 'false'
@@ -51,6 +81,10 @@ jobs:
         run: |
           chmod +x scripts/bump_and_rename.sh
           NEW_VER=$(scripts/bump_and_rename.sh)
+          if [[ "$NEW_VER" != "${{ steps.check.outputs.new_ver }}" ]]; then
+            echo "::error::Expected revision ${{ steps.check.outputs.new_ver }}, got $NEW_VER"
+            exit 1
+          fi
           echo "new_ver=$NEW_VER" >> "$GITHUB_OUTPUT"
 
       - name: Fetch GitHub token via STS

--- a/.github/workflows/resubmit-draft.yml
+++ b/.github/workflows/resubmit-draft.yml
@@ -17,6 +17,7 @@ on:
 # requests. id-token lets the job request the OIDC token the STS exchange
 # verifies.
 permissions:
+  actions: write
   contents: read
   id-token: write
   pull-requests: read
@@ -48,7 +49,16 @@ jobs:
           echo "days_left=$DAYS_LEFT" >> "$GITHUB_OUTPUT"
 
           if (( 10#$LOCAL_VER > 10#$REMOTE_VER )); then
-            echo "Repository revision -$LOCAL_VER is awaiting publication; IETF has -$REMOTE_VER"
+            SUBMISSIONS=$(curl --fail --silent --show-error --retry 3 \
+              "https://datatracker.ietf.org/api/v1/submit/submission/?name=$DRAFT&rev=$LOCAL_VER&limit=1&order_by=-id")
+            STATE=$(echo "$SUBMISSIONS" | jq -r \
+              '.objects[0].state // "" | split("/") | map(select(length > 0)) | last // ""')
+            if [[ -z "$STATE" || "$STATE" == "cancel" ]]; then
+              echo "Repository revision -$LOCAL_VER has no active submission — retrying"
+              gh workflow run submit-draft.yml --ref main
+            else
+              echo "Repository revision -$LOCAL_VER has submission state=$STATE; IETF has -$REMOTE_VER"
+            fi
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/submit-draft.yml
+++ b/.github/workflows/submit-draft.yml
@@ -20,9 +20,34 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect unpublished revision
+        id: detect
+        run: |
+          DRAFT=draft-httpauth-payment
+          SPEC=$(find specs/core -name 'draft-httpauth-payment-*.md' | head -1)
+          DOCNAME=$(grep '^docname:' "$SPEC" | awk '{print $2}')
+          LOCAL_VER=$(grep '^version:' "$SPEC" | awk '{print $2}')
+          REMOTE_VER=$(curl --fail --silent --show-error --retry 3 \
+            "https://datatracker.ietf.org/api/v1/doc/document/$DRAFT/" | jq -er '.rev')
+          EXPECTED_VER=$(printf '%02d' $((10#$REMOTE_VER + 1)))
+
+          echo "docname=$DOCNAME" >> "$GITHUB_OUTPUT"
+          if [[ "$LOCAL_VER" == "$REMOTE_VER" ]]; then
+            echo "Revision -$LOCAL_VER is already published — skipping"
+            echo "submit=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$LOCAL_VER" == "$EXPECTED_VER" ]]; then
+            echo "Submitting $DOCNAME; IETF currently has revision -$REMOTE_VER"
+            echo "submit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Local revision -$LOCAL_VER does not follow IETF revision -$REMOTE_VER"
+            exit 1
+          fi
+
       - uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        if: steps.detect.outputs.submit == 'true'
 
       - uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        if: steps.detect.outputs.submit == 'true'
         with:
           context: .
           load: true
@@ -31,22 +56,16 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build XML
+        if: steps.detect.outputs.submit == 'true'
         run: |
           mkdir -p .cache
           docker run --rm --user $(id -u):$(id -g) -e HOME=/data \
             -v ${{ github.workspace }}:/data ietf-spec-tools:latest /data/scripts/gen.sh
 
-      - name: Detect spec version
-        id: detect
-        run: |
-          SPEC=$(find specs/core -name 'draft-httpauth-payment-*.md' | head -1)
-          DOCNAME=$(grep '^docname:' "$SPEC" | awk '{print $2}')
-          echo "docname=$DOCNAME" >> "$GITHUB_OUTPUT"
-          echo "Submitting $DOCNAME"
-
       - name: Submit to IETF datatracker
+        if: steps.detect.outputs.submit == 'true'
         run: |
-          RESPONSE=$(curl -s -w "\n%{http_code}" \
+          RESPONSE=$(curl --silent --show-error --retry 3 -w "\n%{http_code}" \
             -F "user=${{ secrets.IETF_USER }}" \
             -F "xml=@artifacts/${{ steps.detect.outputs.docname }}.xml" \
             https://datatracker.ietf.org/api/submission)
@@ -61,17 +80,25 @@ jobs:
             exit 1
           fi
 
-          STATUS_URL=$(echo "$BODY" | jq -r '.status_url // empty')
-          if [[ -n "$STATUS_URL" ]]; then
-            echo "Polling status at $STATUS_URL"
-            for i in $(seq 1 10); do
-              sleep 5
-              STATE=$(curl -s "$STATUS_URL" | jq -r '.state')
-              echo "  Attempt $i: state=$STATE"
-              if [[ "$STATE" != "validating" ]]; then
-                break
-              fi
-            done
+          STATUS_URL=$(echo "$BODY" | jq -er '.status_url')
+          echo "Polling status at $STATUS_URL"
+          STATE=validating
+          for i in $(seq 1 10); do
+            sleep 5
+            STATE=$(curl --fail --silent --show-error --retry 3 "$STATUS_URL" | jq -er '.state')
+            echo "  Attempt $i: state=$STATE"
+            if [[ "$STATE" != "validating" ]]; then
+              break
+            fi
+          done
+
+          if [[ "$STATE" == "validating" ]]; then
+            echo "::error::IETF validation did not finish before timeout"
+            exit 1
+          fi
+          if [[ "$STATE" == "cancel" ]]; then
+            echo "::error::IETF validation failed or the submission was canceled"
+            exit 1
           fi
 
-          echo "::notice::Submission complete — an author must confirm via email."
+          echo "::notice::IETF validation completed with state=$STATE — an author must confirm via email."

--- a/.github/workflows/submit-draft.yml
+++ b/.github/workflows/submit-draft.yml
@@ -4,6 +4,7 @@ name: Submit Draft to IETF
 # bump lands on main. One of the listed authors must still confirm via email.
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -26,7 +27,7 @@ jobs:
           DRAFT=draft-httpauth-payment
           SPEC=$(find specs/core -name 'draft-httpauth-payment-*.md' | head -1)
           DOCNAME=$(grep '^docname:' "$SPEC" | awk '{print $2}')
-          LOCAL_VER=$(grep '^version:' "$SPEC" | awk '{print $2}')
+          LOCAL_VER=$(basename "$SPEC" .md | grep -oE '[0-9]+$')
           REMOTE_VER=$(curl --fail --silent --show-error --retry 3 \
             "https://datatracker.ietf.org/api/v1/doc/document/$DRAFT/" | jq -er '.rev')
           EXPECTED_VER=$(printf '%02d' $((10#$REMOTE_VER + 1)))

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	docker run --rm -v "$$(pwd)":/data ietf-spec-tools python3 /data/scripts/lint_frontmatter.py
 
 test:
-	docker run --rm -v "$$(pwd)":/data -w /data/scripts ietf-spec-tools pytest test_lint_frontmatter.py -v
+	docker run --rm -v "$$(pwd)":/data -w /data/scripts ietf-spec-tools pytest test_lint_frontmatter.py test_bump_and_rename.py -v
 
 site: build
 	@python3 scripts/gen_index.py

--- a/scripts/bump_and_rename.sh
+++ b/scripts/bump_and_rename.sh
@@ -32,7 +32,7 @@ git -C "$ROOT_DIR" mv "$CURRENT_FILE" "$NEW_FILE"
 
 # Update frontmatter version and docname
 sed -i.bak "s/^docname: .*$/docname: ${PREFIX}-${NEW_VER}/" "$NEW_FILE"
-sed -i.bak "s/^version: .*$/version: ${NEW_VER}/" "$NEW_FILE"
+sed -i.bak "s/^version: .*$/version: \"${NEW_VER}\"/" "$NEW_FILE"
 rm -f "$NEW_FILE.bak"
 
 echo "$NEW_VER"

--- a/scripts/test_bump_and_rename.py
+++ b/scripts/test_bump_and_rename.py
@@ -1,0 +1,43 @@
+"""Tests for bump_and_rename.sh."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(("current", "expected"), [("00", "01"), ("09", "10")])
+def test_bump_updates_filename_and_frontmatter(tmp_path: Path, current: str, expected: str):
+    root = tmp_path
+    scripts = root / "scripts"
+    core = root / "specs" / "core"
+    scripts.mkdir()
+    core.mkdir(parents=True)
+    source_script = Path(__file__).with_name("bump_and_rename.sh")
+    script = scripts / source_script.name
+    script.write_bytes(source_script.read_bytes())
+
+    current_file = core / f"draft-httpauth-payment-{current}.md"
+    current_file.write_text(
+        "---\n"
+        f"docname: draft-httpauth-payment-{current}\n"
+        f'version: "{current}"\n'
+        "---\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "--quiet"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+
+    result = subprocess.run(
+        ["bash", str(script)], cwd=root, check=True, capture_output=True, text=True
+    )
+
+    updated_file = core / f"draft-httpauth-payment-{expected}.md"
+    assert result.stdout.strip() == expected
+    assert not current_file.exists()
+    assert updated_file.read_text(encoding="utf-8") == (
+        "---\n"
+        f"docname: draft-httpauth-payment-{expected}\n"
+        f'version: "{expected}"\n'
+        "---\n"
+    )

--- a/specs/core/draft-httpauth-payment-01.md
+++ b/specs/core/draft-httpauth-payment-01.md
@@ -1,8 +1,8 @@
 ---
 title: The "Payment" HTTP Authentication Scheme
 abbrev: Payment Auth Scheme
-docname: draft-httpauth-payment-00
-version: 00
+docname: draft-httpauth-payment-01
+version: "01"
 category: std
 ipr: noModificationTrust200902
 submissiontype: IETF


### PR DESCRIPTION
## Motivation

The renewal scheduler used the latest Git edit as the draft age, allowing ordinary changes to postpone renewal beyond the IETF expiration date. Submissions also ran for unchanged revision numbers and failed validation.

## Summary

- derive renewal timing and the next revision from IETF Datatracker metadata
- skip duplicate or already-pending renewals
- submit only a revision that directly follows the published revision
- fail canceled or timed-out IETF validation
- bump the core draft to revision `-01`
- quote bumped frontmatter revisions and cover the bump script with tests

## Key design considerations

- Datatracker is the source of truth for publication revision and expiration
- API failures stop the workflow instead of silently skipping renewal
- ordinary core-spec edits no longer attempt stale-revision submissions
