### PR TITLE
docs: add author countries to IETF draft

### DIFF
--- a/specs/core/draft-httpauth-payment-01.md
+++ b/specs/core/draft-httpauth-payment-01.md
@@ -13,22 +13,27 @@ author:
     ins: B. Ryan
     email: brendan@tempo.xyz
     org: Tempo Labs
+    country: US
   - name: Jake Moxey
     ins: J. Moxey
     email: jake@tempo.xyz
     org: Tempo Labs
+    country: US
   - name: Tom Meagher
     ins: T. Meagher
     email: tom@tempo.xyz
     org: Tempo Labs
+    country: US
   - name: Jeff Weinstein
     ins: J. Weinstein
     email: jweinstein@stripe.com
     org: Stripe
+    country: US
   - name: Steve Kaliski
     ins: S. Kaliski
     email: stevekaliski@stripe.com
     org: Stripe
+    country: US
 
 normative:
   RFC2119:


### PR DESCRIPTION
## Motivation

The core draft author addresses do not identify their countries.

## Summary

- set every core-draft author country to `US`

## Key design considerations

- retain revision `-01` so this metadata does not trigger a new IETF publication
- the next scheduled revision bump will carry the country metadata forward
