### PR TITLE
fix: publish the problem type URIs that specs cite, and lint for coverage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -51,8 +51,12 @@ jobs:
         run: |
           docker run --rm -v "$(pwd)":/data ietf-spec-tools:latest python3 /data/scripts/lint_external_section_refs.py
 
+      - name: Lint problem type coverage
+        run: |
+          docker run --rm -v "$(pwd)":/data ietf-spec-tools:latest python3 /data/scripts/lint_problem_types.py
+
       - name: Check problem page generation
-        run: docker run --rm -v "$(pwd)":/data -w /data/scripts ietf-spec-tools:latest pytest test_gen_problems.py -v
+        run: docker run --rm -v "$(pwd)":/data -w /data/scripts ietf-spec-tools:latest pytest test_gen_problems.py test_lint_problem_types.py -v
 
       - name: Build and validate specs
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ clean:
 
 lint:
 	docker run --rm -v "$$(pwd)":/data ietf-spec-tools python3 /data/scripts/lint_frontmatter.py
+	docker run --rm -v "$$(pwd)":/data ietf-spec-tools python3 /data/scripts/lint_problem_types.py
 
 test:
-	docker run --rm -v "$$(pwd)":/data -w /data/scripts ietf-spec-tools pytest test_lint_frontmatter.py test_bump_and_rename.py test_gen_problems.py -v
+	docker run --rm -v "$$(pwd)":/data -w /data/scripts ietf-spec-tools pytest test_lint_frontmatter.py test_bump_and_rename.py test_gen_problems.py test_lint_problem_types.py -v
 
 site: build
 	@python3 scripts/gen_index.py

--- a/pages/templates/problems_index.html
+++ b/pages/templates/problems_index.html
@@ -96,10 +96,11 @@
   <p>Problem type URIs used in <code>application/problem+json</code> error
   responses per <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457</a>.</p>
 
-  <h2>Core</h2>
+  {% for group in groups %}
+  <h2>{{ group.title }}</h2>
   <table>
     <tr><th>Type</th><th>Status</th><th>Description</th></tr>
-    {% for p in core_problems %}
+    {% for p in group.problems %}
     <tr>
       <td><a href="/problems/{{ p.slug }}"><code>{{ p.slug }}</code></a></td>
       <td><code>{{ p.http_status }}</code></td>
@@ -107,18 +108,7 @@
     </tr>
     {% endfor %}
   </table>
-
-  <h2>Session</h2>
-  <table>
-    <tr><th>Type</th><th>Status</th><th>Description</th></tr>
-    {% for p in session_problems %}
-    <tr>
-      <td><a href="/problems/{{ p.slug }}"><code>{{ p.slug }}</code></a></td>
-      <td><code>{{ p.http_status }}</code></td>
-      <td>{{ p.description }}</td>
-    </tr>
-    {% endfor %}
-  </table>
+  {% endfor %}
 
 </body>
 </html>

--- a/scripts/gen_problems.py
+++ b/scripts/gen_problems.py
@@ -7,6 +7,10 @@ directory-with-index.html convention so that GitHub Pages serves clean URLs
 (e.g. /problems/payment-required -> /problems/payment-required/index.html).
 
 Core problem definitions come from the core specification's Error Codes table.
+Types outside the core namespace are listed below; every one a spec cites MUST
+appear here or the published URI 404s, which scripts/lint_problem_types.py
+enforces in CI.
+
 Jinja2 is already available via xml2rfc's dependencies.
 """
 
@@ -68,10 +72,10 @@ SESSION_PROBLEMS = [
     {"slug": "session/delta-too-small", "title": "Delta Too Small", "http_status": 402,
      "description": "The amount increase is below the server's minimum voucher delta.",
      "spec_label": "draft-tempo-session"},
-    {"slug": "session/channel-not-found", "title": "Channel Not Found", "http_status": 402,
+    {"slug": "session/channel-not-found", "title": "Channel Not Found", "http_status": 410,
      "description": "No payment channel with this ID exists.",
      "spec_label": "draft-tempo-session"},
-    {"slug": "session/channel-finalized", "title": "Channel Finalized", "http_status": 402,
+    {"slug": "session/channel-finalized", "title": "Channel Finalized", "http_status": 410,
      "description": "The payment channel has been closed and can no longer accept vouchers.",
      "spec_label": "draft-tempo-session"},
     {"slug": "session/challenge-not-found", "title": "Challenge Not Found", "http_status": 402,
@@ -80,9 +84,60 @@ SESSION_PROBLEMS = [
     {"slug": "session/insufficient-balance", "title": "Insufficient Balance", "http_status": 402,
      "description": "There is insufficient authorized balance in the channel for this request.",
      "spec_label": "draft-tempo-session"},
+    {"slug": "session/transaction-reverted", "title": "Transaction Reverted", "http_status": 409,
+     "description": "An on-chain open, top-up, settle, or close transaction reverted.",
+     "spec_label": "draft-evm-session"},
 ]
 
-ALL_PROBLEMS = CORE_PROBLEMS + SESSION_PROBLEMS
+# Defined by draft-stellar-charge and reused by draft-nearintents-charge.
+CHARGE_PROBLEMS = [
+    {"slug": "settlement-failed", "title": "Settlement Failed", "http_status": 402,
+     "description": "The credential was valid but settlement did not complete.",
+     "spec_label": "draft-stellar-charge"},
+]
+
+LIGHTNING_PROBLEMS = [
+    {"slug": "lightning/malformed-credential", "title": "Malformed Credential", "http_status": 402,
+     "description": "The credential could not be decoded, or a required field is absent or of the wrong type.",
+     "spec_label": "draft-lightning-charge"},
+    {"slug": "lightning/unknown-challenge", "title": "Unknown Challenge", "http_status": 402,
+     "description": "The challenge ID is not one this server issued, or it has already been consumed.",
+     "spec_label": "draft-lightning-charge"},
+    {"slug": "lightning/invalid-preimage", "title": "Invalid Preimage", "http_status": 402,
+     "description": "The SHA-256 hash of the preimage does not equal the payment hash stored for the challenge.",
+     "spec_label": "draft-lightning-charge"},
+    {"slug": "lightning/expired-invoice", "title": "Expired Invoice", "http_status": 402,
+     "description": "The BOLT11 invoice for this challenge, or the challenge itself, has passed its expiry time.",
+     "spec_label": "draft-lightning-charge"},
+    {"slug": "lightning/session-not-found", "title": "Session Not Found", "http_status": 402,
+     "description": "No session with this ID exists.",
+     "spec_label": "draft-lightning-session"},
+    {"slug": "lightning/session-closed", "title": "Session Closed", "http_status": 402,
+     "description": "The session is closed and accepts no further actions.",
+     "spec_label": "draft-lightning-session"},
+    {"slug": "lightning/insufficient-balance", "title": "Insufficient Balance", "http_status": 402,
+     "description": "The session balance is insufficient for the requested operation.",
+     "spec_label": "draft-lightning-session"},
+    {"slug": "lightning/challenge-expired", "title": "Challenge Expired", "http_status": 402,
+     "description": "The challenge has passed its expiry time; the client must obtain a fresh one.",
+     "spec_label": "draft-lightning-session"},
+    {"slug": "lightning/invalid-return-invoice", "title": "Invalid Return Invoice", "http_status": 402,
+     "description": "The return invoice is not a valid BOLT11 invoice, or it encodes a non-zero amount.",
+     "spec_label": "draft-lightning-session"},
+]
+
+
+def problem_groups():
+    """Sections of the index page, in display order."""
+    return [
+        {"title": "Core", "problems": CORE_PROBLEMS},
+        {"title": "Charge", "problems": CHARGE_PROBLEMS},
+        {"title": "Session", "problems": SESSION_PROBLEMS},
+        {"title": "Lightning", "problems": LIGHTNING_PROBLEMS},
+    ]
+
+
+ALL_PROBLEMS = [problem for group in problem_groups() for problem in group["problems"]]
 
 
 def make_example(slug, title, http_status):
@@ -127,10 +182,7 @@ def main():
 
     # Index page
     os.makedirs(PAGES_DIR, exist_ok=True)
-    html = index_tpl.render(
-        core_problems=CORE_PROBLEMS,
-        session_problems=SESSION_PROBLEMS,
-    )
+    html = index_tpl.render(groups=problem_groups())
     with open(os.path.join(PAGES_DIR, "index.html"), "w") as f:
         f.write(html)
     print(f"    index")

--- a/scripts/lint_problem_types.py
+++ b/scripts/lint_problem_types.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Ensure every problem type URI a spec cites has a published page.
+
+Problem type URIs under https://paymentauth.org/problems/ are dereferenceable:
+scripts/gen_problems.py renders one static page per registered type and
+deploy.yml publishes them. A spec that cites a type missing from that registry
+ships a URI that 404s, which defeats the purpose of an RFC 9457 `type` value.
+
+This lint collects the types cited under specs/ and fails when any of them has
+no page.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPTS_DIR.parent
+SPECS_DIR = ROOT / "specs"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from gen_problems import ALL_PROBLEMS, BASE_URI  # noqa: E402
+
+# The full URI, as used in prose and in JSON examples.
+ABSOLUTE_RE = re.compile(re.escape(BASE_URI) + r"(?P<slug>[a-z0-9][a-z0-9/-]*)")
+# A slug on its own, as tables use once the base URI is given in prose. The
+# leading `.../` is optional: both spellings appear across the session specs.
+SLUG_RE = re.compile(r"\A`(?P<relative>\.\.\./)?(?P<slug>[a-z0-9][a-z0-9-]*(?:/[a-z0-9][a-z0-9-]*)*)`\Z")
+# A table that registers types names the column holding them. Both spellings
+# are in use; only these columns are read, so that a table of method or intent
+# names in backticks is never mistaken for a list of problem types.
+URI_COLUMN_RE = re.compile(r"\A(?:type uri|problem type|type)\Z")
+# A spec defining its own type does so in the same `Code | HTTP | Description`
+# table the core spec uses.
+CODE_COLUMN_RE = re.compile(r"\A(?:code|error code)\Z")
+STATUS_COLUMN_RE = re.compile(r"\A(?:http|http status|status)\Z")
+
+
+def registered_slugs() -> set[str]:
+    """Problem type slugs that gen_problems.py publishes a page for."""
+    return {problem["slug"] for problem in ALL_PROBLEMS}
+
+
+def _cells(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _is_separator(line: str) -> bool:
+    return bool(re.fullmatch(r"\|[\s:|-]+\|", line.strip()))
+
+
+def slugs_in_text(content: str) -> set[str]:
+    """Problem type slugs cited by a single markdown document."""
+    slugs: set[str] = set()
+
+    def record(slug: str) -> None:
+        slug = slug.rstrip("-")
+        # A bare namespace (e.g. ".../problems/lightning/") is not a type.
+        if slug and not slug.endswith("/"):
+            slugs.add(slug)
+
+    for match in ABSOLUTE_RE.finditer(content):
+        record(match.group("slug"))
+
+    # Tables are read column-wise: the header fixes which column holds types,
+    # and whether a bare slug in it counts as a citation.
+    columns: list[int] = []
+    bare_slugs_count = False
+    lines = content.splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip().startswith("|"):
+            columns = []
+            continue
+        if _is_separator(line):
+            continue
+        cells = _cells(line)
+        if index + 1 < len(lines) and _is_separator(lines[index + 1]):
+            headers = [cell.lower() for cell in cells]
+            columns = [i for i, header in enumerate(headers) if URI_COLUMN_RE.match(header)]
+            # A `Code | HTTP | Description` table defines types rather than
+            # referring to them, so its unqualified slugs are citations.
+            if any(STATUS_COLUMN_RE.match(header) for header in headers):
+                code_columns = [i for i, h in enumerate(headers) if CODE_COLUMN_RE.match(h)]
+                bare_slugs_count = bool(code_columns)
+                columns += code_columns
+            else:
+                # Elsewhere an unqualified slug is shorthand for a type the
+                # document registers in full, so only qualified ones count.
+                bare_slugs_count = False
+            continue
+        for column in columns:
+            if column >= len(cells):
+                continue
+            match = SLUG_RE.match(cells[column])
+            if not match:
+                continue
+            qualified = bool(match.group("relative")) or "/" in match.group("slug")
+            if qualified or bare_slugs_count:
+                record(match.group("slug"))
+
+    return slugs
+
+
+def cited_slugs(specs_dir: Path = SPECS_DIR) -> dict[str, set[str]]:
+    """Map each cited problem slug to the spec files citing it."""
+    cited: dict[str, set[str]] = {}
+    for path in sorted(specs_dir.rglob("*.md")):
+        for slug in slugs_in_text(path.read_text(encoding="utf-8")):
+            cited.setdefault(slug, set()).add(path.relative_to(specs_dir).as_posix())
+    return cited
+
+
+def main() -> int:
+    registered = registered_slugs()
+    cited = cited_slugs()
+
+    missing = {slug: specs for slug, specs in cited.items() if slug not in registered}
+    if missing:
+        print("Problem type URIs cited by specs but not published as pages:\n")
+        for slug in sorted(missing):
+            print(f"  x {BASE_URI}{slug}")
+            for spec in sorted(missing[slug]):
+                print(f"      cited in specs/{spec}")
+        print(
+            "\nAdd each type to the registry in scripts/gen_problems.py so the URI"
+            " resolves instead of returning 404."
+        )
+        return 1
+
+    print(f"All {len(cited)} problem type URIs cited by specs have published pages.")
+
+    uncited = sorted(registered - set(cited))
+    if uncited:
+        print("\nPublished but not cited by any spec (informational):")
+        for slug in uncited:
+            print(f"  - {slug}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_lint_problem_types.py
+++ b/scripts/test_lint_problem_types.py
@@ -1,0 +1,99 @@
+"""A problem type URI a spec cites must have a page, or it 404s once published."""
+
+from pathlib import Path
+
+import gen_problems
+from lint_problem_types import cited_slugs, registered_slugs, slugs_in_text
+
+BASE_URI = gen_problems.BASE_URI
+
+
+def write_spec(tmp_path: Path, content: str, name: str = "draft-test-00.md") -> None:
+    spec_dir = tmp_path / "specs" / "methods" / "test"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / name).write_text(content, encoding="utf-8")
+
+
+class TestCitationForms:
+    def test_absolute_uri_in_prose(self):
+        assert slugs_in_text(f"See {BASE_URI}payment-required.") == {"payment-required"}
+
+    def test_absolute_uri_in_json_example(self):
+        content = f'~~~json\n{{\n  "type": "{BASE_URI}verification-failed"\n}}\n~~~\n'
+        assert slugs_in_text(content) == {"verification-failed"}
+
+    def test_namespace_prefix_is_not_a_type(self):
+        assert slugs_in_text(f"types under the `{BASE_URI}lightning/` namespace") == set()
+
+    def test_relative_form_in_a_type_uri_table(self):
+        content = (
+            "| Type URI | Title | Status |\n"
+            "|----------|-------|--------|\n"
+            "| `.../session/transaction-reverted` | Transaction Reverted | 409 |\n"
+        )
+        assert slugs_in_text(content) == {"session/transaction-reverted"}
+
+    def test_namespaced_slug_in_a_problem_type_column(self):
+        content = (
+            "| Condition | Problem type |\n"
+            "|---|---|\n"
+            "| channel expired | `session/channel-finalized` |\n"
+        )
+        assert slugs_in_text(content) == {"session/channel-finalized"}
+
+    def test_code_table_defines_an_unqualified_type(self):
+        content = (
+            "| Code | HTTP | Description |\n"
+            "|------|------|-------------|\n"
+            "| `settlement-failed` | 402 | Settlement did not complete |\n"
+        )
+        assert slugs_in_text(content) == {"settlement-failed"}
+
+
+class TestCitationsNotCounted:
+    def test_unqualified_slug_in_a_mapping_column_is_shorthand(self):
+        # draft-evm-session maps revert conditions to types it registers in
+        # full elsewhere; the short spelling is not a separate type.
+        content = (
+            "| Revert condition | Problem type |\n"
+            "|------------------|--------------|\n"
+            "| `ChannelFinalized` | `channel-finalized` |\n"
+        )
+        assert slugs_in_text(content) == set()
+
+    def test_backticked_names_in_an_unrelated_table(self):
+        content = (
+            "| Intent | Applicable Methods |\n"
+            "|--------|--------------------|\n"
+            "| `session` | `lightning` |\n"
+        )
+        assert slugs_in_text(content) == set()
+
+
+class TestCitedSlugs:
+    def test_every_citing_spec_is_reported(self, tmp_path):
+        for name in ("draft-a-00.md", "draft-b-00.md"):
+            write_spec(tmp_path, f'"type": "{BASE_URI}session/channel-finalized"\n', name)
+
+        assert cited_slugs(tmp_path / "specs") == {
+            "session/channel-finalized": {
+                "methods/test/draft-a-00.md",
+                "methods/test/draft-b-00.md",
+            }
+        }
+
+    def test_a_type_with_no_page_is_detected(self, tmp_path):
+        write_spec(tmp_path, f'"type": "{BASE_URI}lightning/not-registered"\n')
+
+        assert set(cited_slugs(tmp_path / "specs")) - registered_slugs() == {
+            "lightning/not-registered"
+        }
+
+
+class TestRepositorySpecs:
+    def test_every_cited_type_has_a_page(self):
+        assert sorted(set(cited_slugs()) - registered_slugs()) == []
+
+    def test_slugs_are_unique(self):
+        slugs = [problem["slug"] for problem in gen_problems.ALL_PROBLEMS]
+        assert sorted(slugs) == sorted(set(slugs))


### PR DESCRIPTION
## Problem

Eleven problem type URIs that shipped specs cite have no page under `paymentauth.org/problems/`. Every one of them 404s right now:

```console
$ for u in lightning/malformed-credential lightning/unknown-challenge \
    lightning/invalid-preimage lightning/expired-invoice lightning/session-not-found \
    lightning/session-closed lightning/insufficient-balance lightning/challenge-expired \
    lightning/invalid-return-invoice session/transaction-reverted settlement-failed; do
    echo "$(curl -sL -o /dev/null -w '%{http_code}' https://paymentauth.org/problems/$u)  $u"
  done
404  lightning/malformed-credential
404  lightning/unknown-challenge
404  lightning/invalid-preimage
404  lightning/expired-invoice
404  lightning/session-not-found
404  lightning/session-closed
404  lightning/insufficient-balance
404  lightning/challenge-expired
404  lightning/invalid-return-invoice
404  session/transaction-reverted
404  settlement-failed
```

To reproduce from the spec side: `draft-lightning-charge-00` §"Error Responses" defines `https://paymentauth.org/problems/lightning/invalid-preimage` and puts it in a `type` field of its example problem body. Open that URI. A client following an RFC 9457 `type` to learn what went wrong gets a 404 page instead.

Where they come from:

| Type | Defined in | Status |
|---|---|---|
| `lightning/*` (9 types) | `draft-lightning-charge-00`, `draft-lightning-session-00` | 402 |
| `session/transaction-reverted` | `draft-evm-session-00` | 409 |
| `settlement-failed` | `draft-stellar-charge-00`, reused by `draft-nearintents-charge-01` | 402 |

Two published pages are also wrong: `session/channel-not-found` and `session/channel-finalized` say 402, but `draft-tempo-session-00`, `draft-evm-session-00` and `draft-hedera-session-00` all register them as **410** in their IANA tables.

## Changes

**1. Register the missing types** (`scripts/gen_problems.py`). The index page now renders a group per namespace — Core, Charge, Session, Lightning — instead of two hardcoded sections, so adding a namespace no longer means editing the template. Fixes the two 410s.

**2. Keep it from happening again** (`scripts/lint_problem_types.py`). #353 made the core namespace derive from the core spec's Error Codes table; everything outside it is still a hand-maintained list, and nothing today connects a spec citing a type to the registry that publishes it. This lint closes that: it collects the types cited under `specs/` and fails when one has no page.

Run against the registry as it stands on `main`, it reports exactly the eleven URIs above:

```console
$ python3 scripts/lint_problem_types.py
Problem type URIs cited by specs but not published as pages:

  x https://paymentauth.org/problems/lightning/challenge-expired
      cited in specs/methods/lightning/draft-lightning-session-00.md
  ...
  x https://paymentauth.org/problems/settlement-failed
      cited in specs/methods/nearintents/draft-nearintents-charge-01.md
      cited in specs/methods/stellar/draft-stellar-charge-00.md

Add each type to the registry in scripts/gen_problems.py so the URI resolves instead of returning 404.
```

With this PR applied it passes: `All 30 problem type URIs cited by specs have published pages.`

### What counts as a citation

The specs spell types four ways, and the lint reads all four:

- the absolute URI, in prose and in JSON examples;
- `` `.../session/channel-finalized` `` — the relative form the session IANA tables use;
- a namespaced slug in a type column, e.g. `` `lightning/session-closed` `` under `| Type URI |` in `draft-lightning-session-00`, or `` `session/channel-not-found` `` under `| Problem type |` in `draft-xrpl-session-00`;
- an unqualified slug in a `| Code | HTTP | Description |` table — the shape the core spec uses, and where `settlement-failed` is defined.

An unqualified slug **outside** that shape is treated as shorthand, not a citation. That is deliberate: `draft-evm-session-00`'s revert-condition mapping writes `` `channel-finalized` `` for a type it registers in full as `.../session/channel-finalized` a few sections later, and reading those as separate types would be wrong. `scripts/test_lint_problem_types.py` pins both directions.

### Effect on contributors

A new method spec that defines a problem type of its own now needs a matching entry in `gen_problems.py`. The failure names the URI, the spec citing it, and the file to edit. I checked the currently open method PRs (#342, #253, #310, #312, #271) — none cite an unregistered type, so none of them are blocked by this.

## Wiring

- `.github/workflows/pr-check.yml`: new "Lint problem type coverage" step; `test_lint_problem_types.py` added to the existing problem-page pytest step.
- `Makefile`: same lint added to `make lint`, same tests to `make test`.

## Validation

- `pytest test_lint_frontmatter.py test_gen_problems.py test_lint_problem_types.py` — 38 passed. This includes #353's `test_new_spec_error_generates_page_and_index_entry`, which monkeypatches `CORE_PROBLEMS`; the index groups are therefore built inside a function rather than at import, so that test keeps working.
- `python3 scripts/gen_problems.py` generates 30 pages; spot-checked that the new pages carry the right status and that "Defined In" resolves to the right draft.
- `test_bump_and_rename.py` fails locally for me on Windows (it shells out to `bash`); it is untouched by this PR.
- I could not run `make check` locally — no Docker on this machine. CI covers the full spec build; no `.md` under `specs/` is modified by this PR, so nothing here changes a rendered draft.

## Notes

- No spec files are modified, so no version bumps are needed.
- `settlement-failed` is defined identically by `draft-stellar-charge-00` (which introduced it, #199) and `draft-nearintents-charge-01` (#284). The page attributes it to the Stellar draft since that is where it originated; if you would rather it live somewhere shared, say the word and I will move it.
- The `lightning` types shared by both Lightning drafts are attributed to `draft-lightning-charge-00`.

Prepared with AI assistance; I have reviewed the diff and the output above.
